### PR TITLE
build: Make sure to create the root dir at install phase

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -140,6 +140,9 @@ CLEANFILES = $(BUILT_SOURCES)
 src/xkbcomp/parser.c: $(top_builddir)/src/$(am__dirstamp) $(top_builddir)/src/xkbcomp/$(am__dirstamp)
 src/xkbcomp/parser.h: $(top_builddir)/src/$(am__dirstamp) $(top_builddir)/src/xkbcomp/$(am__dirstamp)
 
+install-data-local::
+	$(MKDIR_P) $(XKBCONFIGROOT)
+
 ##
 # Documentation
 ##


### PR DESCRIPTION
It might not exist, so context creation will fail with the message
"failed to add default include path".

Signed-off-by: Jonh Wendell <jonh.wendell@redhat.com>