### PR TITLE
meson.build: use program from build machine not host or target.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -411,7 +411,7 @@ endif
 if get_option('enable-wayland')
     wayland_client_dep = dependency('wayland-client', version: '>=1.2.0', required: false)
     wayland_protocols_dep = dependency('wayland-protocols', version: '>=1.7', required: false)
-    wayland_scanner_dep = dependency('wayland-scanner', required: false)
+    wayland_scanner_dep = dependency('wayland-scanner', required: false, native: true)
     if not wayland_client_dep.found() or not wayland_protocols_dep.found() or not wayland_scanner_dep.found()
         error('''The Wayland demo programs require wayland-client >= 1.2.0, wayland-protocols >= 1.7 which were not found.
 You can disable the Wayland demo programs with -Denable-wayland=false.''')


### PR DESCRIPTION
We can't always execute binaries from the host or target machine,
as is the case in cross compilation.

This instead uses native : true to search the build system for wayland-scanner.pc and get it from there.

Fixes cross compilation on Void Linux

Side-note: Meson is so nice and makes this so trivially easy.