### PR TITLE
Make librt optional, required for at least OpenBSD

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -209,7 +209,7 @@ test_keyseq_LDADD = $(TESTS_LDADD)
 test_rulescomp_LDADD = $(TESTS_LDADD)
 test_rmlvo_to_kccgst_LDADD = $(TESTS_LDADD)
 test_print_compiled_keymap_LDADD = $(TESTS_LDADD)
-test_compose_LDADD = $(TESTS_LDADD) -lrt
+test_compose_LDADD = $(TESTS_LDADD) $(RT_LIBS)
 
 if BUILD_LINUX_TESTS
 check_PROGRAMS += \
@@ -242,7 +242,7 @@ check_PROGRAMS += $(TESTS)
 # Benchmarks
 ##
 
-BENCH_LDADD = $(TESTS_LDADD) -lrt
+BENCH_LDADD = $(TESTS_LDADD) $(RT_LIBS)
 
 check_PROGRAMS += \
 	bench/key-proc \

--- a/configure.ac
+++ b/configure.ac
@@ -95,6 +95,11 @@ XORG_TESTSET_CFLAG([BASE_CFLAGS], [-Wdocumentation])
 XORG_CHECK_LINKER_FLAGS([-Wl,--no-undefined], [have_no_undefined=yes])
 AM_CONDITIONAL([HAVE_NO_UNDEFINED], [test "x$have_no_undefined" = xyes])
 
+AC_CHECK_LIB(rt, clock_gettime,
+    [AC_SUBST(RT_LIBS, "-lrt")],
+    [AC_SUBST(RT_LIBS, "")],
+    [-lrt])
+
 # Define a configuration option for the XKB config root
 xkb_base=`$PKG_CONFIG --variable=xkb_base xkeyboard-config`
 AS_IF([test "x$xkb_base" = x], [


### PR DESCRIPTION
With this patch libxkbcommon passes all the tests on OpenBSD 5.6. 
