### PR TITLE
keymap: add xkb_keymap_keyname_get_keycode()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -185,6 +185,7 @@ AM_TESTS_ENVIRONMENT = \
 
 TESTS = \
 	test/keysym \
+	test/keymap \
 	test/filecomp \
 	test/context \
 	test/rules-file \
@@ -204,6 +205,7 @@ check_PROGRAMS = \
 TESTS_LDADD = libtest.la
 
 test_keysym_LDADD = $(TESTS_LDADD)
+test_keymap_LDADD = $(TESTS_LDADD)
 test_filecomp_LDADD = $(TESTS_LDADD)
 test_context_LDADD = $(TESTS_LDADD)
 test_rules_file_CFLAGS = $(AM_CFLAGS) -Wno-declaration-after-statement

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -470,6 +470,40 @@ xkb_keymap_key_for_each(struct xkb_keymap *keymap, xkb_keymap_key_iter_t iter,
         iter(keymap, key->keycode, data);
 }
 
+XKB_EXPORT const char *
+xkb_keymap_key_get_name(struct xkb_keymap *keymap, xkb_keycode_t kc)
+{
+    const struct xkb_key *key = XkbKey(keymap, kc);
+
+    if (!key)
+        return NULL;
+
+    return xkb_atom_text(keymap->ctx, key->name);
+}
+
+XKB_EXPORT xkb_keycode_t
+xkb_keymap_key_by_name(struct xkb_keymap *keymap, const char *name)
+{
+    struct xkb_key *key;
+    xkb_atom_t atom;
+
+    atom = xkb_atom_lookup(keymap->ctx, name);
+    if (atom) {
+        xkb_atom_t ratom = XkbResolveKeyAlias(keymap, atom);
+        if (ratom)
+            atom = ratom;
+    }
+    if (!atom)
+        return XKB_KEYCODE_INVALID;
+
+    xkb_keys_foreach(key, keymap) {
+        if (key->name == atom)
+            return key->keycode;
+    }
+
+    return XKB_KEYCODE_INVALID;
+}
+
 /**
  * Simple boolean specifying whether or not the key should repeat.
  */

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -2,6 +2,7 @@
 *.trs
 filecomp
 rulescomp
+keymap
 keysym
 state
 context

--- a/test/keymap.c
+++ b/test/keymap.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2016 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Author: Mike Blumenkrantz <zmike@osg.samsung.com>
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "test.h"
+
+int
+main(void)
+{
+    struct xkb_context *context = test_get_context(0);
+    struct xkb_keymap *keymap;
+    xkb_keycode_t kc;
+    const char *keyname;
+
+    assert(context);
+
+    keymap = test_compile_rules(context, "evdev", "pc104", "us,ru", NULL, "grp:menu_toggle");
+    assert(keymap);
+
+    kc = xkb_keymap_key_by_name(keymap, "AE09");
+    assert(kc != XKB_KEYCODE_INVALID);
+    keyname = xkb_keymap_key_get_name(keymap, kc);
+    assert(!strcmp(keyname, "AE09"));
+
+    kc = xkb_keymap_key_by_name(keymap, "COMP");
+    assert(kc != XKB_KEYCODE_INVALID);
+    keyname = xkb_keymap_key_get_name(keymap, kc);
+    assert(!strcmp(keyname, "COMP"));
+
+
+    xkb_keymap_unref(keymap);
+    xkb_context_unref(context);
+}

--- a/xkbcommon/xkbcommon.h
+++ b/xkbcommon/xkbcommon.h
@@ -941,6 +941,32 @@ xkb_keymap_key_for_each(struct xkb_keymap *keymap, xkb_keymap_key_iter_t iter,
                         void *data);
 
 /**
+ * Find the key name for a given keycode in a keymap.
+ *
+ * @returns The key name. If no key with this keycode exists,
+ * returns NULL.
+ *
+ * @sa xkb_keycode_t
+ * @memberof xkb_keymap
+ * @since 0.6.0
+ */
+const char *
+xkb_keymap_key_get_name(struct xkb_keymap *keymap, xkb_keycode_t kc);
+
+/**
+ * Find the keycode of the key with a given name.
+ *
+ * @returns The keycode. If no key with this name exists,
+ * returns XKB_KEYCODE_INVALID.
+ *
+ * @sa xkb_keycode_t
+ * @memberof xkb_keymap
+ * @since 0.6.0
+ */
+xkb_keycode_t
+xkb_keymap_key_by_name(struct xkb_keymap *keymap, const char *name);
+
+/**
  * Get the number of modifiers in the keymap.
  *
  * @sa xkb_mod_index_t


### PR DESCRIPTION
this function allows finding a keycode from a given keyname and
is useful for generating keyboard events to use in regression tests
during CI

Signed-off-by: Mike Blumenkrantz <zmike@osg.samsung.com>