### PR TITLE
Fix off-by-one error in index check in xkb_file_type_to_string

### DIFF
--- a/src/xkbcomp/ast-build.c
+++ b/src/xkbcomp/ast-build.c
@@ -729,7 +729,7 @@ static const char *xkb_file_type_strings[_FILE_TYPE_NUM_ENTRIES] = {
 const char *
 xkb_file_type_to_string(enum xkb_file_type type)
 {
-    if (type > _FILE_TYPE_NUM_ENTRIES)
+    if (type >= _FILE_TYPE_NUM_ENTRIES)
         return "unknown";
     return xkb_file_type_strings[type];
 }


### PR DESCRIPTION
Found by Oracle's Parfait 2.2 static analyzer:
Error: Buffer overrun
   Read outside array bounds [read-outside-array-bounds] (CWE 125):
      In array dereference of xkb_file_type_strings[type] with index type
      Array size is 56 bytes, index <= 56
        at line 734 of src/xkbcomp/ast-build.c in function 'xkb_file_type_to_string'.

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>