### PR TITLE
travis: remove --disable-x11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
+sudo: required
+dist: trusty
 language: c
 
 before_install:
     - sudo apt-get update -qq
-    - sudo apt-get install xutils-dev doxygen
+    - sudo apt-get -y install xutils-dev doxygen libxcb-xkb-dev
 
 compiler:
     - gcc
     - clang
 
-# libxcb too old -- should enable when possible.
-script: ./autogen.sh --disable-x11 && make && make check
+script: ./autogen.sh && make && make check


### PR DESCRIPTION
Looks like the CI machines were updated to use Ubuntu 14.04, which has
libxcb 1.10, which is new enough. Lets see if it works.

Signed-off-by: Ran Benita <ran234@gmail.com>