### PR TITLE
keymap: Add xkb_keymap_mod_get_mask

### DIFF
--- a/src/keymap.c
+++ b/src/keymap.c
@@ -292,6 +292,18 @@ xkb_keymap_mod_get_index(struct xkb_keymap *keymap, const char *name)
 }
 
 /**
+ * Returns the mask for a given modifier.
+ */
+XKB_EXPORT xkb_mod_mask_t
+xkb_keymap_mod_get_mask(struct xkb_keymap *keymap, xkb_mod_index_t idx)
+{
+    if (idx >= keymap->mods.num_mods)
+        return 0;
+
+    return keymap->mods.mods[idx].mapping;
+}
+
+/**
  * Return the total number of active groups in the keymap.
  */
 XKB_EXPORT xkb_layout_index_t

--- a/xkbcommon/xkbcommon.h
+++ b/xkbcommon/xkbcommon.h
@@ -973,6 +973,20 @@ xkb_mod_index_t
 xkb_keymap_mod_get_index(struct xkb_keymap *keymap, const char *name);
 
 /**
+ * Get the mask of a modifier by index.
+ *
+ * The modifier mask is a devirtualized mask that can be used to
+ * communicate back with the server for key grabs and other features.
+ *
+ * @returns The modifier mask.
+ *
+ * @sa xkb_mod_index_t
+ * @memberof xkb_keymap
+ */
+xkb_mod_mask_t
+xkb_keymap_mod_get_mask(struct xkb_keymap *keymap, xkb_mod_index_t idx);
+
+/**
  * Get the number of layouts in the keymap.
  *
  * @sa xkb_layout_index_t xkb_rule_names xkb_keymap_num_layouts_for_key()


### PR DESCRIPTION
This is a convenience function to return the xkb_mod_mask_t for a given
modifier. The use for this is so we can find the correct mod mask for
a given modifier when calling XIGrabButton / XIGrabKeycode, or to
decipher device events we get from the server.
