### PR TITLE
CI: Use the Azure Pipelines service

### DIFF
--- a/.azure-pipelines/steps/autotools.yml
+++ b/.azure-pipelines/steps/autotools.yml
@@ -1,0 +1,23 @@
+---
+parameters:
+  options: ""
+  workdir: "autotools-build"
+
+steps:
+  - bash: |
+      mkdir '${{ parameters.workdir }}' && cd "$_"
+      ../autogen.sh ${{ parameters.options }}
+    displayName: 'Configuration (Autotools)'
+  - bash: make -j$(nproc)
+    displayName: 'Build (Autotools)'
+    workingDirectory: ${{ parameters.workdir }}
+  - bash: make check
+    displayName: 'Tests (Autotools)'
+    workingDirectory: ${{ parameters.workdir }}
+  - bash: |
+      shopt -s nullglob
+      for file in "$(pwd)"/*.log ; do
+        echo "##vso[task.uploadfile]${file}"
+      done
+    displayName: 'Save Results (Autotools)'
+    condition: always()

--- a/.azure-pipelines/steps/autotools.yml
+++ b/.azure-pipelines/steps/autotools.yml
@@ -1,10 +1,16 @@
 ---
 parameters:
+  compiler: ""
   options: ""
   workdir: "autotools-build"
 
 steps:
   - bash: |
+      export COMPILER=${{ parameters.compiler }}
+      case ${COMPILER:-default} in
+        clang ) export CC=clang CXX=clang++ ;;
+        gcc   ) export CC=gcc   CXX=g++     ;;
+      esac
       mkdir '${{ parameters.workdir }}' && cd "$_"
       ../autogen.sh ${{ parameters.options }}
     displayName: 'Configuration (Autotools)'

--- a/.azure-pipelines/steps/dependencies-linux.yml
+++ b/.azure-pipelines/steps/dependencies-linux.yml
@@ -1,0 +1,13 @@
+---
+steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.7'
+    displayName: 'Use Python 3.7'
+  - bash: |
+      python -m pip install --upgrade pip meson
+      sudo apt update -y
+      sudo env DEBIAN_FRONTEND=noninteractive apt install -y \
+        xutils-dev doxygen libxcb-xkb-dev valgrind meson libwayland-dev \
+        wayland-protocols bison valgrind
+    displayName: 'Dependencies (GNU/Linux)'

--- a/.azure-pipelines/steps/dependencies-linux.yml
+++ b/.azure-pipelines/steps/dependencies-linux.yml
@@ -8,6 +8,6 @@ steps:
       python -m pip install --upgrade pip meson
       sudo apt update -y
       sudo env DEBIAN_FRONTEND=noninteractive apt install -y \
-        xutils-dev doxygen libxcb-xkb-dev valgrind meson libwayland-dev \
-        wayland-protocols bison valgrind
+        xutils-dev doxygen libxcb-xkb-dev valgrind ninja-build \
+        libwayland-dev wayland-protocols bison graphviz
     displayName: 'Dependencies (GNU/Linux)'

--- a/.azure-pipelines/steps/dependencies-macos.yml
+++ b/.azure-pipelines/steps/dependencies-macos.yml
@@ -1,0 +1,9 @@
+---
+steps:
+  - bash: |
+      brew install meson doxygen bison
+      brew link bison --force
+    displayName: 'Dependencies (macOS)'
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1

--- a/.azure-pipelines/steps/meson.yml
+++ b/.azure-pipelines/steps/meson.yml
@@ -1,10 +1,15 @@
 ---
 parameters:
   options: ""
+  wrapper: ""
   workdir: "meson-build"
 
 steps:
-  - bash: meson setup '${{ parameters.workdir }}' ${{ parameters.options }}
+  - bash: |
+      if [[ -x /usr/local/opt/bison/bin/bison ]] ; then
+        export PATH="/usr/local/opt/bison/bin:${PATH}"
+      fi
+      meson setup '${{ parameters.workdir }}' ${{ parameters.options }}
     displayName: 'Configuration (Meson)'
   - bash: ninja
     displayName: 'Build (Meson)'
@@ -12,8 +17,7 @@ steps:
     env:
       TERM: dumb
   - bash: |
-      meson test --print-errorlogs \
-        --wrap='valgrind --leak-check=full --track-origins=yes --error-exitcode=99'
+      meson test --print-errorlogs --wrap='${{ parameters.wrapper }}'
     displayName: 'Tests (Meson)'
     workingDirectory: ${{ parameters.workdir }}
   - bash: |

--- a/.azure-pipelines/steps/meson.yml
+++ b/.azure-pipelines/steps/meson.yml
@@ -1,5 +1,6 @@
 ---
 parameters:
+  compiler: ""
   options: ""
   wrapper: ""
   workdir: "meson-build"
@@ -9,6 +10,11 @@ steps:
       if [[ -x /usr/local/opt/bison/bin/bison ]] ; then
         export PATH="/usr/local/opt/bison/bin:${PATH}"
       fi
+      export COMPILER=${{ parameters.compiler }}
+      case ${COMPILER:-default} in
+        clang ) export CC=clang CXX=clang++ ;;
+        gcc   ) export CC=gcc   CXX=g++     ;;
+      esac
       meson setup '${{ parameters.workdir }}' ${{ parameters.options }}
     displayName: 'Configuration (Meson)'
   - bash: ninja

--- a/.azure-pipelines/steps/meson.yml
+++ b/.azure-pipelines/steps/meson.yml
@@ -1,0 +1,21 @@
+---
+parameters:
+  options: ""
+  workdir: "meson-build"
+
+steps:
+  - bash: meson setup '${{ parameters.workdir }}' ${{ parameters.options }}
+    displayName: 'Configuration (Meson)'
+  - bash: ninja
+    displayName: 'Build (Meson)'
+    workingDirectory: ${{ parameters.workdir }}
+    env:
+      TERM: dumb
+  - bash: |
+      meson test --print-errorlogs \
+        --wrap='valgrind --leak-check=full --track-origins=yes --error-exitcode=99'
+      for file in "$(pwd)"/meson-logs/* ; do
+        echo "##vso[task.uploadfile]${file}"
+      done
+    displayName: 'Tests (Meson)'
+    workingDirectory: ${{ parameters.workdir }}

--- a/.azure-pipelines/steps/meson.yml
+++ b/.azure-pipelines/steps/meson.yml
@@ -14,8 +14,13 @@ steps:
   - bash: |
       meson test --print-errorlogs \
         --wrap='valgrind --leak-check=full --track-origins=yes --error-exitcode=99'
+    displayName: 'Tests (Meson)'
+    workingDirectory: ${{ parameters.workdir }}
+  - bash: |
+      shopt -s nullglob
       for file in "$(pwd)"/meson-logs/* ; do
         echo "##vso[task.uploadfile]${file}"
       done
-    displayName: 'Tests (Meson)'
+    displayName: 'Save Results (Meson)'
     workingDirectory: ${{ parameters.workdir }}
+    condition: always()

--- a/.azure-pipelines/steps/meson.yml
+++ b/.azure-pipelines/steps/meson.yml
@@ -31,6 +31,15 @@ steps:
       for file in "$(pwd)"/meson-logs/* ; do
         echo "##vso[task.uploadfile]${file}"
       done
-    displayName: 'Save Results (Meson)'
+      for file in "$(pwd)"/meson-logs/*.json ; do
+        python3 ../scripts/meson-junit-report.py --project-name=xkbcommon \
+          --job-id='$(Build.BuildId)' --branch='$(Build.SourceBranch)' \
+          --output="${file}-junit.xml" "${file}"
+      done
+    displayName: 'Process Results (Meson)'
     workingDirectory: ${{ parameters.workdir }}
     condition: always()
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFiles: '**/*-junit.xml'
+      failTaskOnFailedTests: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,30 @@
+trigger:
+  - ci-azure
+
+jobs:
+  - job: 'Ubuntu_16_04'
+    pool:
+      vmImage: 'ubuntu-16.04'
+    steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '3.7'
+        displayName: 'Use Python 3.7'
+      - script: |
+          python -m pip install --upgrade pip meson
+          sudo apt update -y
+          sudo env DEBIAN_FRONTEND=noninteractive apt install -y \
+            xutils-dev doxygen libxcb-xkb-dev valgrind meson libwayland-dev \
+            wayland-protocols bison valgrind
+        displayName: 'Install dependencies'
+      - script: |
+          mkdir autotools-build && pushd autotools-build
+          ../autogen.sh && make -j$(nproc) && make check
+          popd
+        displayName: 'Autotools'
+      - script: |
+          meson setup meson-build -Denable-wayland=false
+          ninja -C meson-build
+          meson test -C meson-build --print-errorlogs \
+            --wrap='valgrind --leak-check=full --track-origins=yes --error-exitcode=99'
+        displayName: 'Meson'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,7 @@ jobs:
       - template: .azure-pipelines/steps/meson.yml
         parameters:
           options: -Denable-wayland=false
+          wrapper: valgrind --leak-check=full --track-origins=yes --error-exitcode=99
   - job: 'Autotools'
     dependsOn: []
     pool:
@@ -19,3 +20,12 @@ jobs:
     steps:
       - template: .azure-pipelines/steps/dependencies-linux.yml
       - template: .azure-pipelines/steps/autotools.yml
+  - job: 'macOS'
+    dependsOn: []
+    pool:
+      vmImage: 'macos-10.13'
+    steps:
+      - template: .azure-pipelines/steps/dependencies-macos.yml
+      - template: .azure-pipelines/steps/meson.yml
+        parameters:
+          options: -Denable-wayland=false -Denable-x11=false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,4 +27,7 @@ jobs:
           ninja -C meson-build
           meson test -C meson-build --print-errorlogs \
             --wrap='valgrind --leak-check=full --track-origins=yes --error-exitcode=99'
+          for file in "$(pwd)"/meson-build/meson-logs/* ; do
+            echo "##vso[task.uploadfile]${file}"
+          done
         displayName: 'Meson'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,27 +1,21 @@
+---
 trigger:
   - ci-azure
 
 jobs:
-  - job: 'Ubuntu_16_04'
+  - job: 'Meson'
+    dependsOn: []
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '3.7'
-        displayName: 'Use Python 3.7'
-      - script: |
-          python -m pip install --upgrade pip meson
-          sudo apt update -y
-          sudo env DEBIAN_FRONTEND=noninteractive apt install -y \
-            xutils-dev doxygen libxcb-xkb-dev valgrind meson libwayland-dev \
-            wayland-protocols bison valgrind
-        displayName: 'Install dependencies'
-      - script: |
-          mkdir autotools-build && pushd autotools-build
-          ../autogen.sh && make -j$(nproc) && make check
-          popd
-        displayName: 'Autotools'
+      - template: .azure-pipelines/steps/dependencies-linux.yml
       - template: .azure-pipelines/steps/meson.yml
         parameters:
           options: -Denable-wayland=false
+  - job: 'Autotools'
+    dependsOn: []
+    pool:
+      vmImage: 'ubuntu-16.04'
+    steps:
+      - template: .azure-pipelines/steps/dependencies-linux.yml
+      - template: .azure-pipelines/steps/autotools.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,12 +22,6 @@ jobs:
           ../autogen.sh && make -j$(nproc) && make check
           popd
         displayName: 'Autotools'
-      - script: |
-          meson setup meson-build -Denable-wayland=false
-          ninja -C meson-build
-          meson test -C meson-build --print-errorlogs \
-            --wrap='valgrind --leak-check=full --track-origins=yes --error-exitcode=99'
-          for file in "$(pwd)"/meson-build/meson-logs/* ; do
-            echo "##vso[task.uploadfile]${file}"
-          done
-        displayName: 'Meson'
+      - template: .azure-pipelines/steps/meson.yml
+        parameters:
+          options: -Denable-wayland=false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,21 +5,36 @@ trigger:
 jobs:
   - job: 'Meson'
     dependsOn: []
+    strategy:
+      matrix:
+        Clang:
+          compiler: clang
+        GCC:
+          compiler: gcc
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
       - template: .azure-pipelines/steps/dependencies-linux.yml
       - template: .azure-pipelines/steps/meson.yml
         parameters:
+          compiler: $(compiler)
           options: -Denable-wayland=false
           wrapper: valgrind --leak-check=full --track-origins=yes --error-exitcode=99
   - job: 'Autotools'
     dependsOn: []
+    strategy:
+      matrix:
+        Clang:
+          compiler: clang
+        GCC:
+          compiler: gcc
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
       - template: .azure-pipelines/steps/dependencies-linux.yml
       - template: .azure-pipelines/steps/autotools.yml
+        parameters:
+          compiler: $(compiler)
   - job: 'macOS'
     dependsOn: []
     pool:

--- a/scripts/meson-junit-report.py
+++ b/scripts/meson-junit-report.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import sys
+import unicodedata
+import xml.etree.ElementTree as ET
+from datetime import datetime
+
+
+aparser = argparse.ArgumentParser(
+    description='Convert Meson test log into JUnit report')
+aparser.add_argument('--project-name', metavar='NAME',
+                     help='The project name',
+                     default='unknown')
+aparser.add_argument('--job-id', metavar='ID',
+                     help='The job ID for the report',
+                     default='Unknown')
+aparser.add_argument('--branch', metavar='NAME',
+                     help='Branch of the project being tested',
+                     default='master')
+aparser.add_argument('--output', metavar='FILE',
+                     help='The output file, stdout by default',
+                     type=argparse.FileType('w', encoding='UTF-8'),
+                     default=sys.stdout)
+aparser.add_argument('infile', metavar='FILE',
+                     help='The input testlog.json, stdin by default',
+                     type=argparse.FileType('r', encoding='UTF-8'),
+                     default=sys.stdin)
+args = aparser.parse_args()
+
+outfile = args.output
+
+testsuites = ET.Element('testsuites')
+testsuites.set('id', '{}/{}'.format(args.job_id, args.branch))
+testsuites.set('package', args.project_name)
+testsuites.set('timestamp', datetime.utcnow().isoformat(timespec='minutes'))
+
+testsuite = ET.SubElement(testsuites, 'testsuite')
+testsuite.set('name', args.project_name)
+
+successes = 0
+failures = 0
+skips = 0
+
+
+def escape_control_chars(text):
+    return "".join(c if unicodedata.category(c)[0] != "C" else
+                   "<{:02x}>".format(ord(c)) for c in text)
+
+
+for line in args.infile:
+    unit = json.loads(line)
+
+    testcase = ET.SubElement(testsuite, 'testcase')
+    testcase.set('classname', '{}/{}'.format(args.project_name, unit['name']))
+    testcase.set('name', unit['name'])
+    testcase.set('time', str(unit['duration']))
+
+    stdout = escape_control_chars(unit.get('stdout', ''))
+    stderr = escape_control_chars(unit.get('stderr', ''))
+    if stdout:
+        ET.SubElement(testcase, 'system-out').text = stdout
+    if stderr:
+        ET.SubElement(testcase, 'system-out').text = stderr
+
+    result = unit['result'].lower()
+    if result == 'skip':
+        skips += 1
+        ET.SubElement(testcase, 'skipped')
+    elif result == 'fail':
+        failures += 1
+        failure = ET.SubElement(testcase, 'failure')
+        failure.set('message', "{} failed".format(unit['name']))
+        failure.text = "### stdout\n{}\n### stderr\n{}\n".format(stdout,
+                                                                 stderr)
+    else:
+        successes += 1
+        assert unit['returncode'] == 0
+
+testsuite.set('tests', str(successes + failures + skips))
+testsuite.set('skipped', str(skips))
+testsuite.set('errors', str(failures))
+testsuite.set('failures', str(failures))
+
+print('{}: {} pass, {} fail, {} skip'.format(args.project_name,
+                                             successes,
+                                             failures,
+                                             skips))
+
+output = ET.tostring(testsuites, encoding='unicode')
+outfile.write(output)


### PR DESCRIPTION
As requested by @bluetech in #103 I have been investigating on using Azure Pipelines for the continuous integration, and it looks like I more or less have been able to replicate what Travis is currently doing:

- Building on Ubuntu:
  - Clang+Autotools
  - Clang+Meson+Valgrind
  - GCC+Autotools
  - GCC+Meson+Valgrind
- Building on Mac OS:
  - Clang+Meson

The only differences with the current Travis configuration are:

- The most recent Ubuntu version Azure has is Xenial, so I had to pass `-Denable-wayland=false` for the Meson builds because the Wayland development packages are too old.
- Mac OS gets an update from 10.2 to 10.13
- Output from the tests is gathered from Meson's JSON log files an converted to JUnit XML, which Azure can ingest to show the test results in the Web interface.

Note that I have been learning to use the Azure Pipelines service while working on this patch set, so it could be as well that some things could be done better. I kept multiple commits to show the evolution of the configuration files as features were being added and improved upon, hopefully that will help out reviewing the PR. The conversion script for the unit test output was thrown together in a rush, so it might be possible to improve on it—the result is already quite nice, though! :eyes: 

You can see a [sample build on Azure Pipelines](https://dev.azure.com/aperezdc/libxkbcommon-ci/_build/results?buildId=50) running on my copy of the repository.
