### PR TITLE
Sync Keysyms with recent xproto additions

### DIFF
--- a/src/ks_tables.h
+++ b/src/ks_tables.h
@@ -2213,6 +2213,7 @@ static const char *keysym_names =
     "XF86AudioNext\0"
     "XF86AudioPause\0"
     "XF86AudioPlay\0"
+    "XF86AudioPreset\0"
     "XF86AudioPrev\0"
     "XF86AudioRaiseVolume\0"
     "XF86AudioRandomPlay\0"
@@ -2262,6 +2263,7 @@ static const char *keysym_names =
     "XF86KbdBrightnessDown\0"
     "XF86KbdBrightnessUp\0"
     "XF86KbdLightOnOff\0"
+    "XF86Keyboard\0"
     "XF86Launch0\0"
     "XF86Launch1\0"
     "XF86Launch2\0"
@@ -2314,6 +2316,7 @@ static const char *keysym_names =
     "XF86Refresh\0"
     "XF86Reload\0"
     "XF86Reply\0"
+    "XF86RFKill\0"
     "XF86RockerDown\0"
     "XF86RockerEnter\0"
     "XF86RockerUp\0"
@@ -2373,6 +2376,7 @@ static const char *keysym_names =
     "XF86WheelButton\0"
     "XF86WLAN\0"
     "XF86Word\0"
+    "XF86WWAN\0"
     "XF86WWW\0"
     "XF86Xfer\0"
     "XF86Yellow\0"
@@ -4624,203 +4628,207 @@ static const struct name_keysym name_to_keysym[] = {
     { 0x1008ff17, 26816 }, /* XF86AudioNext */
     { 0x1008ff31, 26830 }, /* XF86AudioPause */
     { 0x1008ff14, 26845 }, /* XF86AudioPlay */
-    { 0x1008ff16, 26859 }, /* XF86AudioPrev */
-    { 0x1008ff13, 26873 }, /* XF86AudioRaiseVolume */
-    { 0x1008ff99, 26894 }, /* XF86AudioRandomPlay */
-    { 0x1008ff1c, 26914 }, /* XF86AudioRecord */
-    { 0x1008ff98, 26930 }, /* XF86AudioRepeat */
-    { 0x1008ff3e, 26946 }, /* XF86AudioRewind */
-    { 0x1008ff15, 26962 }, /* XF86AudioStop */
-    { 0x1008ff8d, 26976 }, /* XF86Away */
-    { 0x1008ff26, 26985 }, /* XF86Back */
-    { 0x1008ff3f, 26994 }, /* XF86BackForward */
-    { 0x1008ff93, 27010 }, /* XF86Battery */
-    { 0x1008ffa6, 27022 }, /* XF86Blue */
-    { 0x1008ff94, 27031 }, /* XF86Bluetooth */
-    { 0x1008ff52, 27045 }, /* XF86Book */
-    { 0x1008ff3b, 27054 }, /* XF86BrightnessAdjust */
-    { 0x1008ff54, 27075 }, /* XF86Calculater */
-    { 0x1008ff1d, 27090 }, /* XF86Calculator */
-    { 0x1008ff20, 27105 }, /* XF86Calendar */
-    { 0x1008ff53, 27118 }, /* XF86CD */
-    { 0x1008ff55, 27125 }, /* XF86Clear */
-    { 0x1008fe21, 27135 }, /* XF86ClearGrab */
-    { 0x1008ff56, 27149 }, /* XF86Close */
-    { 0x1008ff3d, 27159 }, /* XF86Community */
-    { 0x1008ff22, 27173 }, /* XF86ContrastAdjust */
-    { 0x1008ff57, 27192 }, /* XF86Copy */
-    { 0x1008ff58, 27201 }, /* XF86Cut */
-    { 0x1008ff9c, 27209 }, /* XF86CycleAngle */
-    { 0x1008ff59, 27224 }, /* XF86Display */
-    { 0x1008ff5b, 27236 }, /* XF86Documents */
-    { 0x1008ff5a, 27250 }, /* XF86DOS */
-    { 0x1008ff2c, 27258 }, /* XF86Eject */
-    { 0x1008ff5c, 27268 }, /* XF86Excel */
-    { 0x1008ff5d, 27278 }, /* XF86Explorer */
-    { 0x1008ff30, 27291 }, /* XF86Favorites */
-    { 0x1008ff3c, 27305 }, /* XF86Finance */
-    { 0x1008ff27, 27317 }, /* XF86Forward */
-    { 0x1008ff9d, 27329 }, /* XF86FrameBack */
-    { 0x1008ff9e, 27343 }, /* XF86FrameForward */
-    { 0x1008ff5e, 27360 }, /* XF86Game */
-    { 0x1008ff5f, 27369 }, /* XF86Go */
-    { 0x1008ffa4, 27376 }, /* XF86Green */
-    { 0x1008ffa8, 27386 }, /* XF86Hibernate */
-    { 0x1008ff37, 27400 }, /* XF86History */
-    { 0x1008ff18, 27412 }, /* XF86HomePage */
-    { 0x1008ff3a, 27425 }, /* XF86HotLinks */
-    { 0x1008ff60, 27438 }, /* XF86iTouch */
-    { 0x1008ff06, 27449 }, /* XF86KbdBrightnessDown */
-    { 0x1008ff05, 27471 }, /* XF86KbdBrightnessUp */
-    { 0x1008ff04, 27491 }, /* XF86KbdLightOnOff */
-    { 0x1008ff40, 27509 }, /* XF86Launch0 */
-    { 0x1008ff41, 27521 }, /* XF86Launch1 */
-    { 0x1008ff42, 27533 }, /* XF86Launch2 */
-    { 0x1008ff43, 27545 }, /* XF86Launch3 */
-    { 0x1008ff44, 27557 }, /* XF86Launch4 */
-    { 0x1008ff45, 27569 }, /* XF86Launch5 */
-    { 0x1008ff46, 27581 }, /* XF86Launch6 */
-    { 0x1008ff47, 27593 }, /* XF86Launch7 */
-    { 0x1008ff48, 27605 }, /* XF86Launch8 */
-    { 0x1008ff49, 27617 }, /* XF86Launch9 */
-    { 0x1008ff4a, 27629 }, /* XF86LaunchA */
-    { 0x1008ff4b, 27641 }, /* XF86LaunchB */
-    { 0x1008ff4c, 27653 }, /* XF86LaunchC */
-    { 0x1008ff4d, 27665 }, /* XF86LaunchD */
-    { 0x1008ff4e, 27677 }, /* XF86LaunchE */
-    { 0x1008ff4f, 27689 }, /* XF86LaunchF */
-    { 0x1008ff35, 27701 }, /* XF86LightBulb */
-    { 0x1008fe25, 27715 }, /* XF86LogGrabInfo */
-    { 0x1008ff61, 27731 }, /* XF86LogOff */
-    { 0x1008fe24, 27742 }, /* XF86LogWindowTree */
-    { 0x1008ff19, 27760 }, /* XF86Mail */
-    { 0x1008ff90, 27769 }, /* XF86MailForward */
-    { 0x1008ff62, 27785 }, /* XF86Market */
-    { 0x1008ff63, 27796 }, /* XF86Meeting */
-    { 0x1008ff1e, 27808 }, /* XF86Memo */
-    { 0x1008ff65, 27817 }, /* XF86MenuKB */
-    { 0x1008ff66, 27828 }, /* XF86MenuPB */
-    { 0x1008ff8e, 27839 }, /* XF86Messenger */
-    { 0x1008ff01, 27853 }, /* XF86ModeLock */
-    { 0x1008ff03, 27866 }, /* XF86MonBrightnessDown */
-    { 0x1008ff02, 27888 }, /* XF86MonBrightnessUp */
-    { 0x1008ff92, 27908 }, /* XF86Music */
-    { 0x1008ff33, 27918 }, /* XF86MyComputer */
-    { 0x1008ff67, 27933 }, /* XF86MySites */
-    { 0x1008ff68, 27945 }, /* XF86New */
-    { 0x1008ff69, 27953 }, /* XF86News */
-    { 0x1008fe22, 27962 }, /* XF86Next_VMode */
-    { 0x1008ff6a, 27977 }, /* XF86OfficeHome */
-    { 0x1008ff6b, 27992 }, /* XF86Open */
-    { 0x1008ff38, 28001 }, /* XF86OpenURL */
-    { 0x1008ff6c, 28013 }, /* XF86Option */
-    { 0x1008ff6d, 28024 }, /* XF86Paste */
-    { 0x1008ff6e, 28034 }, /* XF86Phone */
-    { 0x1008ff91, 28044 }, /* XF86Pictures */
-    { 0x1008ff21, 28057 }, /* XF86PowerDown */
-    { 0x1008ff2a, 28071 }, /* XF86PowerOff */
-    { 0x1008fe23, 28084 }, /* XF86Prev_VMode */
-    { 0x1008ff70, 28099 }, /* XF86Q */
-    { 0x1008ffa3, 28105 }, /* XF86Red */
-    { 0x1008ff29, 28113 }, /* XF86Refresh */
-    { 0x1008ff73, 28125 }, /* XF86Reload */
-    { 0x1008ff72, 28136 }, /* XF86Reply */
-    { 0x1008ff24, 28146 }, /* XF86RockerDown */
-    { 0x1008ff25, 28161 }, /* XF86RockerEnter */
-    { 0x1008ff23, 28177 }, /* XF86RockerUp */
-    { 0x1008ff74, 28190 }, /* XF86RotateWindows */
-    { 0x1008ff76, 28208 }, /* XF86RotationKB */
-    { 0x1008ff75, 28223 }, /* XF86RotationPB */
-    { 0x1008ff77, 28238 }, /* XF86Save */
-    { 0x1008ff2d, 28247 }, /* XF86ScreenSaver */
-    { 0x1008ff7a, 28263 }, /* XF86ScrollClick */
-    { 0x1008ff79, 28279 }, /* XF86ScrollDown */
-    { 0x1008ff78, 28294 }, /* XF86ScrollUp */
-    { 0x1008ff1b, 28307 }, /* XF86Search */
-    { 0x1008ffa0, 28318 }, /* XF86Select */
-    { 0x1008ff7b, 28329 }, /* XF86Send */
-    { 0x1008ff36, 28338 }, /* XF86Shop */
-    { 0x1008ff2f, 28347 }, /* XF86Sleep */
-    { 0x1008ff7c, 28357 }, /* XF86Spell */
-    { 0x1008ff7d, 28367 }, /* XF86SplitScreen */
-    { 0x1008ff10, 28383 }, /* XF86Standby */
-    { 0x1008ff1a, 28395 }, /* XF86Start */
-    { 0x1008ff28, 28405 }, /* XF86Stop */
-    { 0x1008ff9a, 28414 }, /* XF86Subtitle */
-    { 0x1008ff7e, 28427 }, /* XF86Support */
-    { 0x1008ffa7, 28439 }, /* XF86Suspend */
-    { 0x1008fe01, 28451 }, /* XF86Switch_VT_1 */
-    { 0x1008fe0a, 28467 }, /* XF86Switch_VT_10 */
-    { 0x1008fe0b, 28484 }, /* XF86Switch_VT_11 */
-    { 0x1008fe0c, 28501 }, /* XF86Switch_VT_12 */
-    { 0x1008fe02, 28518 }, /* XF86Switch_VT_2 */
-    { 0x1008fe03, 28534 }, /* XF86Switch_VT_3 */
-    { 0x1008fe04, 28550 }, /* XF86Switch_VT_4 */
-    { 0x1008fe05, 28566 }, /* XF86Switch_VT_5 */
-    { 0x1008fe06, 28582 }, /* XF86Switch_VT_6 */
-    { 0x1008fe07, 28598 }, /* XF86Switch_VT_7 */
-    { 0x1008fe08, 28614 }, /* XF86Switch_VT_8 */
-    { 0x1008fe09, 28630 }, /* XF86Switch_VT_9 */
-    { 0x1008ff7f, 28646 }, /* XF86TaskPane */
-    { 0x1008ff80, 28659 }, /* XF86Terminal */
-    { 0x1008ff9f, 28672 }, /* XF86Time */
-    { 0x1008ff1f, 28681 }, /* XF86ToDoList */
-    { 0x1008ff81, 28694 }, /* XF86Tools */
-    { 0x1008ffa2, 28704 }, /* XF86TopMenu */
-    { 0x1008ffb1, 28716 }, /* XF86TouchpadOff */
-    { 0x1008ffb0, 28732 }, /* XF86TouchpadOn */
-    { 0x1008ffa9, 28747 }, /* XF86TouchpadToggle */
-    { 0x1008ff82, 28766 }, /* XF86Travel */
-    { 0x1008fe20, 28777 }, /* XF86Ungrab */
-    { 0x1008ff85, 28788 }, /* XF86User1KB */
-    { 0x1008ff86, 28800 }, /* XF86User2KB */
-    { 0x1008ff84, 28812 }, /* XF86UserPB */
-    { 0x1008ff96, 28823 }, /* XF86UWB */
-    { 0x1008ff34, 28831 }, /* XF86VendorHome */
-    { 0x1008ff87, 28846 }, /* XF86Video */
-    { 0x1008ffa1, 28856 }, /* XF86View */
-    { 0x1008ff2b, 28865 }, /* XF86WakeUp */
-    { 0x1008ff8f, 28876 }, /* XF86WebCam */
-    { 0x1008ff88, 28887 }, /* XF86WheelButton */
-    { 0x1008ff95, 28903 }, /* XF86WLAN */
-    { 0x1008ff89, 28912 }, /* XF86Word */
-    { 0x1008ff2e, 28921 }, /* XF86WWW */
-    { 0x1008ff8a, 28929 }, /* XF86Xfer */
-    { 0x1008ffa5, 28938 }, /* XF86Yellow */
-    { 0x1008ff8b, 28949 }, /* XF86ZoomIn */
-    { 0x1008ff8c, 28960 }, /* XF86ZoomOut */
-    { 0x00000059, 28972 }, /* Y */
-    { 0x00000079, 28974 }, /* y */
-    { 0x000000dd, 28976 }, /* Yacute */
-    { 0x000000fd, 28983 }, /* yacute */
-    { 0x01001ef4, 28990 }, /* Ybelowdot */
-    { 0x01001ef5, 29000 }, /* ybelowdot */
-    { 0x01000176, 29010 }, /* Ycircumflex */
-    { 0x01000177, 29022 }, /* ycircumflex */
-    { 0x000000ff, 29034 }, /* ydiaeresis */
-    { 0x000013be, 29045 }, /* Ydiaeresis */
-    { 0x000000a5, 29056 }, /* yen */
-    { 0x01001ef2, 29060 }, /* Ygrave */
-    { 0x01001ef3, 29067 }, /* ygrave */
-    { 0x01001ef6, 29074 }, /* Yhook */
-    { 0x01001ef7, 29080 }, /* yhook */
-    { 0x01001ef8, 29086 }, /* Ytilde */
-    { 0x01001ef9, 29093 }, /* ytilde */
-    { 0x0000005a, 29100 }, /* Z */
-    { 0x0000007a, 29102 }, /* z */
-    { 0x000001af, 29104 }, /* Zabovedot */
-    { 0x000001bf, 29114 }, /* zabovedot */
-    { 0x000001ac, 29124 }, /* Zacute */
-    { 0x000001bc, 29131 }, /* zacute */
-    { 0x000001ae, 29138 }, /* Zcaron */
-    { 0x000001be, 29145 }, /* zcaron */
-    { 0x0000ff3d, 29152 }, /* Zen_Koho */
-    { 0x0000ff28, 29161 }, /* Zenkaku */
-    { 0x0000ff2a, 29169 }, /* Zenkaku_Hankaku */
-    { 0x01002080, 29185 }, /* zerosubscript */
-    { 0x01002070, 29199 }, /* zerosuperior */
-    { 0x010001b5, 29212 }, /* Zstroke */
-    { 0x010001b6, 29220 }, /* zstroke */
+    { 0x1008ffb6, 26859 }, /* XF86AudioPreset */
+    { 0x1008ff16, 26875 }, /* XF86AudioPrev */
+    { 0x1008ff13, 26889 }, /* XF86AudioRaiseVolume */
+    { 0x1008ff99, 26910 }, /* XF86AudioRandomPlay */
+    { 0x1008ff1c, 26930 }, /* XF86AudioRecord */
+    { 0x1008ff98, 26946 }, /* XF86AudioRepeat */
+    { 0x1008ff3e, 26962 }, /* XF86AudioRewind */
+    { 0x1008ff15, 26978 }, /* XF86AudioStop */
+    { 0x1008ff8d, 26992 }, /* XF86Away */
+    { 0x1008ff26, 27001 }, /* XF86Back */
+    { 0x1008ff3f, 27010 }, /* XF86BackForward */
+    { 0x1008ff93, 27026 }, /* XF86Battery */
+    { 0x1008ffa6, 27038 }, /* XF86Blue */
+    { 0x1008ff94, 27047 }, /* XF86Bluetooth */
+    { 0x1008ff52, 27061 }, /* XF86Book */
+    { 0x1008ff3b, 27070 }, /* XF86BrightnessAdjust */
+    { 0x1008ff54, 27091 }, /* XF86Calculater */
+    { 0x1008ff1d, 27106 }, /* XF86Calculator */
+    { 0x1008ff20, 27121 }, /* XF86Calendar */
+    { 0x1008ff53, 27134 }, /* XF86CD */
+    { 0x1008ff55, 27141 }, /* XF86Clear */
+    { 0x1008fe21, 27151 }, /* XF86ClearGrab */
+    { 0x1008ff56, 27165 }, /* XF86Close */
+    { 0x1008ff3d, 27175 }, /* XF86Community */
+    { 0x1008ff22, 27189 }, /* XF86ContrastAdjust */
+    { 0x1008ff57, 27208 }, /* XF86Copy */
+    { 0x1008ff58, 27217 }, /* XF86Cut */
+    { 0x1008ff9c, 27225 }, /* XF86CycleAngle */
+    { 0x1008ff59, 27240 }, /* XF86Display */
+    { 0x1008ff5b, 27252 }, /* XF86Documents */
+    { 0x1008ff5a, 27266 }, /* XF86DOS */
+    { 0x1008ff2c, 27274 }, /* XF86Eject */
+    { 0x1008ff5c, 27284 }, /* XF86Excel */
+    { 0x1008ff5d, 27294 }, /* XF86Explorer */
+    { 0x1008ff30, 27307 }, /* XF86Favorites */
+    { 0x1008ff3c, 27321 }, /* XF86Finance */
+    { 0x1008ff27, 27333 }, /* XF86Forward */
+    { 0x1008ff9d, 27345 }, /* XF86FrameBack */
+    { 0x1008ff9e, 27359 }, /* XF86FrameForward */
+    { 0x1008ff5e, 27376 }, /* XF86Game */
+    { 0x1008ff5f, 27385 }, /* XF86Go */
+    { 0x1008ffa4, 27392 }, /* XF86Green */
+    { 0x1008ffa8, 27402 }, /* XF86Hibernate */
+    { 0x1008ff37, 27416 }, /* XF86History */
+    { 0x1008ff18, 27428 }, /* XF86HomePage */
+    { 0x1008ff3a, 27441 }, /* XF86HotLinks */
+    { 0x1008ff60, 27454 }, /* XF86iTouch */
+    { 0x1008ff06, 27465 }, /* XF86KbdBrightnessDown */
+    { 0x1008ff05, 27487 }, /* XF86KbdBrightnessUp */
+    { 0x1008ff04, 27507 }, /* XF86KbdLightOnOff */
+    { 0x1008ffb3, 27525 }, /* XF86Keyboard */
+    { 0x1008ff40, 27538 }, /* XF86Launch0 */
+    { 0x1008ff41, 27550 }, /* XF86Launch1 */
+    { 0x1008ff42, 27562 }, /* XF86Launch2 */
+    { 0x1008ff43, 27574 }, /* XF86Launch3 */
+    { 0x1008ff44, 27586 }, /* XF86Launch4 */
+    { 0x1008ff45, 27598 }, /* XF86Launch5 */
+    { 0x1008ff46, 27610 }, /* XF86Launch6 */
+    { 0x1008ff47, 27622 }, /* XF86Launch7 */
+    { 0x1008ff48, 27634 }, /* XF86Launch8 */
+    { 0x1008ff49, 27646 }, /* XF86Launch9 */
+    { 0x1008ff4a, 27658 }, /* XF86LaunchA */
+    { 0x1008ff4b, 27670 }, /* XF86LaunchB */
+    { 0x1008ff4c, 27682 }, /* XF86LaunchC */
+    { 0x1008ff4d, 27694 }, /* XF86LaunchD */
+    { 0x1008ff4e, 27706 }, /* XF86LaunchE */
+    { 0x1008ff4f, 27718 }, /* XF86LaunchF */
+    { 0x1008ff35, 27730 }, /* XF86LightBulb */
+    { 0x1008fe25, 27744 }, /* XF86LogGrabInfo */
+    { 0x1008ff61, 27760 }, /* XF86LogOff */
+    { 0x1008fe24, 27771 }, /* XF86LogWindowTree */
+    { 0x1008ff19, 27789 }, /* XF86Mail */
+    { 0x1008ff90, 27798 }, /* XF86MailForward */
+    { 0x1008ff62, 27814 }, /* XF86Market */
+    { 0x1008ff63, 27825 }, /* XF86Meeting */
+    { 0x1008ff1e, 27837 }, /* XF86Memo */
+    { 0x1008ff65, 27846 }, /* XF86MenuKB */
+    { 0x1008ff66, 27857 }, /* XF86MenuPB */
+    { 0x1008ff8e, 27868 }, /* XF86Messenger */
+    { 0x1008ff01, 27882 }, /* XF86ModeLock */
+    { 0x1008ff03, 27895 }, /* XF86MonBrightnessDown */
+    { 0x1008ff02, 27917 }, /* XF86MonBrightnessUp */
+    { 0x1008ff92, 27937 }, /* XF86Music */
+    { 0x1008ff33, 27947 }, /* XF86MyComputer */
+    { 0x1008ff67, 27962 }, /* XF86MySites */
+    { 0x1008ff68, 27974 }, /* XF86New */
+    { 0x1008ff69, 27982 }, /* XF86News */
+    { 0x1008fe22, 27991 }, /* XF86Next_VMode */
+    { 0x1008ff6a, 28006 }, /* XF86OfficeHome */
+    { 0x1008ff6b, 28021 }, /* XF86Open */
+    { 0x1008ff38, 28030 }, /* XF86OpenURL */
+    { 0x1008ff6c, 28042 }, /* XF86Option */
+    { 0x1008ff6d, 28053 }, /* XF86Paste */
+    { 0x1008ff6e, 28063 }, /* XF86Phone */
+    { 0x1008ff91, 28073 }, /* XF86Pictures */
+    { 0x1008ff21, 28086 }, /* XF86PowerDown */
+    { 0x1008ff2a, 28100 }, /* XF86PowerOff */
+    { 0x1008fe23, 28113 }, /* XF86Prev_VMode */
+    { 0x1008ff70, 28128 }, /* XF86Q */
+    { 0x1008ffa3, 28134 }, /* XF86Red */
+    { 0x1008ff29, 28142 }, /* XF86Refresh */
+    { 0x1008ff73, 28154 }, /* XF86Reload */
+    { 0x1008ff72, 28165 }, /* XF86Reply */
+    { 0x1008ffb5, 28175 }, /* XF86RFKill */
+    { 0x1008ff24, 28186 }, /* XF86RockerDown */
+    { 0x1008ff25, 28201 }, /* XF86RockerEnter */
+    { 0x1008ff23, 28217 }, /* XF86RockerUp */
+    { 0x1008ff74, 28230 }, /* XF86RotateWindows */
+    { 0x1008ff76, 28248 }, /* XF86RotationKB */
+    { 0x1008ff75, 28263 }, /* XF86RotationPB */
+    { 0x1008ff77, 28278 }, /* XF86Save */
+    { 0x1008ff2d, 28287 }, /* XF86ScreenSaver */
+    { 0x1008ff7a, 28303 }, /* XF86ScrollClick */
+    { 0x1008ff79, 28319 }, /* XF86ScrollDown */
+    { 0x1008ff78, 28334 }, /* XF86ScrollUp */
+    { 0x1008ff1b, 28347 }, /* XF86Search */
+    { 0x1008ffa0, 28358 }, /* XF86Select */
+    { 0x1008ff7b, 28369 }, /* XF86Send */
+    { 0x1008ff36, 28378 }, /* XF86Shop */
+    { 0x1008ff2f, 28387 }, /* XF86Sleep */
+    { 0x1008ff7c, 28397 }, /* XF86Spell */
+    { 0x1008ff7d, 28407 }, /* XF86SplitScreen */
+    { 0x1008ff10, 28423 }, /* XF86Standby */
+    { 0x1008ff1a, 28435 }, /* XF86Start */
+    { 0x1008ff28, 28445 }, /* XF86Stop */
+    { 0x1008ff9a, 28454 }, /* XF86Subtitle */
+    { 0x1008ff7e, 28467 }, /* XF86Support */
+    { 0x1008ffa7, 28479 }, /* XF86Suspend */
+    { 0x1008fe01, 28491 }, /* XF86Switch_VT_1 */
+    { 0x1008fe0a, 28507 }, /* XF86Switch_VT_10 */
+    { 0x1008fe0b, 28524 }, /* XF86Switch_VT_11 */
+    { 0x1008fe0c, 28541 }, /* XF86Switch_VT_12 */
+    { 0x1008fe02, 28558 }, /* XF86Switch_VT_2 */
+    { 0x1008fe03, 28574 }, /* XF86Switch_VT_3 */
+    { 0x1008fe04, 28590 }, /* XF86Switch_VT_4 */
+    { 0x1008fe05, 28606 }, /* XF86Switch_VT_5 */
+    { 0x1008fe06, 28622 }, /* XF86Switch_VT_6 */
+    { 0x1008fe07, 28638 }, /* XF86Switch_VT_7 */
+    { 0x1008fe08, 28654 }, /* XF86Switch_VT_8 */
+    { 0x1008fe09, 28670 }, /* XF86Switch_VT_9 */
+    { 0x1008ff7f, 28686 }, /* XF86TaskPane */
+    { 0x1008ff80, 28699 }, /* XF86Terminal */
+    { 0x1008ff9f, 28712 }, /* XF86Time */
+    { 0x1008ff1f, 28721 }, /* XF86ToDoList */
+    { 0x1008ff81, 28734 }, /* XF86Tools */
+    { 0x1008ffa2, 28744 }, /* XF86TopMenu */
+    { 0x1008ffb1, 28756 }, /* XF86TouchpadOff */
+    { 0x1008ffb0, 28772 }, /* XF86TouchpadOn */
+    { 0x1008ffa9, 28787 }, /* XF86TouchpadToggle */
+    { 0x1008ff82, 28806 }, /* XF86Travel */
+    { 0x1008fe20, 28817 }, /* XF86Ungrab */
+    { 0x1008ff85, 28828 }, /* XF86User1KB */
+    { 0x1008ff86, 28840 }, /* XF86User2KB */
+    { 0x1008ff84, 28852 }, /* XF86UserPB */
+    { 0x1008ff96, 28863 }, /* XF86UWB */
+    { 0x1008ff34, 28871 }, /* XF86VendorHome */
+    { 0x1008ff87, 28886 }, /* XF86Video */
+    { 0x1008ffa1, 28896 }, /* XF86View */
+    { 0x1008ff2b, 28905 }, /* XF86WakeUp */
+    { 0x1008ff8f, 28916 }, /* XF86WebCam */
+    { 0x1008ff88, 28927 }, /* XF86WheelButton */
+    { 0x1008ff95, 28943 }, /* XF86WLAN */
+    { 0x1008ff89, 28952 }, /* XF86Word */
+    { 0x1008ffb4, 28961 }, /* XF86WWAN */
+    { 0x1008ff2e, 28970 }, /* XF86WWW */
+    { 0x1008ff8a, 28978 }, /* XF86Xfer */
+    { 0x1008ffa5, 28987 }, /* XF86Yellow */
+    { 0x1008ff8b, 28998 }, /* XF86ZoomIn */
+    { 0x1008ff8c, 29009 }, /* XF86ZoomOut */
+    { 0x00000059, 29021 }, /* Y */
+    { 0x00000079, 29023 }, /* y */
+    { 0x000000dd, 29025 }, /* Yacute */
+    { 0x000000fd, 29032 }, /* yacute */
+    { 0x01001ef4, 29039 }, /* Ybelowdot */
+    { 0x01001ef5, 29049 }, /* ybelowdot */
+    { 0x01000176, 29059 }, /* Ycircumflex */
+    { 0x01000177, 29071 }, /* ycircumflex */
+    { 0x000000ff, 29083 }, /* ydiaeresis */
+    { 0x000013be, 29094 }, /* Ydiaeresis */
+    { 0x000000a5, 29105 }, /* yen */
+    { 0x01001ef2, 29109 }, /* Ygrave */
+    { 0x01001ef3, 29116 }, /* ygrave */
+    { 0x01001ef6, 29123 }, /* Yhook */
+    { 0x01001ef7, 29129 }, /* yhook */
+    { 0x01001ef8, 29135 }, /* Ytilde */
+    { 0x01001ef9, 29142 }, /* ytilde */
+    { 0x0000005a, 29149 }, /* Z */
+    { 0x0000007a, 29151 }, /* z */
+    { 0x000001af, 29153 }, /* Zabovedot */
+    { 0x000001bf, 29163 }, /* zabovedot */
+    { 0x000001ac, 29173 }, /* Zacute */
+    { 0x000001bc, 29180 }, /* zacute */
+    { 0x000001ae, 29187 }, /* Zcaron */
+    { 0x000001be, 29194 }, /* zcaron */
+    { 0x0000ff3d, 29201 }, /* Zen_Koho */
+    { 0x0000ff28, 29210 }, /* Zenkaku */
+    { 0x0000ff2a, 29218 }, /* Zenkaku_Hankaku */
+    { 0x01002080, 29234 }, /* zerosubscript */
+    { 0x01002070, 29248 }, /* zerosuperior */
+    { 0x010001b5, 29261 }, /* Zstroke */
+    { 0x010001b6, 29269 }, /* zstroke */
 };
 
 static const struct name_keysym keysym_to_name[] = {
@@ -4882,8 +4890,8 @@ static const struct name_keysym keysym_to_name[] = {
     { 0x00000056, 26483 }, /* V */
     { 0x00000057, 26545 }, /* W */
     { 0x00000058, 26631 }, /* X */
-    { 0x00000059, 28972 }, /* Y */
-    { 0x0000005a, 29100 }, /* Z */
+    { 0x00000059, 29021 }, /* Y */
+    { 0x0000005a, 29149 }, /* Z */
     { 0x0000005b, 3603 }, /* bracketleft */
     { 0x0000005c, 3352 }, /* backslash */
     { 0x0000005d, 3615 }, /* bracketright */
@@ -4914,8 +4922,8 @@ static const struct name_keysym keysym_to_name[] = {
     { 0x00000076, 26485 }, /* v */
     { 0x00000077, 26547 }, /* w */
     { 0x00000078, 26633 }, /* x */
-    { 0x00000079, 28974 }, /* y */
-    { 0x0000007a, 29102 }, /* z */
+    { 0x00000079, 29023 }, /* y */
+    { 0x0000007a, 29151 }, /* z */
     { 0x0000007b, 3582 }, /* braceleft */
     { 0x0000007c, 3392 }, /* bar */
     { 0x0000007d, 3592 }, /* braceright */
@@ -4925,7 +4933,7 @@ static const struct name_keysym keysym_to_name[] = {
     { 0x000000a2, 8589 }, /* cent */
     { 0x000000a3, 23827 }, /* sterling */
     { 0x000000a4, 8766 }, /* currency */
-    { 0x000000a5, 29056 }, /* yen */
+    { 0x000000a5, 29105 }, /* yen */
     { 0x000000a6, 8389 }, /* brokenbar */
     { 0x000000a7, 22719 }, /* section */
     { 0x000000a8, 11203 }, /* diaeresis */
@@ -4981,7 +4989,7 @@ static const struct name_keysym keysym_to_name[] = {
     { 0x000000da, 25851 }, /* Uacute */
     { 0x000000db, 25899 }, /* Ucircumflex */
     { 0x000000dc, 25923 }, /* Udiaeresis */
-    { 0x000000dd, 28976 }, /* Yacute */
+    { 0x000000dd, 29025 }, /* Yacute */
     { 0x000000de, 25499 }, /* THORN */
     { 0x000000df, 23820 }, /* ssharp */
     { 0x000000e0, 861 }, /* agrave */
@@ -5013,9 +5021,9 @@ static const struct name_keysym keysym_to_name[] = {
     { 0x000000fa, 25858 }, /* uacute */
     { 0x000000fb, 25911 }, /* ucircumflex */
     { 0x000000fc, 25934 }, /* udiaeresis */
-    { 0x000000fd, 28983 }, /* yacute */
+    { 0x000000fd, 29032 }, /* yacute */
     { 0x000000fe, 25511 }, /* thorn */
-    { 0x000000ff, 29034 }, /* ydiaeresis */
+    { 0x000000ff, 29083 }, /* ydiaeresis */
     { 0x000001a1, 918 }, /* Aogonek */
     { 0x000001a2, 8383 }, /* breve */
     { 0x000001a3, 19517 }, /* Lstroke */
@@ -5024,9 +5032,9 @@ static const struct name_keysym keysym_to_name[] = {
     { 0x000001a9, 22617 }, /* Scaron */
     { 0x000001aa, 22631 }, /* Scedilla */
     { 0x000001ab, 24322 }, /* Tcaron */
-    { 0x000001ac, 29124 }, /* Zacute */
-    { 0x000001ae, 29138 }, /* Zcaron */
-    { 0x000001af, 29104 }, /* Zabovedot */
+    { 0x000001ac, 29173 }, /* Zacute */
+    { 0x000001ae, 29187 }, /* Zcaron */
+    { 0x000001af, 29153 }, /* Zabovedot */
     { 0x000001b1, 926 }, /* aogonek */
     { 0x000001b2, 20520 }, /* ogonek */
     { 0x000001b3, 19525 }, /* lstroke */
@@ -5036,10 +5044,10 @@ static const struct name_keysym keysym_to_name[] = {
     { 0x000001b9, 22624 }, /* scaron */
     { 0x000001ba, 22640 }, /* scedilla */
     { 0x000001bb, 24329 }, /* tcaron */
-    { 0x000001bc, 29131 }, /* zacute */
+    { 0x000001bc, 29180 }, /* zacute */
     { 0x000001bd, 11283 }, /* doubleacute */
-    { 0x000001be, 29145 }, /* zcaron */
-    { 0x000001bf, 29114 }, /* zabovedot */
+    { 0x000001be, 29194 }, /* zcaron */
+    { 0x000001bf, 29163 }, /* zabovedot */
     { 0x000001c0, 22272 }, /* Racute */
     { 0x000001c3, 445 }, /* Abreve */
     { 0x000001c5, 19147 }, /* Lacute */
@@ -5789,7 +5797,7 @@ static const struct name_keysym keysym_to_name[] = {
     { 0x00000eff, 18797 }, /* Korean_Won */
     { 0x000013bc, 20514 }, /* OE */
     { 0x000013bd, 20517 }, /* oe */
-    { 0x000013be, 29045 }, /* Ydiaeresis */
+    { 0x000013be, 29094 }, /* Ydiaeresis */
     { 0x000020ac, 12090 }, /* EuroSign */
     { 0x0000fd01, 125 }, /* 3270_Duplicate */
     { 0x0000fd02, 195 }, /* 3270_FieldMark */
@@ -5978,9 +5986,9 @@ static const struct name_keysym keysym_to_name[] = {
     { 0x0000ff25, 16635 }, /* Hiragana */
     { 0x0000ff26, 18770 }, /* Katakana */
     { 0x0000ff27, 16644 }, /* Hiragana_Katakana */
-    { 0x0000ff28, 29161 }, /* Zenkaku */
+    { 0x0000ff28, 29210 }, /* Zenkaku */
     { 0x0000ff29, 16048 }, /* Hankaku */
-    { 0x0000ff2a, 29169 }, /* Zenkaku_Hankaku */
+    { 0x0000ff2a, 29218 }, /* Zenkaku_Hankaku */
     { 0x0000ff2b, 25752 }, /* Touroku */
     { 0x0000ff2c, 19698 }, /* Massyo */
     { 0x0000ff2d, 18351 }, /* Kana_Lock */
@@ -6124,16 +6132,16 @@ static const struct name_keysym keysym_to_name[] = {
     { 0x0100012d, 17124 }, /* ibreve */
     { 0x01000174, 26563 }, /* Wcircumflex */
     { 0x01000175, 26575 }, /* wcircumflex */
-    { 0x01000176, 29010 }, /* Ycircumflex */
-    { 0x01000177, 29022 }, /* ycircumflex */
+    { 0x01000176, 29059 }, /* Ycircumflex */
+    { 0x01000177, 29071 }, /* ycircumflex */
     { 0x0100018f, 22649 }, /* SCHWA */
     { 0x0100019f, 20218 }, /* Obarred */
     { 0x010001a0, 20553 }, /* Ohorn */
     { 0x010001a1, 20559 }, /* ohorn */
     { 0x010001af, 25997 }, /* Uhorn */
     { 0x010001b0, 26003 }, /* uhorn */
-    { 0x010001b5, 29212 }, /* Zstroke */
-    { 0x010001b6, 29220 }, /* zstroke */
+    { 0x010001b5, 29261 }, /* Zstroke */
+    { 0x010001b6, 29269 }, /* zstroke */
     { 0x010001b7, 12147 }, /* EZH */
     { 0x010001d1, 20254 }, /* Ocaron */
     { 0x010001d2, 20261 }, /* ocaron */
@@ -6521,22 +6529,22 @@ static const struct name_keysym keysym_to_name[] = {
     { 0x01001eef, 26112 }, /* uhorntilde */
     { 0x01001ef0, 26031 }, /* Uhornbelowdot */
     { 0x01001ef1, 26045 }, /* uhornbelowdot */
-    { 0x01001ef2, 29060 }, /* Ygrave */
-    { 0x01001ef3, 29067 }, /* ygrave */
-    { 0x01001ef4, 28990 }, /* Ybelowdot */
-    { 0x01001ef5, 29000 }, /* ybelowdot */
-    { 0x01001ef6, 29074 }, /* Yhook */
-    { 0x01001ef7, 29080 }, /* yhook */
-    { 0x01001ef8, 29086 }, /* Ytilde */
-    { 0x01001ef9, 29093 }, /* ytilde */
-    { 0x01002070, 29199 }, /* zerosuperior */
+    { 0x01001ef2, 29109 }, /* Ygrave */
+    { 0x01001ef3, 29116 }, /* ygrave */
+    { 0x01001ef4, 29039 }, /* Ybelowdot */
+    { 0x01001ef5, 29049 }, /* ybelowdot */
+    { 0x01001ef6, 29123 }, /* Yhook */
+    { 0x01001ef7, 29129 }, /* yhook */
+    { 0x01001ef8, 29135 }, /* Ytilde */
+    { 0x01001ef9, 29142 }, /* ytilde */
+    { 0x01002070, 29248 }, /* zerosuperior */
     { 0x01002074, 12632 }, /* foursuperior */
     { 0x01002075, 12594 }, /* fivesuperior */
     { 0x01002076, 23756 }, /* sixsuperior */
     { 0x01002077, 22932 }, /* sevensuperior */
     { 0x01002078, 11765 }, /* eightsuperior */
     { 0x01002079, 20062 }, /* ninesuperior */
-    { 0x01002080, 29185 }, /* zerosubscript */
+    { 0x01002080, 29234 }, /* zerosubscript */
     { 0x01002081, 20742 }, /* onesubscript */
     { 0x01002082, 25812 }, /* twosubscript */
     { 0x01002083, 25556 }, /* threesubscript */
@@ -6924,181 +6932,185 @@ static const struct name_keysym keysym_to_name[] = {
     { 0x1005ff7b, 24215 }, /* SunVideoLowerBrightness */
     { 0x1005ff7c, 24239 }, /* SunVideoRaiseBrightness */
     { 0x1005ff7d, 24127 }, /* SunPowerSwitchShift */
-    { 0x1008fe01, 28451 }, /* XF86Switch_VT_1 */
-    { 0x1008fe02, 28518 }, /* XF86Switch_VT_2 */
-    { 0x1008fe03, 28534 }, /* XF86Switch_VT_3 */
-    { 0x1008fe04, 28550 }, /* XF86Switch_VT_4 */
-    { 0x1008fe05, 28566 }, /* XF86Switch_VT_5 */
-    { 0x1008fe06, 28582 }, /* XF86Switch_VT_6 */
-    { 0x1008fe07, 28598 }, /* XF86Switch_VT_7 */
-    { 0x1008fe08, 28614 }, /* XF86Switch_VT_8 */
-    { 0x1008fe09, 28630 }, /* XF86Switch_VT_9 */
-    { 0x1008fe0a, 28467 }, /* XF86Switch_VT_10 */
-    { 0x1008fe0b, 28484 }, /* XF86Switch_VT_11 */
-    { 0x1008fe0c, 28501 }, /* XF86Switch_VT_12 */
-    { 0x1008fe20, 28777 }, /* XF86Ungrab */
-    { 0x1008fe21, 27135 }, /* XF86ClearGrab */
-    { 0x1008fe22, 27962 }, /* XF86Next_VMode */
-    { 0x1008fe23, 28084 }, /* XF86Prev_VMode */
-    { 0x1008fe24, 27742 }, /* XF86LogWindowTree */
-    { 0x1008fe25, 27715 }, /* XF86LogGrabInfo */
-    { 0x1008ff01, 27853 }, /* XF86ModeLock */
-    { 0x1008ff02, 27888 }, /* XF86MonBrightnessUp */
-    { 0x1008ff03, 27866 }, /* XF86MonBrightnessDown */
-    { 0x1008ff04, 27491 }, /* XF86KbdLightOnOff */
-    { 0x1008ff05, 27471 }, /* XF86KbdBrightnessUp */
-    { 0x1008ff06, 27449 }, /* XF86KbdBrightnessDown */
-    { 0x1008ff10, 28383 }, /* XF86Standby */
+    { 0x1008fe01, 28491 }, /* XF86Switch_VT_1 */
+    { 0x1008fe02, 28558 }, /* XF86Switch_VT_2 */
+    { 0x1008fe03, 28574 }, /* XF86Switch_VT_3 */
+    { 0x1008fe04, 28590 }, /* XF86Switch_VT_4 */
+    { 0x1008fe05, 28606 }, /* XF86Switch_VT_5 */
+    { 0x1008fe06, 28622 }, /* XF86Switch_VT_6 */
+    { 0x1008fe07, 28638 }, /* XF86Switch_VT_7 */
+    { 0x1008fe08, 28654 }, /* XF86Switch_VT_8 */
+    { 0x1008fe09, 28670 }, /* XF86Switch_VT_9 */
+    { 0x1008fe0a, 28507 }, /* XF86Switch_VT_10 */
+    { 0x1008fe0b, 28524 }, /* XF86Switch_VT_11 */
+    { 0x1008fe0c, 28541 }, /* XF86Switch_VT_12 */
+    { 0x1008fe20, 28817 }, /* XF86Ungrab */
+    { 0x1008fe21, 27151 }, /* XF86ClearGrab */
+    { 0x1008fe22, 27991 }, /* XF86Next_VMode */
+    { 0x1008fe23, 28113 }, /* XF86Prev_VMode */
+    { 0x1008fe24, 27771 }, /* XF86LogWindowTree */
+    { 0x1008fe25, 27744 }, /* XF86LogGrabInfo */
+    { 0x1008ff01, 27882 }, /* XF86ModeLock */
+    { 0x1008ff02, 27917 }, /* XF86MonBrightnessUp */
+    { 0x1008ff03, 27895 }, /* XF86MonBrightnessDown */
+    { 0x1008ff04, 27507 }, /* XF86KbdLightOnOff */
+    { 0x1008ff05, 27487 }, /* XF86KbdBrightnessUp */
+    { 0x1008ff06, 27465 }, /* XF86KbdBrightnessDown */
+    { 0x1008ff10, 28423 }, /* XF86Standby */
     { 0x1008ff11, 26749 }, /* XF86AudioLowerVolume */
     { 0x1008ff12, 26802 }, /* XF86AudioMute */
-    { 0x1008ff13, 26873 }, /* XF86AudioRaiseVolume */
+    { 0x1008ff13, 26889 }, /* XF86AudioRaiseVolume */
     { 0x1008ff14, 26845 }, /* XF86AudioPlay */
-    { 0x1008ff15, 26962 }, /* XF86AudioStop */
-    { 0x1008ff16, 26859 }, /* XF86AudioPrev */
+    { 0x1008ff15, 26978 }, /* XF86AudioStop */
+    { 0x1008ff16, 26875 }, /* XF86AudioPrev */
     { 0x1008ff17, 26816 }, /* XF86AudioNext */
-    { 0x1008ff18, 27412 }, /* XF86HomePage */
-    { 0x1008ff19, 27760 }, /* XF86Mail */
-    { 0x1008ff1a, 28395 }, /* XF86Start */
-    { 0x1008ff1b, 28307 }, /* XF86Search */
-    { 0x1008ff1c, 26914 }, /* XF86AudioRecord */
-    { 0x1008ff1d, 27090 }, /* XF86Calculator */
-    { 0x1008ff1e, 27808 }, /* XF86Memo */
-    { 0x1008ff1f, 28681 }, /* XF86ToDoList */
-    { 0x1008ff20, 27105 }, /* XF86Calendar */
-    { 0x1008ff21, 28057 }, /* XF86PowerDown */
-    { 0x1008ff22, 27173 }, /* XF86ContrastAdjust */
-    { 0x1008ff23, 28177 }, /* XF86RockerUp */
-    { 0x1008ff24, 28146 }, /* XF86RockerDown */
-    { 0x1008ff25, 28161 }, /* XF86RockerEnter */
-    { 0x1008ff26, 26985 }, /* XF86Back */
-    { 0x1008ff27, 27317 }, /* XF86Forward */
-    { 0x1008ff28, 28405 }, /* XF86Stop */
-    { 0x1008ff29, 28113 }, /* XF86Refresh */
-    { 0x1008ff2a, 28071 }, /* XF86PowerOff */
-    { 0x1008ff2b, 28865 }, /* XF86WakeUp */
-    { 0x1008ff2c, 27258 }, /* XF86Eject */
-    { 0x1008ff2d, 28247 }, /* XF86ScreenSaver */
-    { 0x1008ff2e, 28921 }, /* XF86WWW */
-    { 0x1008ff2f, 28347 }, /* XF86Sleep */
-    { 0x1008ff30, 27291 }, /* XF86Favorites */
+    { 0x1008ff18, 27428 }, /* XF86HomePage */
+    { 0x1008ff19, 27789 }, /* XF86Mail */
+    { 0x1008ff1a, 28435 }, /* XF86Start */
+    { 0x1008ff1b, 28347 }, /* XF86Search */
+    { 0x1008ff1c, 26930 }, /* XF86AudioRecord */
+    { 0x1008ff1d, 27106 }, /* XF86Calculator */
+    { 0x1008ff1e, 27837 }, /* XF86Memo */
+    { 0x1008ff1f, 28721 }, /* XF86ToDoList */
+    { 0x1008ff20, 27121 }, /* XF86Calendar */
+    { 0x1008ff21, 28086 }, /* XF86PowerDown */
+    { 0x1008ff22, 27189 }, /* XF86ContrastAdjust */
+    { 0x1008ff23, 28217 }, /* XF86RockerUp */
+    { 0x1008ff24, 28186 }, /* XF86RockerDown */
+    { 0x1008ff25, 28201 }, /* XF86RockerEnter */
+    { 0x1008ff26, 27001 }, /* XF86Back */
+    { 0x1008ff27, 27333 }, /* XF86Forward */
+    { 0x1008ff28, 28445 }, /* XF86Stop */
+    { 0x1008ff29, 28142 }, /* XF86Refresh */
+    { 0x1008ff2a, 28100 }, /* XF86PowerOff */
+    { 0x1008ff2b, 28905 }, /* XF86WakeUp */
+    { 0x1008ff2c, 27274 }, /* XF86Eject */
+    { 0x1008ff2d, 28287 }, /* XF86ScreenSaver */
+    { 0x1008ff2e, 28970 }, /* XF86WWW */
+    { 0x1008ff2f, 28387 }, /* XF86Sleep */
+    { 0x1008ff30, 27307 }, /* XF86Favorites */
     { 0x1008ff31, 26830 }, /* XF86AudioPause */
     { 0x1008ff32, 26770 }, /* XF86AudioMedia */
-    { 0x1008ff33, 27918 }, /* XF86MyComputer */
-    { 0x1008ff34, 28831 }, /* XF86VendorHome */
-    { 0x1008ff35, 27701 }, /* XF86LightBulb */
-    { 0x1008ff36, 28338 }, /* XF86Shop */
-    { 0x1008ff37, 27400 }, /* XF86History */
-    { 0x1008ff38, 28001 }, /* XF86OpenURL */
+    { 0x1008ff33, 27947 }, /* XF86MyComputer */
+    { 0x1008ff34, 28871 }, /* XF86VendorHome */
+    { 0x1008ff35, 27730 }, /* XF86LightBulb */
+    { 0x1008ff36, 28378 }, /* XF86Shop */
+    { 0x1008ff37, 27416 }, /* XF86History */
+    { 0x1008ff38, 28030 }, /* XF86OpenURL */
     { 0x1008ff39, 26655 }, /* XF86AddFavorite */
-    { 0x1008ff3a, 27425 }, /* XF86HotLinks */
-    { 0x1008ff3b, 27054 }, /* XF86BrightnessAdjust */
-    { 0x1008ff3c, 27305 }, /* XF86Finance */
-    { 0x1008ff3d, 27159 }, /* XF86Community */
-    { 0x1008ff3e, 26946 }, /* XF86AudioRewind */
-    { 0x1008ff3f, 26994 }, /* XF86BackForward */
-    { 0x1008ff40, 27509 }, /* XF86Launch0 */
-    { 0x1008ff41, 27521 }, /* XF86Launch1 */
-    { 0x1008ff42, 27533 }, /* XF86Launch2 */
-    { 0x1008ff43, 27545 }, /* XF86Launch3 */
-    { 0x1008ff44, 27557 }, /* XF86Launch4 */
-    { 0x1008ff45, 27569 }, /* XF86Launch5 */
-    { 0x1008ff46, 27581 }, /* XF86Launch6 */
-    { 0x1008ff47, 27593 }, /* XF86Launch7 */
-    { 0x1008ff48, 27605 }, /* XF86Launch8 */
-    { 0x1008ff49, 27617 }, /* XF86Launch9 */
-    { 0x1008ff4a, 27629 }, /* XF86LaunchA */
-    { 0x1008ff4b, 27641 }, /* XF86LaunchB */
-    { 0x1008ff4c, 27653 }, /* XF86LaunchC */
-    { 0x1008ff4d, 27665 }, /* XF86LaunchD */
-    { 0x1008ff4e, 27677 }, /* XF86LaunchE */
-    { 0x1008ff4f, 27689 }, /* XF86LaunchF */
+    { 0x1008ff3a, 27441 }, /* XF86HotLinks */
+    { 0x1008ff3b, 27070 }, /* XF86BrightnessAdjust */
+    { 0x1008ff3c, 27321 }, /* XF86Finance */
+    { 0x1008ff3d, 27175 }, /* XF86Community */
+    { 0x1008ff3e, 26962 }, /* XF86AudioRewind */
+    { 0x1008ff3f, 27010 }, /* XF86BackForward */
+    { 0x1008ff40, 27538 }, /* XF86Launch0 */
+    { 0x1008ff41, 27550 }, /* XF86Launch1 */
+    { 0x1008ff42, 27562 }, /* XF86Launch2 */
+    { 0x1008ff43, 27574 }, /* XF86Launch3 */
+    { 0x1008ff44, 27586 }, /* XF86Launch4 */
+    { 0x1008ff45, 27598 }, /* XF86Launch5 */
+    { 0x1008ff46, 27610 }, /* XF86Launch6 */
+    { 0x1008ff47, 27622 }, /* XF86Launch7 */
+    { 0x1008ff48, 27634 }, /* XF86Launch8 */
+    { 0x1008ff49, 27646 }, /* XF86Launch9 */
+    { 0x1008ff4a, 27658 }, /* XF86LaunchA */
+    { 0x1008ff4b, 27670 }, /* XF86LaunchB */
+    { 0x1008ff4c, 27682 }, /* XF86LaunchC */
+    { 0x1008ff4d, 27694 }, /* XF86LaunchD */
+    { 0x1008ff4e, 27706 }, /* XF86LaunchE */
+    { 0x1008ff4f, 27718 }, /* XF86LaunchF */
     { 0x1008ff50, 26671 }, /* XF86ApplicationLeft */
     { 0x1008ff51, 26691 }, /* XF86ApplicationRight */
-    { 0x1008ff52, 27045 }, /* XF86Book */
-    { 0x1008ff53, 27118 }, /* XF86CD */
-    { 0x1008ff54, 27075 }, /* XF86Calculater */
-    { 0x1008ff55, 27125 }, /* XF86Clear */
-    { 0x1008ff56, 27149 }, /* XF86Close */
-    { 0x1008ff57, 27192 }, /* XF86Copy */
-    { 0x1008ff58, 27201 }, /* XF86Cut */
-    { 0x1008ff59, 27224 }, /* XF86Display */
-    { 0x1008ff5a, 27250 }, /* XF86DOS */
-    { 0x1008ff5b, 27236 }, /* XF86Documents */
-    { 0x1008ff5c, 27268 }, /* XF86Excel */
-    { 0x1008ff5d, 27278 }, /* XF86Explorer */
-    { 0x1008ff5e, 27360 }, /* XF86Game */
-    { 0x1008ff5f, 27369 }, /* XF86Go */
-    { 0x1008ff60, 27438 }, /* XF86iTouch */
-    { 0x1008ff61, 27731 }, /* XF86LogOff */
-    { 0x1008ff62, 27785 }, /* XF86Market */
-    { 0x1008ff63, 27796 }, /* XF86Meeting */
-    { 0x1008ff65, 27817 }, /* XF86MenuKB */
-    { 0x1008ff66, 27828 }, /* XF86MenuPB */
-    { 0x1008ff67, 27933 }, /* XF86MySites */
-    { 0x1008ff68, 27945 }, /* XF86New */
-    { 0x1008ff69, 27953 }, /* XF86News */
-    { 0x1008ff6a, 27977 }, /* XF86OfficeHome */
-    { 0x1008ff6b, 27992 }, /* XF86Open */
-    { 0x1008ff6c, 28013 }, /* XF86Option */
-    { 0x1008ff6d, 28024 }, /* XF86Paste */
-    { 0x1008ff6e, 28034 }, /* XF86Phone */
-    { 0x1008ff70, 28099 }, /* XF86Q */
-    { 0x1008ff72, 28136 }, /* XF86Reply */
-    { 0x1008ff73, 28125 }, /* XF86Reload */
-    { 0x1008ff74, 28190 }, /* XF86RotateWindows */
-    { 0x1008ff75, 28223 }, /* XF86RotationPB */
-    { 0x1008ff76, 28208 }, /* XF86RotationKB */
-    { 0x1008ff77, 28238 }, /* XF86Save */
-    { 0x1008ff78, 28294 }, /* XF86ScrollUp */
-    { 0x1008ff79, 28279 }, /* XF86ScrollDown */
-    { 0x1008ff7a, 28263 }, /* XF86ScrollClick */
-    { 0x1008ff7b, 28329 }, /* XF86Send */
-    { 0x1008ff7c, 28357 }, /* XF86Spell */
-    { 0x1008ff7d, 28367 }, /* XF86SplitScreen */
-    { 0x1008ff7e, 28427 }, /* XF86Support */
-    { 0x1008ff7f, 28646 }, /* XF86TaskPane */
-    { 0x1008ff80, 28659 }, /* XF86Terminal */
-    { 0x1008ff81, 28694 }, /* XF86Tools */
-    { 0x1008ff82, 28766 }, /* XF86Travel */
-    { 0x1008ff84, 28812 }, /* XF86UserPB */
-    { 0x1008ff85, 28788 }, /* XF86User1KB */
-    { 0x1008ff86, 28800 }, /* XF86User2KB */
-    { 0x1008ff87, 28846 }, /* XF86Video */
-    { 0x1008ff88, 28887 }, /* XF86WheelButton */
-    { 0x1008ff89, 28912 }, /* XF86Word */
-    { 0x1008ff8a, 28929 }, /* XF86Xfer */
-    { 0x1008ff8b, 28949 }, /* XF86ZoomIn */
-    { 0x1008ff8c, 28960 }, /* XF86ZoomOut */
-    { 0x1008ff8d, 26976 }, /* XF86Away */
-    { 0x1008ff8e, 27839 }, /* XF86Messenger */
-    { 0x1008ff8f, 28876 }, /* XF86WebCam */
-    { 0x1008ff90, 27769 }, /* XF86MailForward */
-    { 0x1008ff91, 28044 }, /* XF86Pictures */
-    { 0x1008ff92, 27908 }, /* XF86Music */
-    { 0x1008ff93, 27010 }, /* XF86Battery */
-    { 0x1008ff94, 27031 }, /* XF86Bluetooth */
-    { 0x1008ff95, 28903 }, /* XF86WLAN */
-    { 0x1008ff96, 28823 }, /* XF86UWB */
+    { 0x1008ff52, 27061 }, /* XF86Book */
+    { 0x1008ff53, 27134 }, /* XF86CD */
+    { 0x1008ff54, 27091 }, /* XF86Calculater */
+    { 0x1008ff55, 27141 }, /* XF86Clear */
+    { 0x1008ff56, 27165 }, /* XF86Close */
+    { 0x1008ff57, 27208 }, /* XF86Copy */
+    { 0x1008ff58, 27217 }, /* XF86Cut */
+    { 0x1008ff59, 27240 }, /* XF86Display */
+    { 0x1008ff5a, 27266 }, /* XF86DOS */
+    { 0x1008ff5b, 27252 }, /* XF86Documents */
+    { 0x1008ff5c, 27284 }, /* XF86Excel */
+    { 0x1008ff5d, 27294 }, /* XF86Explorer */
+    { 0x1008ff5e, 27376 }, /* XF86Game */
+    { 0x1008ff5f, 27385 }, /* XF86Go */
+    { 0x1008ff60, 27454 }, /* XF86iTouch */
+    { 0x1008ff61, 27760 }, /* XF86LogOff */
+    { 0x1008ff62, 27814 }, /* XF86Market */
+    { 0x1008ff63, 27825 }, /* XF86Meeting */
+    { 0x1008ff65, 27846 }, /* XF86MenuKB */
+    { 0x1008ff66, 27857 }, /* XF86MenuPB */
+    { 0x1008ff67, 27962 }, /* XF86MySites */
+    { 0x1008ff68, 27974 }, /* XF86New */
+    { 0x1008ff69, 27982 }, /* XF86News */
+    { 0x1008ff6a, 28006 }, /* XF86OfficeHome */
+    { 0x1008ff6b, 28021 }, /* XF86Open */
+    { 0x1008ff6c, 28042 }, /* XF86Option */
+    { 0x1008ff6d, 28053 }, /* XF86Paste */
+    { 0x1008ff6e, 28063 }, /* XF86Phone */
+    { 0x1008ff70, 28128 }, /* XF86Q */
+    { 0x1008ff72, 28165 }, /* XF86Reply */
+    { 0x1008ff73, 28154 }, /* XF86Reload */
+    { 0x1008ff74, 28230 }, /* XF86RotateWindows */
+    { 0x1008ff75, 28263 }, /* XF86RotationPB */
+    { 0x1008ff76, 28248 }, /* XF86RotationKB */
+    { 0x1008ff77, 28278 }, /* XF86Save */
+    { 0x1008ff78, 28334 }, /* XF86ScrollUp */
+    { 0x1008ff79, 28319 }, /* XF86ScrollDown */
+    { 0x1008ff7a, 28303 }, /* XF86ScrollClick */
+    { 0x1008ff7b, 28369 }, /* XF86Send */
+    { 0x1008ff7c, 28397 }, /* XF86Spell */
+    { 0x1008ff7d, 28407 }, /* XF86SplitScreen */
+    { 0x1008ff7e, 28467 }, /* XF86Support */
+    { 0x1008ff7f, 28686 }, /* XF86TaskPane */
+    { 0x1008ff80, 28699 }, /* XF86Terminal */
+    { 0x1008ff81, 28734 }, /* XF86Tools */
+    { 0x1008ff82, 28806 }, /* XF86Travel */
+    { 0x1008ff84, 28852 }, /* XF86UserPB */
+    { 0x1008ff85, 28828 }, /* XF86User1KB */
+    { 0x1008ff86, 28840 }, /* XF86User2KB */
+    { 0x1008ff87, 28886 }, /* XF86Video */
+    { 0x1008ff88, 28927 }, /* XF86WheelButton */
+    { 0x1008ff89, 28952 }, /* XF86Word */
+    { 0x1008ff8a, 28978 }, /* XF86Xfer */
+    { 0x1008ff8b, 28998 }, /* XF86ZoomIn */
+    { 0x1008ff8c, 29009 }, /* XF86ZoomOut */
+    { 0x1008ff8d, 26992 }, /* XF86Away */
+    { 0x1008ff8e, 27868 }, /* XF86Messenger */
+    { 0x1008ff8f, 28916 }, /* XF86WebCam */
+    { 0x1008ff90, 27798 }, /* XF86MailForward */
+    { 0x1008ff91, 28073 }, /* XF86Pictures */
+    { 0x1008ff92, 27937 }, /* XF86Music */
+    { 0x1008ff93, 27026 }, /* XF86Battery */
+    { 0x1008ff94, 27047 }, /* XF86Bluetooth */
+    { 0x1008ff95, 28943 }, /* XF86WLAN */
+    { 0x1008ff96, 28863 }, /* XF86UWB */
     { 0x1008ff97, 26732 }, /* XF86AudioForward */
-    { 0x1008ff98, 26930 }, /* XF86AudioRepeat */
-    { 0x1008ff99, 26894 }, /* XF86AudioRandomPlay */
-    { 0x1008ff9a, 28414 }, /* XF86Subtitle */
+    { 0x1008ff98, 26946 }, /* XF86AudioRepeat */
+    { 0x1008ff99, 26910 }, /* XF86AudioRandomPlay */
+    { 0x1008ff9a, 28454 }, /* XF86Subtitle */
     { 0x1008ff9b, 26712 }, /* XF86AudioCycleTrack */
-    { 0x1008ff9c, 27209 }, /* XF86CycleAngle */
-    { 0x1008ff9d, 27329 }, /* XF86FrameBack */
-    { 0x1008ff9e, 27343 }, /* XF86FrameForward */
-    { 0x1008ff9f, 28672 }, /* XF86Time */
-    { 0x1008ffa0, 28318 }, /* XF86Select */
-    { 0x1008ffa1, 28856 }, /* XF86View */
-    { 0x1008ffa2, 28704 }, /* XF86TopMenu */
-    { 0x1008ffa3, 28105 }, /* XF86Red */
-    { 0x1008ffa4, 27376 }, /* XF86Green */
-    { 0x1008ffa5, 28938 }, /* XF86Yellow */
-    { 0x1008ffa6, 27022 }, /* XF86Blue */
-    { 0x1008ffa7, 28439 }, /* XF86Suspend */
-    { 0x1008ffa8, 27386 }, /* XF86Hibernate */
-    { 0x1008ffa9, 28747 }, /* XF86TouchpadToggle */
-    { 0x1008ffb0, 28732 }, /* XF86TouchpadOn */
-    { 0x1008ffb1, 28716 }, /* XF86TouchpadOff */
+    { 0x1008ff9c, 27225 }, /* XF86CycleAngle */
+    { 0x1008ff9d, 27345 }, /* XF86FrameBack */
+    { 0x1008ff9e, 27359 }, /* XF86FrameForward */
+    { 0x1008ff9f, 28712 }, /* XF86Time */
+    { 0x1008ffa0, 28358 }, /* XF86Select */
+    { 0x1008ffa1, 28896 }, /* XF86View */
+    { 0x1008ffa2, 28744 }, /* XF86TopMenu */
+    { 0x1008ffa3, 28134 }, /* XF86Red */
+    { 0x1008ffa4, 27392 }, /* XF86Green */
+    { 0x1008ffa5, 28987 }, /* XF86Yellow */
+    { 0x1008ffa6, 27038 }, /* XF86Blue */
+    { 0x1008ffa7, 28479 }, /* XF86Suspend */
+    { 0x1008ffa8, 27402 }, /* XF86Hibernate */
+    { 0x1008ffa9, 28787 }, /* XF86TouchpadToggle */
+    { 0x1008ffb0, 28772 }, /* XF86TouchpadOn */
+    { 0x1008ffb1, 28756 }, /* XF86TouchpadOff */
     { 0x1008ffb2, 26785 }, /* XF86AudioMicMute */
+    { 0x1008ffb3, 27525 }, /* XF86Keyboard */
+    { 0x1008ffb4, 28961 }, /* XF86WWAN */
+    { 0x1008ffb5, 28175 }, /* XF86RFKill */
+    { 0x1008ffb6, 26859 }, /* XF86AudioPreset */
 };

--- a/xkbcommon/xkbcommon-keysyms.h
+++ b/xkbcommon/xkbcommon-keysyms.h
@@ -2451,29 +2451,6 @@ SOFTWARE.
  *
  * The XFree86 keysym range is 0x10080001 - 0x1008FFFF.
  *
- * When adding new entries, the xc/lib/XKeysymDB file should also be
- * updated to make the new entries visible to Xlib.
- */
-
-/*
- * ModeLock
- *
- * This one is old, and not really used any more since XKB offers this
- * functionality.
- */
-
-#define XKB_KEY_XF86ModeLock		0x1008FF01	/* Mode Switch Lock */
-
-/*
- * Note, 0x1008FF07 - 0x1008FF0F are free and should be used for misc new
- * keysyms that don't fit into any of the groups below.
- *
- * 0x1008FF64, 0x1008FF6F, 0x1008FF71, 0x1008FF83 are no longer used,
- * and should be used first for new keysyms.
- *
- * Check in keysymdef.h for generic symbols before adding new XFree86-specific
- * symbols here.
- *
  * X.Org will not be adding to the XF86 set of keysyms, though they have
  * been adopted and are considered a "standard" part of X keysym definitions.
  * XFree86 never properly commented these keysyms, so we have done our
@@ -2484,6 +2461,14 @@ SOFTWARE.
  * these archives, these are from memory and usage.
  */
 
+/*
+ * ModeLock
+ *
+ * This one is old, and not really used any more since XKB offers this
+ * functionality.
+ */
+
+#define XKB_KEY_XF86ModeLock		0x1008FF01	/* Mode Switch Lock */
 
 /* Backlight controls. */
 #define XKB_KEY_XF86MonBrightnessUp   0x1008FF02  /* Monitor/panel brightness */
@@ -2659,6 +2644,13 @@ SOFTWARE.
 #define XKB_KEY_XF86TouchpadOff	0x1008FFB1   /* The touchpad got switched off */
 
 #define XKB_KEY_XF86AudioMicMute	0x1008FFB2   /* Mute the Mic from the system */
+
+#define XKB_KEY_XF86Keyboard		0x1008FFB3   /* User defined keyboard related action */
+
+#define XKB_KEY_XF86WWAN		0x1008FFB4   /* Toggle WWAN (LTE, UMTS, etc.) radio */
+#define XKB_KEY_XF86RFKill		0x1008FFB5   /* Toggle radios on/off */
+
+#define XKB_KEY_XF86AudioPreset	0x1008FFB6   /* Select equalizer preset, e.g. theatre-mode */
 
 /* Keys for special action keys (hot keys) */
 /* Virtual terminals on some operating systems */


### PR DESCRIPTION
xproto recently has been extended with 4 new keysyms:
XF86XK_Keyboard
XF86XK_WWAN
XF86XK_RFKill
XF86XK_AudioPreset

This commit is the result of running "make update-keysyms" on a system
with the updated xproto installed.

Signed-off-by: Hans de Goede <hdegoede@redhat.com>