### PR TITLE
Modifications to make 'make check' test complete for Mac OS X

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -250,8 +250,12 @@ check_PROGRAMS += $(TESTS)
 ##
 # Benchmarks
 ##
-
-BENCH_LDADD = $(TESTS_LDADD) $(RT_LIBS)
+check_LTLIBRARIES += libbench.la
+libbench_la_SOURCES = \
+	bench/bench.c \
+	bench/bench.h
+BENCH_LDADD  = libbench.la
+BENCH_LDADD += $(TESTS_LDADD) $(RT_LIBS)
 
 check_PROGRAMS += \
 	bench/key-proc \

--- a/bench/bench.c
+++ b/bench/bench.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2015 Kazunobu Kuriyama <kazunobu.kuriyama@nifty.com>
+ *                  Ran Benita <ran234@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#if defined(HAVE_CLOCK_GETTIME)
+#define USE_CLOCK_GETTIME
+#include <time.h>
+#elif defined(__MACH__) && __MACH__ == 1
+#define USE_MACH_ABSOLUTE_TIME
+#include <mach/mach_time.h>
+#else
+/* gettimeofday() - a last resort */
+#include <sys/time.h>
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "bench.h"
+
+static void
+set_bench_time(struct bench_time *dest, long seconds, long milliseconds)
+{
+    dest->seconds = seconds;
+    dest->milliseconds = milliseconds;
+}
+
+static void
+normalize_bench_time(struct bench_time *obj)
+{
+    if (obj->milliseconds >= 0) {
+        return;
+    }
+    obj->milliseconds += 1000000;
+    obj->seconds--;
+}
+
+void
+bench_timer_reset(struct bench_timer *self)
+{
+#if defined(USE_MACH_ABSOLUTE_TIME)
+    mach_timebase_info_data_t info;
+    if (mach_timebase_info(&info) == 0) {
+        self->scaling_factor = info.numer / info.denom;
+    }
+#endif
+    self->start.seconds = 0L;
+    self->start.milliseconds = 0L;
+    self->stop.seconds = 0L;
+    self->stop.milliseconds = 0L;
+}
+
+void
+bench_timer_start(struct bench_timer *self)
+{
+#if defined(USE_CLOCK_GETTIME)
+    struct timespec val;
+
+    (void)clock_gettime(CLOCK_MONOTONIC, &val);
+
+    /* With conversion from nanosecond to millisecond */
+    set_bench_time(&self->start, val.tv_sec, val.tv_nsec / 1000);
+#elif defined(USE_MACH_ABSOLUTE_TIME)
+    uint64_t val;
+
+    val = mach_absolute_time();
+
+    /* With conversion from nanosecond to millisecond */
+    set_bench_time(&self->start,
+                   self->scaling_factor * val / 1000000000,
+                   self->scaling_factor * val % 1000000000 / 1000);
+#else
+    struct timeval val;
+
+    (void)gettimeofday(&val, NULL);
+
+    set_bench_time(&self->start, val.tv_sec, val.tv_usec);
+#endif
+}
+
+void
+bench_timer_stop(struct bench_timer *self)
+{
+#if defined(USE_CLOCK_GETTIME)
+    struct timespec val;
+
+    (void)clock_gettime(CLOCK_MONOTONIC, &val);
+
+    /* With conversion from nanosecond to millisecond */
+    set_bench_time(&self->stop, val.tv_sec, val.tv_nsec / 1000);
+#elif defined(USE_MACH_ABSOLUTE_TIME)
+    uint64_t val;
+
+    val = mach_absolute_time();
+
+    /* With conversion from nanosecond to millisecond */
+    set_bench_time(&self->stop,
+                   self->scaling_factor * val / 1000000000,
+                   self->scaling_factor * val % 1000000000 / 1000);
+#else
+    struct timeval val;
+
+    (void)gettimeofday(&val, NULL);
+
+    set_bench_time(&self->stop, val.tv_sec, val.tv_usec);
+#endif
+}
+
+void
+bench_timer_get_elapsed_time(struct bench_timer *self, struct bench_time *result)
+{
+    result->seconds = self->stop.seconds - self->start.seconds;
+    result->milliseconds = self->stop.milliseconds - self->start.milliseconds;
+}
+
+char *
+bench_timer_get_elapsed_time_str(struct bench_timer *self)
+{
+    struct bench_time elapsed;
+    char *buf;
+
+    bench_timer_get_elapsed_time(self, &elapsed);
+    normalize_bench_time(&elapsed);
+    asprintf(&buf, "%ld.%06ld", elapsed.seconds, elapsed.milliseconds);
+
+    return buf;
+}

--- a/bench/key-proc.c
+++ b/bench/key-proc.c
@@ -25,6 +25,7 @@
 #include <time.h>
 
 #include "../test/test.h"
+#include "bench.h"
 
 #define BENCHMARK_ITERATIONS 20000000
 
@@ -56,7 +57,8 @@ main(void)
     struct xkb_context *ctx;
     struct xkb_keymap *keymap;
     struct xkb_state *state;
-    struct timespec start, stop, elapsed;
+    struct bench_timer timer;
+    char *elapsed;
 
     ctx = test_get_context(0);
     assert(ctx);
@@ -73,19 +75,16 @@ main(void)
 
     srand(time(NULL));
 
-    clock_gettime(CLOCK_MONOTONIC, &start);
+    bench_timer_reset(&timer);
+
+    bench_timer_start(&timer);
     bench(state);
-    clock_gettime(CLOCK_MONOTONIC, &stop);
+    bench_timer_stop(&timer);
 
-    elapsed.tv_sec = stop.tv_sec - start.tv_sec;
-    elapsed.tv_nsec = stop.tv_nsec - start.tv_nsec;
-    if (elapsed.tv_nsec < 0) {
-        elapsed.tv_nsec += 1000000000;
-        elapsed.tv_sec--;
-    }
-
-    fprintf(stderr, "ran %d iterations in %ld.%09lds\n",
-            BENCHMARK_ITERATIONS, elapsed.tv_sec, elapsed.tv_nsec);
+    elapsed = bench_timer_get_elapsed_time_str(&timer);
+    fprintf(stderr, "ran %d iterations in %ss\n",
+            BENCHMARK_ITERATIONS, elapsed);
+    free(elapsed);
 
     xkb_state_unref(state);
     xkb_keymap_unref(keymap);

--- a/configure.ac
+++ b/configure.ac
@@ -109,6 +109,7 @@ AC_CHECK_LIB(rt, clock_gettime,
     [AC_SUBST(RT_LIBS, "-lrt")],
     [AC_SUBST(RT_LIBS, "")],
     [-lrt])
+AC_CHECK_FUNCS([clock_gettime])
 
 # Define a configuration option for the XKB config root
 xkb_base=`$PKG_CONFIG --variable=xkb_base xkeyboard-config`


### PR DESCRIPTION
This series of patches consists of two commits.

Although each of the commits may be handled independently, I'm placing them in a single PR because I think they are closely related in terms of the `make check` test on a specific platform, as suggested in the title.

On Mac OS X, the `make check` test cannot be carried out because

(1) Since `clock_gettime()` is not available on the OS, all the programs `bench/*.c` won't compile.

(2) When XQuartz's `Xvfb` is given the option `-displayfd`, it is observed that it always returns `:0`.   As a consequence, `x11comp` uses that (default) display number to connect to the X server and closes it when it's finished.  Obviously, that leaves the window system in an undesirable state.

Commit 4627892 handles the first issue and Commit 18e6612 the second.

With the patches proposed, `make check` can build the programs `bench/*.c` successfully and carry out the test suite with clean exit state.