### PR TITLE
Makefile.am: add include dir for AC_CONFIG_MACRO_DIR to work

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,8 @@
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = xkbcommon.pc
 
+ACLOCAL_AMFLAGS = -I m4
+
 EXTRA_DIST = \
 	scripts/makeheader \
 	scripts/makekeys \


### PR DESCRIPTION
With older versions of autotools, one needs to add this line to
Makefile.am. From the autoconf docs: "Note that if you use aclocal from
Automake to generate aclocal.m4, you must also set ACLOCAL_AMFLAGS = -I dir
in your top-level Makefile.am". [1]

I couldn't build with autoconf 2.68 without this.

[1] https://www.gnu.org/software/autoconf/manual/autoconf-2.65/html_node/Input.html

Signed-off-by: milloni <milloni@preemptable.org>