### PR TITLE
keymap: Add a xkb_keymap_num_levels() function

### DIFF
--- a/src/keymap.c
+++ b/src/keymap.c
@@ -367,6 +367,27 @@ xkb_keymap_num_levels_for_key(struct xkb_keymap *keymap, xkb_keycode_t kc,
 }
 
 /**
+ * Returns the maximum number of levels on a single key in the keymap.
+ */
+XKB_EXPORT xkb_level_index_t
+xkb_keymap_num_levels(struct xkb_keymap *keymap)
+{
+    struct xkb_key *key;
+    xkb_level_index_t max_levels = 0;
+
+    xkb_keys_foreach(key, keymap) {
+        xkb_layout_index_t layout;
+        for (layout = 0; layout < key->num_groups; layout++) {
+            xkb_level_index_t levels = XkbKeyGroupWidth(key, layout);
+            if (levels > max_levels)
+                max_levels = levels;
+        }
+    }
+
+    return max_levels;
+}
+
+/**
  * Return the total number of LEDs in the keymap.
  */
 XKB_EXPORT xkb_led_index_t

--- a/xkbcommon.map
+++ b/xkbcommon.map
@@ -34,6 +34,7 @@ global:
 	xkb_keymap_mod_get_name;
 	xkb_keymap_mod_get_index;
 	xkb_keymap_num_layouts;
+	xkb_keymap_num_levels;
 	xkb_keymap_layout_get_name;
 	xkb_keymap_layout_get_index;
 	xkb_keymap_num_leds;

--- a/xkbcommon/xkbcommon.h
+++ b/xkbcommon/xkbcommon.h
@@ -982,6 +982,15 @@ xkb_layout_index_t
 xkb_keymap_num_layouts(struct xkb_keymap *keymap);
 
 /**
+ * Get the maximum number of shift levels on a single key in the keymap.
+ *
+ * @sa xkb_level_index_t xkb_keymap_num_levels_for_key()
+ * @memberof xkb_keymap
+ */
+xkb_level_index_t
+xkb_keymap_num_levels(struct xkb_keymap *keymap);
+
+/**
  * Get the name of a layout by index.
  *
  * @returns The name.  If the index is invalid, or the layout does not have


### PR DESCRIPTION
This allows callers to know the maximum number of shift levels of a
single key on a given keymap.

See https://bugzilla.gnome.org/show_bug.cgi?id=737134 for why we need this in mutter. Better ideas for how to implement that are very welcome. Thanks