### PR TITLE
Hebrew symbols: mention SI-1452-2

### DIFF
--- a/test/data/symbols/il
+++ b/test/data/symbols/il
@@ -74,7 +74,8 @@ xkb_symbols "basic" {
 };
 
 
-// nikud patter based on Dekel Tsur's Hebrew mapping for LyX
+// nikud pattern based on Dekel Tsur's Hebrew mapping for LyX
+// SI-1432-2 is based on this mapping.
 partial alphanumeric_keys
 xkb_symbols "lyx" {
     name[Group1]= "Hebrew (lyx)";


### PR DESCRIPTION
https://portal.sii.org.il/heb/standardization/teken/?tid=E9166C38-C384-4A5B-8E91-BBB4F08003D3 is formal state standard, but it is not freely available for review. Don't ask me why. Still, being a formal standard that matches the mapping here, it is worthwhile to mention their common ancestry.