### PR TITLE
meson: Fix xkbcommon-x11.pc Requires versioning

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -258,8 +258,8 @@ You can disable X11 support with -Denable-x11=false.''')
         libraries: libxkbcommon_x11,
         version: meson.project_version(),
         description: 'XKB API common to servers and clients - X11 support',
-        requires: 'xkbcommon',
-        requires_private: 'xcb>=1.10 xcb-xkb>=1.10',
+        requires: ['xkbcommon'],
+        requires_private: ['xcb>=1.10', 'xcb-xkb>=1.10'],
     )
 endif
 


### PR DESCRIPTION
Old meson expects an array with one dependency per element. Providing a
string containing multiple deps results in only the first dep getting
its whitespace properly applied. As a result, the output was:

    Requires.private: xcb >= 1.10 xcb-xkb>=1.10

And downstream projects failed to find a package named 'xcb-xkb>=1.10'.

Specifying an array of versioned deps results in correct output:

    Requires.private: xcb >= 1.10, xcb-xkb >= 1.10

Fixes #64.