### PR TITLE
RFC: Constify functions that doesn't mutate state

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -129,7 +129,7 @@ xkb_context_include_path_reset_defaults(struct xkb_context *ctx)
  * Returns the number of entries in the context's include path.
  */
 XKB_EXPORT unsigned int
-xkb_context_num_include_paths(struct xkb_context *ctx)
+xkb_context_num_include_paths(const struct xkb_context *ctx)
 {
     return darray_size(ctx->includes);
 }
@@ -293,7 +293,7 @@ xkb_context_set_log_fn(struct xkb_context *ctx,
 }
 
 XKB_EXPORT enum xkb_log_level
-xkb_context_get_log_level(struct xkb_context *ctx)
+xkb_context_get_log_level(const struct xkb_context *ctx)
 {
     return ctx->log_level;
 }
@@ -305,7 +305,7 @@ xkb_context_set_log_level(struct xkb_context *ctx, enum xkb_log_level level)
 }
 
 XKB_EXPORT int
-xkb_context_get_log_verbosity(struct xkb_context *ctx)
+xkb_context_get_log_verbosity(const struct xkb_context *ctx)
 {
     return ctx->log_verbosity;
 }

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -370,7 +370,7 @@ xkb_keymap_num_levels_for_key(struct xkb_keymap *keymap, xkb_keycode_t kc,
  * Return the total number of LEDs in the keymap.
  */
 XKB_EXPORT xkb_led_index_t
-xkb_keymap_num_leds(struct xkb_keymap *keymap)
+xkb_keymap_num_leds(const struct xkb_keymap *keymap)
 {
     return keymap->num_leds;
 }

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -425,7 +425,7 @@ struct xkb_keymap {
          (idx)++, (iter)++)
 
 static inline const struct xkb_key *
-XkbKey(struct xkb_keymap *keymap, xkb_keycode_t kc)
+XkbKey(const struct xkb_keymap *keymap, xkb_keycode_t kc)
 {
     if (kc < keymap->min_key_code || kc > keymap->max_key_code)
         return NULL;

--- a/src/state.c
+++ b/src/state.c
@@ -138,7 +138,7 @@ get_entry_for_mods(const struct xkb_key_type *type, xkb_mod_mask_t mods)
 }
 
 static const struct xkb_key_type_entry *
-get_entry_for_key_state(struct xkb_state *state, const struct xkb_key *key,
+get_entry_for_key_state(const struct xkb_state *state, const struct xkb_key *key,
                         xkb_layout_index_t group)
 {
     const struct xkb_key_type *type = key->groups[group].type;
@@ -151,7 +151,7 @@ get_entry_for_key_state(struct xkb_state *state, const struct xkb_key *key,
  * XKB_LEVEL_INVALID.
  */
 XKB_EXPORT xkb_level_index_t
-xkb_state_key_get_level(struct xkb_state *state, xkb_keycode_t kc,
+xkb_state_key_get_level(const struct xkb_state *state, xkb_keycode_t kc,
                         xkb_layout_index_t layout)
 {
     const struct xkb_key *key = XkbKey(state->keymap, kc);
@@ -210,7 +210,7 @@ XkbWrapGroupIntoRange(int32_t group,
  * wrapping/clamping/etc into account, or XKB_LAYOUT_INVALID.
  */
 XKB_EXPORT xkb_layout_index_t
-xkb_state_key_get_layout(struct xkb_state *state, xkb_keycode_t kc)
+xkb_state_key_get_layout(const struct xkb_state *state, xkb_keycode_t kc)
 {
     const struct xkb_key *key = XkbKey(state->keymap, kc);
 

--- a/xkbcommon/xkbcommon.h
+++ b/xkbcommon/xkbcommon.h
@@ -673,7 +673,7 @@ xkb_context_include_path_clear(struct xkb_context *context);
  * @memberof xkb_context
  */
 unsigned int
-xkb_context_num_include_paths(struct xkb_context *context);
+xkb_context_num_include_paths(const struct xkb_context *context);
 
 /**
  * Get a specific include path from the context's include path.
@@ -727,7 +727,7 @@ xkb_context_set_log_level(struct xkb_context *context,
  * @memberof xkb_context
  */
 enum xkb_log_level
-xkb_context_get_log_level(struct xkb_context *context);
+xkb_context_get_log_level(const struct xkb_context *context);
 
 /**
  * Sets the current logging verbosity.
@@ -757,7 +757,7 @@ xkb_context_set_log_verbosity(struct xkb_context *context, int verbosity);
  * @memberof xkb_context
  */
 int
-xkb_context_get_log_verbosity(struct xkb_context *context);
+xkb_context_get_log_verbosity(const struct xkb_context *context);
 
 /**
  * Set a custom function to handle logging messages.
@@ -1088,7 +1088,7 @@ xkb_keymap_layout_get_index(struct xkb_keymap *keymap, const char *name);
  * @memberof xkb_keymap
  */
 xkb_led_index_t
-xkb_keymap_num_leds(struct xkb_keymap *keymap);
+xkb_keymap_num_leds(const struct xkb_keymap *keymap);
 
 /**
  * Get the name of a LED by index.
@@ -1469,7 +1469,7 @@ xkb_state_key_get_one_sym(struct xkb_state *state, xkb_keycode_t key);
  * @memberof xkb_state
  */
 xkb_layout_index_t
-xkb_state_key_get_layout(struct xkb_state *state, xkb_keycode_t key);
+xkb_state_key_get_layout(const struct xkb_state *state, xkb_keycode_t key);
 
 /**
  * Get the effective shift level for a key in a given keyboard state and
@@ -1494,7 +1494,7 @@ xkb_state_key_get_layout(struct xkb_state *state, xkb_keycode_t key);
  * @memberof xkb_state
  */
 xkb_level_index_t
-xkb_state_key_get_level(struct xkb_state *state, xkb_keycode_t key,
+xkb_state_key_get_level(const struct xkb_state *state, xkb_keycode_t key,
                         xkb_layout_index_t layout);
 
 /**


### PR DESCRIPTION
This PR is pretty small, I wanted to get some feedback before proceeding.

As part of [somewhat irrelevant issue I found](https://github.com/xkbcommon/libxkbcommon/issues/72#issuecomment-435698478) that libxkbcommon has a lot of functions that do not mutate any state, yet they accept non-const arguments.

Having such arguments declared as `const`:

1. Improves readability for library users
2. Allows compiler optimizations *(which sounds important, given xkb protocol used a lot by applications)*
3. Enables better design for end-users of the library, as they, in turn, can declare arguments they don't intend to modify as `const`.

So I wanted to constify whatever possible without breaking existing interface.

My questions:

1. Is it okay with library maintainers?
2. How shall I design patches to suit better for review: e.g. one big commit, or a commit per change, or a commit per `.h` file?
