### PR TITLE
interactive-wayland: Port to stable xdg-shell

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -299,8 +299,8 @@ endef
 	$(AM_V_GEN)$(MKDIR_P) $(dir $@) && $(wayland_scanner) client-header < $< > $@
 
 INTERACTIVE_WL_XDG_SHELL_SRCS = \
-	xdg-shell-unstable-v6-protocol.c \
-	xdg-shell-unstable-v6-client-protocol.h
+	xdg-shell-protocol.c \
+	xdg-shell-client-protocol.h
 
 test_interactive_wayland_SOURCES = \
 	test/interactive-wayland.c \

--- a/configure.ac
+++ b/configure.ac
@@ -174,7 +174,7 @@ You can disable X11 support with --disable-x11.])])
 ], [enable_x11=no])
 AM_CONDITIONAL([ENABLE_X11], [test "x$enable_x11" = xyes])
 
-WAYLAND_PKGS="wayland-client >= 1.2.0 wayland-protocols >= 1.7 wayland-scanner"
+WAYLAND_PKGS="wayland-client >= 1.2.0 wayland-protocols >= 1.12 wayland-scanner"
 AC_ARG_ENABLE([wayland],
     [AS_HELP_STRING([--disable-wayland],
         [Disable support for Wayland utility programs (default: auto)])],

--- a/meson.build
+++ b/meson.build
@@ -407,7 +407,7 @@ if get_option('enable-x11')
 endif
 if get_option('enable-wayland')
     wayland_client_dep = dependency('wayland-client', version: '>=1.2.0', required: false)
-    wayland_protocols_dep = dependency('wayland-protocols', version: '>=1.7', required: false)
+    wayland_protocols_dep = dependency('wayland-protocols', version: '>=1.12', required: false)
     wayland_scanner_dep = dependency('wayland-scanner', required: false, native: true)
     if not wayland_client_dep.found() or not wayland_protocols_dep.found() or not wayland_scanner_dep.found()
         error('''The Wayland demo programs require wayland-client >= 1.2.0, wayland-protocols >= 1.7 which were not found.
@@ -426,7 +426,7 @@ You can disable the Wayland demo programs with -Denable-wayland=false.''')
         arguments: ['client-header', '@INPUT@', '@OUTPUT@'],
     )
     wayland_protocols_datadir = wayland_protocols_dep.get_pkgconfig_variable('pkgdatadir')
-    xdg_shell_xml = join_paths(wayland_protocols_datadir, 'unstable/xdg-shell/xdg-shell-unstable-v6.xml')
+    xdg_shell_xml = join_paths(wayland_protocols_datadir, 'stable/xdg-shell/xdg-shell.xml')
     xdg_shell_sources = [
         wayland_scanner_code_gen.process(xdg_shell_xml),
         wayland_scanner_client_header_gen.process(xdg_shell_xml),


### PR DESCRIPTION
xdg_shell v6 was pretty close to the finalised stable version of
xdg-shell. We can now just use the stable version, which is supported
everywhere (Enlightenment, KWin, Mutter, Weston, wlroots).

This requires bumping the wayland-protocols dependency.

Signed-off-by: Daniel Stone <daniels@collabora.com>