### PR TITLE
[RFC] Make it possible to build using Meson and MSVC

### DIFF
--- a/.azure-pipelines/steps/dependencies-windows.yml
+++ b/.azure-pipelines/steps/dependencies-windows.yml
@@ -1,0 +1,12 @@
+---
+steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.6'
+    displayName: 'Use Python 3.6'
+  - script: |
+      choco install ninja winflexbison3 -y --no-progress --stop-on-first-failure
+      if not errorlevel 0 exit /b %errorlevel%
+      python -m pip install --upgrade pip meson
+      if not errorlevel 0 exit /b %errorlevel%
+    displayName: 'Dependencies (Windows)'

--- a/.azure-pipelines/steps/meson.yml
+++ b/.azure-pipelines/steps/meson.yml
@@ -1,30 +1,28 @@
 ---
 parameters:
-  compiler: ""
+  compiler: "cc"
   options: ""
   wrapper: ""
   workdir: "meson-build"
+  prepare: ""
 
 steps:
-  - bash: |
-      if [[ -x /usr/local/opt/bison/bin/bison ]] ; then
-        export PATH="/usr/local/opt/bison/bin:${PATH}"
-      fi
-      export COMPILER=${{ parameters.compiler }}
-      case ${COMPILER:-default} in
-        clang ) export CC=clang CXX=clang++ ;;
-        gcc   ) export CC=gcc   CXX=g++     ;;
-      esac
-      meson setup '${{ parameters.workdir }}' ${{ parameters.options }}
-    displayName: 'Configuration (Meson)'
-  - bash: ninja
-    displayName: 'Build (Meson)'
+  - script: |
+      ${{ parameters.prepare }}
+      meson setup "${{ parameters.workdir }}" ${{ parameters.options }}
+    displayName: 'Configuration'
+    env:
+      CC: ${{ parameters.compiler }}
+  - script: |
+      ${{ parameters.prepare }}
+      ninja
+    displayName: 'Build'
     workingDirectory: ${{ parameters.workdir }}
     env:
       TERM: dumb
-  - bash: |
-      meson test --print-errorlogs --wrap='${{ parameters.wrapper }}'
-    displayName: 'Tests (Meson)'
+  - script: |
+      meson test --print-errorlogs --wrap="${{ parameters.wrapper }}"
+    displayName: 'Run Tests'
     workingDirectory: ${{ parameters.workdir }}
   - bash: |
       shopt -s nullglob
@@ -36,7 +34,7 @@ steps:
           --job-id='$(Build.BuildId)' --branch='$(Build.SourceBranch)' \
           --output="${file}-junit.xml" "${file}"
       done
-    displayName: 'Process Results (Meson)'
+    displayName: 'Process Test Results'
     workingDirectory: ${{ parameters.workdir }}
     condition: always()
   - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,3 +26,15 @@ jobs:
       - template: .azure-pipelines/steps/meson.yml
         parameters:
           options: -Denable-wayland=false -Denable-x11=false
+          prepare: 'export PATH="/usr/local/opt/bison/bin:${PATH}"'
+  - job: 'Windows'
+    dependsOn: []
+    pool:
+      vmImage: 'vs2017-win2016'
+    steps:
+      - template: .azure-pipelines/steps/dependencies-windows.yml
+      - template: .azure-pipelines/steps/meson.yml
+        parameters:
+          compiler: cl
+          options: -Denable-wayland=false -Denable-x11=false -Denable-docs=false
+          prepare: 'call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64'

--- a/meson.build
+++ b/meson.build
@@ -121,7 +121,7 @@ have_version_script = cc.links(
 # libxkbcommon.
 # Note: we use some yacc extensions, which work with either GNU bison
 # (preferred) or byacc. Other yacc's may or may not work.
-yacc = find_program('bison', 'byacc')
+yacc = find_program('bison', 'win_bison', 'byacc')
 yacc_gen = generator(
     yacc,
     output: ['@BASENAME@.c', '@BASENAME@.h'],

--- a/meson.build
+++ b/meson.build
@@ -413,9 +413,11 @@ executable('fuzz-compose', 'fuzz/compose/target.c', dependencies: test_dep)
 
 
 # Demo programs.
-executable('rmlvo-to-kccgst', 'test/rmlvo-to-kccgst.c', dependencies: test_dep)
-executable('rmlvo-to-keymap', 'test/rmlvo-to-keymap.c', dependencies: test_dep)
-executable('print-compiled-keymap', 'test/print-compiled-keymap.c', dependencies: test_dep)
+if cc.has_header_symbol('getopt.h', 'getopt_long', prefix: '#define _GNU_SOURCE')
+	executable('rmlvo-to-kccgst', 'test/rmlvo-to-kccgst.c', dependencies: test_dep)
+	executable('rmlvo-to-keymap', 'test/rmlvo-to-keymap.c', dependencies: test_dep)
+	executable('print-compiled-keymap', 'test/print-compiled-keymap.c', dependencies: test_dep)
+endif
 if cc.has_header('linux/input.h')
     executable('interactive-evdev', 'test/interactive-evdev.c', dependencies: test_dep)
 endif

--- a/meson.build
+++ b/meson.build
@@ -102,6 +102,11 @@ endif
 if cc.has_header_symbol('string.h', 'strndup', prefix: system_ext_define)
     configh_data.set('HAVE_STRNDUP', 1)
 endif
+if cc.has_header_symbol('stdio.h', 'asprintf', prefix: system_ext_define)
+    configh_data.set('HAVE_ASPRINTF', 1)
+elif cc.has_header_symbol('stdio.h', 'vasprintf', prefix: system_ext_define)
+    configh_data.set('HAVE_VASPRINTF', 1)
+endif
 if cc.has_header_symbol('stdlib.h', 'secure_getenv', prefix: system_ext_define)
     configh_data.set('HAVE_SECURE_GETENV', 1)
 elif cc.has_header_symbol('stdlib.h', '__secure_getenv', prefix: system_ext_define)

--- a/meson.build
+++ b/meson.build
@@ -107,7 +107,12 @@ else
     message('C library does not support secure_getenv, using getenv instead')
 endif
 configure_file(output: 'config.h', configuration: configh_data)
-add_project_arguments('-include', 'config.h', language: 'c')
+
+if cc.get_id() == 'msvc'
+  add_project_arguments('/FI', 'config.h', '/D_CRT_SECURE_NO_WARNINGS', language: 'c')
+else
+  add_project_arguments('-include', 'config.h', language: 'c')
+endif
 
 
 # Supports -Wl,--version-script?

--- a/meson.build
+++ b/meson.build
@@ -99,6 +99,9 @@ endif
 if cc.has_header_symbol('fcntl.h', 'posix_fallocate', prefix: system_ext_define)
     configh_data.set('HAVE_POSIX_FALLOCATE', 1)
 endif
+if cc.has_header_symbol('string.h', 'strndup', prefix: system_ext_define)
+    configh_data.set('HAVE_STRNDUP', 1)
+endif
 if cc.has_header_symbol('stdlib.h', 'secure_getenv', prefix: system_ext_define)
     configh_data.set('HAVE_SECURE_GETENV', 1)
 elif cc.has_header_symbol('stdlib.h', '__secure_getenv', prefix: system_ext_define)

--- a/meson.build
+++ b/meson.build
@@ -109,7 +109,10 @@ endif
 configure_file(output: 'config.h', configuration: configh_data)
 
 if cc.get_id() == 'msvc'
-  add_project_arguments('/FI', 'config.h', '/D_CRT_SECURE_NO_WARNINGS', language: 'c')
+  add_project_arguments('/FI', 'config.h',
+	'/D_CRT_SECURE_NO_WARNINGS',
+	'/Dstrdup=_strdup',
+	language: 'c')
 else
   add_project_arguments('-include', 'config.h', language: 'c')
 endif

--- a/meson.build
+++ b/meson.build
@@ -111,7 +111,7 @@ configure_file(output: 'config.h', configuration: configh_data)
 if cc.get_id() == 'msvc'
   add_project_arguments('/FI', 'config.h',
 	'/D_CRT_SECURE_NO_WARNINGS',
-	'/Dstrdup=_strdup',
+	'/D_CRT_NONSTDC_NO_DEPRECATE',
 	language: 'c')
 else
   add_project_arguments('-include', 'config.h', language: 'c')

--- a/src/context-priv.c
+++ b/src/context-priv.c
@@ -27,7 +27,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>
-#include <unistd.h>
 
 #include "xkbcommon/xkbcommon.h"
 #include "utils.h"

--- a/src/context.c
+++ b/src/context.c
@@ -29,6 +29,9 @@
 #include <errno.h>
 #ifdef _MSC_VER
 #include <io.h>
+#ifndef S_ISDIR
+#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
+#endif
 #else
 #include <unistd.h>
 #endif

--- a/src/context.c
+++ b/src/context.c
@@ -27,7 +27,11 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>
+#ifdef _MSC_VER
+#include <io.h>
+#else
 #include <unistd.h>
+#endif
 
 #include "xkbcommon/xkbcommon.h"
 #include "utils.h"

--- a/src/keysym.c
+++ b/src/keysym.c
@@ -203,7 +203,7 @@ xkb_keysym_from_name(const char *s, enum xkb_keysym_flags flags)
      * no separating underscore, while some XF86* syms in the latter did.
      * As a last ditch effort, try without. */
     if (strncmp(s, "XF86_", 5) == 0 ||
-        (icase && strncasecmp(s, "XF86_", 5) == 0)) {
+        (icase && istrncmp(s, "XF86_", 5) == 0)) {
         xkb_keysym_t ret;
         tmp = strdup(s);
         if (!tmp)

--- a/src/utils.h
+++ b/src/utils.h
@@ -278,4 +278,12 @@ unmap_file(char *string, size_t size);
 #define ATTR_PACKED
 #endif
 
+#if !(defined(HAVE_ASPRINTF) && HAVE_ASPRINTF)
+int asprintf(char **strp, const char *fmt, ...) ATTR_PRINTF(2, 3);
+# if !(defined(HAVE_VASPRINTF) && HAVE_VASPRINTF)
+#  include <stdarg.h>
+int vasprintf(char **strp, const char *fmt, va_list ap);
+# endif /* !HAVE_VASPRINTF */
+#endif /* !HAVE_ASPRINTF */
+
 #endif /* UTILS_H */

--- a/src/utils.h
+++ b/src/utils.h
@@ -129,6 +129,19 @@ my_max(int misc, int other)
     return (misc > other) ? misc : other;
 }
 
+#if !(defined(HAVE_STRNDUP) && HAVE_STRNDUP)
+static inline char *
+strndup(const char *str, size_t len)
+{
+    char *p = calloc(my_min(strlen(str), len) + 1, sizeof(char));
+    if (p) {
+        memcpy(p, str, len * sizeof(char));
+        p[len] = '\0';
+    }
+    return p;
+}
+#endif
+
 /* ctype.h is locale-dependent and has other oddities. */
 static inline bool
 is_space(char ch)

--- a/src/utils.h
+++ b/src/utils.h
@@ -118,13 +118,13 @@ memdup(const void *mem, size_t nmemb, size_t size)
 }
 
 static inline int
-min(int misc, int other)
+my_min(int misc, int other)
 {
     return (misc < other) ? misc : other;
 }
 
 static inline int
-max(int misc, int other)
+my_max(int misc, int other)
 {
     return (misc > other) ? misc : other;
 }

--- a/src/x11/util.c
+++ b/src/x11/util.c
@@ -164,7 +164,7 @@ adopt_atoms(struct xkb_context *ctx, xcb_connection_t *conn,
     /* Send and collect the atoms in batches of reasonable SIZE. */
     for (size_t batch = 0; batch < num_batches; batch++) {
         const size_t start = batch * SIZE;
-        const size_t stop = min((batch + 1) * SIZE, count);
+        const size_t stop = my_min((batch + 1) * SIZE, count);
 
         /* Send. */
         for (size_t i = start; i < stop; i++)

--- a/src/xkbcomp/keymap-dump.c
+++ b/src/xkbcomp/keymap-dump.c
@@ -161,8 +161,8 @@ write_keycodes(struct xkb_keymap *keymap, struct buf *buf)
      * a maximum of at least 255, else XWayland really starts hating life.
      * If this is a problem and people really need strictly bounded keymaps,
      * we should probably control this with a flag. */
-    write_buf(buf, "\tminimum = %u;\n", min(keymap->min_key_code, 8));
-    write_buf(buf, "\tmaximum = %u;\n", max(keymap->max_key_code, 255));
+    write_buf(buf, "\tminimum = %u;\n", my_min(keymap->min_key_code, 8));
+    write_buf(buf, "\tmaximum = %u;\n", my_max(keymap->max_key_code, 255));
 
     xkb_keys_foreach(key, keymap) {
         if (key->name == XKB_ATOM_NONE)

--- a/test/common.c
+++ b/test/common.c
@@ -32,14 +32,16 @@
 
 #include <limits.h>
 #include <fcntl.h>
-#ifdef _MSC_VER
-#include <io.h>
-#else
-#include <unistd.h>
-#endif
 #include <sys/types.h>
 #include <sys/stat.h>
+#ifdef _MSC_VER
+#define WIN32_LEAN_AND_MEAN
+#include <io.h>
+#include <windows.h>
+#else
+#include <unistd.h>
 #include <termios.h>
+#endif
 
 #include "test.h"
 
@@ -465,6 +467,25 @@ test_print_state_changes(enum xkb_state_component changed)
     printf("]\n");
 }
 
+#ifdef _MSC_VER
+void
+test_disable_stdin_echo(void)
+{
+    HANDLE stdin_handle = GetStdHandle(STD_INPUT_HANDLE);
+    DWORD mode = 0;
+    GetConsoleMode(stdin_handle, &mode);
+    SetConsoleMode(stdin_handle, mode & ~ENABLE_ECHO_INPUT);
+}
+
+void
+test_enable_stdin_echo(void)
+{
+    HANDLE stdin_handle = GetStdHandle(STD_INPUT_HANDLE);
+    DWORD mode = 0;
+    GetConsoleMode(stdin_handle, &mode);
+    SetConsoleMode(stdin_handle, mode | ENABLE_ECHO_INPUT);
+}
+#else
 void
 test_disable_stdin_echo(void)
 {
@@ -486,3 +507,4 @@ test_enable_stdin_echo(void)
         (void) tcsetattr(STDIN_FILENO, TCSADRAIN, &termios);
     }
 }
+#endif

--- a/test/common.c
+++ b/test/common.c
@@ -32,7 +32,11 @@
 
 #include <limits.h>
 #include <fcntl.h>
+#ifdef _MSC_VER
+#include <io.h>
+#else
 #include <unistd.h>
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <termios.h>

--- a/test/test.h
+++ b/test/test.h
@@ -95,3 +95,8 @@ test_disable_stdin_echo(void);
 
 void
 test_enable_stdin_echo(void);
+
+#ifdef _MSC_VER
+#define setenv(varname, value, overwrite) _putenv_s((varname), (value))
+#define unsetenv(varname) _putenv(varname "=")
+#endif


### PR DESCRIPTION
This PR includes a series of commits which make it possible to build libxkbcommon on Windows using Microsoft Visual C (a.k.a. MSVC). Most of the commits are quite small and deal with providing small implementations of functions commonly available on “Unixy” systems (GNU/Linux, the BSDs, etc.) which are not available in Windows when using MSVC: in some cases functions are renamed (e.g. `strdup` → `_strdup`), small wrappers are needed over native functions (`gettimeofday`), or different headers need to be used.

The biggest change by itself is the commit that attempts to use backslashes as directory separators where appropriate. I had the hope that this would make `test-filecomp` pass successfully, but sadly I am probably missing something—my lack of Windows development knowledge and not having a Windows box around may be to blame.

A few interspersed commits are used to enable CI builds on AppVeyor, which are currently running for my `msvc` branch ([sample build](https://ci.appveyor.com/project/aperezdc/libxkbcommon/builds/26483305)), so that's how I know things are building and most tests passing.

I have no idea why `test-filecomp` is broken, and some help to understand and figure out what it is supposed to do and how the output should look would be very appreciated—you can check the output of the test in the build linked above.
