### PR TITLE
doc: Fix Doxygen include for srcdir != builddir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 
 before_install:
     - sudo apt-get update -qq
-    - sudo apt-get install xutils-dev
+    - sudo apt-get install xutils-dev doxygen
 
 compiler:
     - gcc

--- a/Makefile.am
+++ b/Makefile.am
@@ -151,7 +151,7 @@ all-local:: doc
 clean-local:: clean-doc
 
 doc/stamp-doxygen: $(top_srcdir)/xkbcommon/*.h
-	$(AM_V_GEN)$(DOXYGEN) doc/Doxyfile
+	$(AM_V_GEN)(cd $(top_srcdir) && $(DOXYGEN) $(abs_top_builddir)/doc/Doxyfile)
 	touch $@
 
 clean-doxygen:

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -2,7 +2,7 @@ PROJECT_NAME           = @PACKAGE_NAME@
 
 PROJECT_NUMBER         = @PACKAGE_VERSION@
 
-OUTPUT_DIRECTORY       = doc
+OUTPUT_DIRECTORY       = @abs_top_builddir@/doc
 
 BRIEF_MEMBER_DESC      = NO
 
@@ -18,13 +18,13 @@ QUIET                  = YES
 
 WARN_IF_UNDOCUMENTED   = NO
 
-INPUT                  = @abs_top_srcdir@/README.md \
-                         @abs_top_srcdir@/doc/quick-guide.md \
-                         @abs_top_srcdir@/doc/compat.md \
-                         @abs_top_srcdir@/xkbcommon/xkbcommon.h \
-                         @abs_top_srcdir@/xkbcommon/xkbcommon-names.h \
-                         @abs_top_srcdir@/xkbcommon/xkbcommon-x11.h \
-                         @abs_top_srcdir@/xkbcommon/xkbcommon-compose.h \
+INPUT                  = README.md \
+                         doc/quick-guide.md \
+                         doc/compat.md \
+                         xkbcommon/xkbcommon.h \
+                         xkbcommon/xkbcommon-names.h \
+                         xkbcommon/xkbcommon-x11.h \
+                         xkbcommon/xkbcommon-compose.h \
 
 FILE_PATTERNS          = *.c \
                          *.h
@@ -40,7 +40,7 @@ ALPHABETICAL_INDEX     = NO
 IGNORE_PREFIX          = xkb_ \
                          XKB_
 
-HTML_EXTRA_STYLESHEET  = @abs_top_srcdir@/doc/doxygen-extra.css
+HTML_EXTRA_STYLESHEET  = doc/doxygen-extra.css
 
 HTML_TIMESTAMP         = NO
 


### PR DESCRIPTION
Instead of giving Doxygen a series of absolute paths to the source
files and a relative path to the output directory, run it from the
source directory with purely relative paths to the source files, and
give it an absolute path to the build directory.

This fixes the parsing of README.md with a separate build directory,
since the relative includes for doc/quick-guide.md and doc/compat.md
don't resolve otherwise. Doxygen's INCLUDE_PATH turns out not to fix
this either, since that's just a set of paths to open and parse, rather
than an analogue to cpp's -I.

Signed-off-by: Daniel Stone <daniels@collabora.com>