### PR TITLE
Actions: Break latch on modifier/group changes

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -430,6 +430,12 @@ xkb_action_breaks_latch(const union xkb_action *action)
     case ACTION_TYPE_CTRL_LOCK:
     case ACTION_TYPE_SWITCH_VT:
     case ACTION_TYPE_TERMINATE:
+    case ACTION_TYPE_MOD_SET:
+    case ACTION_TYPE_MOD_LATCH:
+    case ACTION_TYPE_MOD_LOCK:
+    case ACTION_TYPE_GROUP_SET:
+    case ACTION_TYPE_GROUP_LATCH:
+    case ACTION_TYPE_GROUP_LOCK:
         return true;
     default:
         return false;

--- a/test/data/compat/testlatch
+++ b/test/data/compat/testlatch
@@ -1,0 +1,13 @@
+partial default xkb_compatibility "testlatch" {
+	interpret Shift_L {
+		action= LatchMods(modifiers=Shift);
+	};
+
+	interpret Lock+Exactly(Shift) {
+		action= LockMods(modifiers=Lock,affect=lock);
+	};
+
+	interpret Lock+Exactly(Shift+Lock) {
+		action= LockMods(modifiers=Lock,affect=unlock);
+	};
+};

--- a/test/data/rules/evdev
+++ b/test/data/rules/evdev
@@ -205,6 +205,7 @@
   *			$sun_custom	$sun_var	=	pc+sun_vndr/%l%(v)
 
 ! model		layout				=	symbols
+  testlatch	*			=	testlatch(%l)
   *		ar			=	pc+ara
   *		ben			=	pc+in(ben)
   *		bs			=	pc+ba
@@ -893,6 +894,7 @@
   *		jp		=	complete+japan
   olpc          *               =       olpc
   olpcm         *               =       olpc
+  testlatch	*		=	complete+testlatch
   *		*		=	complete
 
 ! model		layout[1]	=	compat

--- a/test/data/symbols/testlatch
+++ b/test/data/symbols/testlatch
@@ -1,0 +1,58 @@
+// Latch behaviour testing
+
+partial default alphanumeric_keys
+xkb_symbols "us" {
+    name[Group1] = "English";
+
+    include "testlatch(base)"
+
+
+    key <AD01>	{	[	q,		Q		]};
+    key <AD02>	{	[	w,		W		]};
+    key <AD03>	{	[	e,		E		]};
+    key <AD04>	{	[	r,		R		]};
+    key <AD05>	{	[	t,		T		]};
+    key <AD06>	{	[	y,		Y		]};
+    key <AD07>	{	[	u,		U		]};
+    key <AD08>	{	[	i,		I		]};
+    key <AD09>	{	[	o,		O		]};
+    key <AD10>	{	[	p,		P		]};
+
+    key <AC01>	{	[	a,		A		]};
+    key <AC02>	{	[	s,		S		]};
+    key <AC03>	{	[	d,		D		]};
+    key <AC04>	{	[	f,		F		]};
+    key <AC05>	{	[	g,		G		]};
+    key <AC06>	{	[	h,		H		]};
+    key <AC07>	{	[	j,		J		]};
+    key <AC08>	{	[	k,		K		]};
+    key <AC09>	{	[	l,		L		]};
+
+    key <AB01>	{	[	z,		Z		]};
+    key <AB02>	{	[	x,		X		]};
+    key <AB03>	{	[	c,		C		]};
+    key <AB04>	{	[	v,		V		]};
+    key <AB05>	{	[	b,		B		]};
+    key <AB06>	{	[	n,		N		]};
+    key <AB07>	{	[	m,		M		]};
+};
+
+partial alphanumeric_keys
+xkb_symbols "base" {
+    key <ESC>   {   [ Escape        ]   };
+
+    // We want Shift to latch normally, but also to produce caps when pressed
+    // twice in a row.
+    key <LFSH>	{	[	Shift_L,	Caps_Lock	]	};
+
+    key <AE01>	{	[	1,		exclam		]};
+    key <AE02>	{	[	2,		quotedbl	]};
+    key <AE03>	{	[	3,		currency	]};
+    key <AE04>	{	[	4,		at		]};
+    key <AE05>	{	[	5,		percent		]};
+    key <AE06>	{	[	6,		question	]};
+    key <AE07>	{	[	7,		minus		]};
+    key <AE08>	{	[	8,		plus		]};
+    key <AE09>	{	[	9,		apostrophe	]};
+    key <AE10>	{	[	0,		equal		]};
+};


### PR DESCRIPTION
Right now, only a few actions result in breaking a key latch. Add modifier/group actions to this, as presumably the effect of the latch should not last beyond already shifting the modifier/group state.

This was discovered with a real-world use in an input device for the physically impaired, where shift latches, but pressing shift twice goes to caps lock (note shift vs. caps lock, so not pure latch-to-lock). This is possible to implement with current keymap files, but locking caps lock would not break the shift latch. Hence, the following key sequence:

[Shift] [a -> A] [Shift] [Shift -> Lock] [b -> b] [c -> C]

would occur, as the modifier state when pressing b was lock locked and shift latched. With this patch, the sequence is correct:

[Shift] [a -> A] [Shift] [Shift -> Lock] [b -> B] [c -> C]