### PR TITLE
keysyms: fix comment for XKB_KEY_OCARON

### DIFF
--- a/xkbcommon/xkbcommon-keysyms.h
+++ b/xkbcommon/xkbcommon-keysyms.h
@@ -1931,7 +1931,7 @@ SOFTWARE.
 #define XKB_KEY_Ibreve                     0x100012c  /* U+012C LATIN CAPITAL LETTER I WITH BREVE */
 #define XKB_KEY_Zstroke                    0x10001b5  /* U+01B5 LATIN CAPITAL LETTER Z WITH STROKE */
 #define XKB_KEY_Gcaron                     0x10001e6  /* U+01E6 LATIN CAPITAL LETTER G WITH CARON */
-#define XKB_KEY_Ocaron                     0x10001d1  /* U+01D2 LATIN CAPITAL LETTER O WITH CARON */
+#define XKB_KEY_Ocaron                     0x10001d1  /* U+01D1 LATIN CAPITAL LETTER O WITH CARON */
 #define XKB_KEY_Obarred                    0x100019f  /* U+019F LATIN CAPITAL LETTER O WITH MIDDLE TILDE */
 #define XKB_KEY_xabovedot                  0x1001e8b  /* U+1E8B LATIN SMALL LETTER X WITH DOT ABOVE */
 #define XKB_KEY_ibreve                     0x100012d  /* U+012D LATIN SMALL LETTER I WITH BREVE */


### PR DESCRIPTION
Fixes #80 