### PR TITLE
Allow for custom rulesets through include files.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -285,6 +285,11 @@ test_env.set('XKB_LOG_LEVEL', 'debug')
 test_env.set('XKB_LOG_VERBOSITY', '10')
 test_env.set('top_srcdir', meson.source_root())
 test_env.set('top_builddir', meson.build_root())
+
+test_configh_data = configuration_data()
+test_configh_data.set_quoted('TEST_XKB_CONFIG_ROOT', join_paths(meson.source_root(), 'test', 'data'))
+configure_file(output: 'test-config.h', configuration: test_configh_data)
+
 # Some tests need to use unexported symbols, so we link them against
 # an internal copy of libxkbcommon with all symbols exposed.
 libxkbcommon_test_internal = static_library(
@@ -332,6 +337,11 @@ test(
 test(
     'rules-file',
     executable('test-rules-file', 'test/rules-file.c', dependencies: test_dep),
+    env: test_env,
+)
+test(
+    'rules-file-includes',
+    executable('test-rules-file-includes', 'test/rules-file-includes.c', dependencies: test_dep),
     env: test_env,
 )
 test(

--- a/src/context.c
+++ b/src/context.c
@@ -69,6 +69,13 @@ err:
     return 0;
 }
 
+const char *
+xkb_context_include_path_get_system_path(struct xkb_context *ctx)
+{
+    const char *root = secure_getenv("XKB_CONFIG_ROOT");
+    return root ? root : DFLT_XKB_CONFIG_ROOT;
+}
+
 /**
  * Append the default include directories to the context.
  */
@@ -106,11 +113,8 @@ xkb_context_include_path_append_default(struct xkb_context *ctx)
         }
     }
 
-    root = secure_getenv("XKB_CONFIG_ROOT");
-    if (root != NULL)
-       ret |= xkb_context_include_path_append(ctx, root);
-    else
-       ret |= xkb_context_include_path_append(ctx, DFLT_XKB_CONFIG_ROOT);
+    root = xkb_context_include_path_get_system_path(ctx);
+    ret |= xkb_context_include_path_append(ctx, root);
 
     return ret;
 }

--- a/src/context.h
+++ b/src/context.h
@@ -59,6 +59,9 @@ const char *
 xkb_context_failed_include_path_get(struct xkb_context *ctx,
                                     unsigned int idx);
 
+const char *
+xkb_context_include_path_get_system_path(struct xkb_context *ctx);
+
 /*
  * Returns XKB_ATOM_NONE if @string was not previously interned,
  * otherwise returns the atom.

--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -619,7 +619,7 @@ static bool
 append_expanded_kccgst_value(struct matcher *m, darray_char *to,
                              struct sval value)
 {
-    const char *s = value.start;
+    const char *str = value.start;
     darray_char expanded = darray_new();
     char ch;
     bool expanded_plus, to_plus;
@@ -635,9 +635,9 @@ append_expanded_kccgst_value(struct matcher *m, darray_char *to,
         struct matched_sval *expanded_value;
 
         /* Check if that's a start of an expansion. */
-        if (s[i] != '%') {
+        if (str[i] != '%') {
             /* Just a normal character. */
-            darray_appends_nullterminate(expanded, &s[i++], 1);
+            darray_appends_nullterminate(expanded, &str[i++], 1);
             continue;
         }
         if (++i >= value.len) goto error;
@@ -645,15 +645,15 @@ append_expanded_kccgst_value(struct matcher *m, darray_char *to,
         pfx = sfx = 0;
 
         /* Check for prefix. */
-        if (s[i] == '(' || s[i] == '+' || s[i] == '|' ||
-            s[i] == '_' || s[i] == '-') {
-            pfx = s[i];
-            if (s[i] == '(') sfx = ')';
+        if (str[i] == '(' || str[i] == '+' || str[i] == '|' ||
+            str[i] == '_' || str[i] == '-') {
+            pfx = str[i];
+            if (str[i] == '(') sfx = ')';
             if (++i >= value.len) goto error;
         }
 
         /* Mandatory model/layout/variant specifier. */
-        switch (s[i++]) {
+        switch (str[i++]) {
         case 'm': mlv = MLVO_MODEL; break;
         case 'l': mlv = MLVO_LAYOUT; break;
         case 'v': mlv = MLVO_VARIANT; break;
@@ -662,7 +662,7 @@ append_expanded_kccgst_value(struct matcher *m, darray_char *to,
 
         /* Check for index. */
         idx = XKB_LAYOUT_INVALID;
-        if (i < value.len && s[i] == '[') {
+        if (i < value.len && str[i] == '[') {
             int consumed;
 
             if (mlv != MLVO_LAYOUT && mlv != MLVO_VARIANT) {
@@ -670,7 +670,7 @@ append_expanded_kccgst_value(struct matcher *m, darray_char *to,
                 goto error;
             }
 
-            consumed = extract_layout_index(s + i, value.len - i, &idx);
+            consumed = extract_layout_index(str + i, value.len - i, &idx);
             if (consumed == -1) goto error;
             i += consumed;
         }
@@ -678,7 +678,7 @@ append_expanded_kccgst_value(struct matcher *m, darray_char *to,
         /* Check for suffix, if there supposed to be one. */
         if (sfx != 0) {
             if (i >= value.len) goto error;
-            if (s[i++] != sfx) goto error;
+            if (str[i++] != sfx) goto error;
         }
 
         /* Get the expanded value. */

--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -1034,8 +1034,8 @@ xkb_components_from_rules(struct xkb_context *ctx,
 {
     bool ret = false;
     FILE *file;
-    char *path;
-    struct matcher *matcher;
+    char *path = NULL;
+    struct matcher *matcher = NULL;
 
     file = FindFileInXkbPath(ctx, rmlvo->rules, FILE_TYPE_RULES, &path);
     if (!file)
@@ -1050,8 +1050,8 @@ xkb_components_from_rules(struct xkb_context *ctx,
     if (!ret)
         log_err(ctx, "No components returned from XKB rules \"%s\"\n", path);
 
+err_out:
     matcher_free(matcher);
     free(path);
-err_out:
     return ret;
 }

--- a/test/data/rules/inc-dst-loop-twice
+++ b/test/data/rules/inc-dst-loop-twice
@@ -1,0 +1,20 @@
+! model         = keycodes
+  *             = default_keycodes
+
+! layout        variant    = symbols
+  my_layout     my_variant = my_symbols+extra_variant
+
+! layout        = symbols
+  my_layout     = my_symbols
+  *             = default_symbols
+
+! model         = types
+  *             = default_types
+
+! model         = compat
+  *             = default_compat
+
+! option        = compat
+  my_option     = |some:compat
+
+! include %S/inc-src-loop-twice

--- a/test/data/rules/inc-dst-simple
+++ b/test/data/rules/inc-dst-simple
@@ -1,0 +1,18 @@
+! model         = keycodes
+  my_model      = my_keycodes
+  *             = default_keycodes
+
+! layout        variant    = symbols
+  my_layout     my_variant = my_symbols+extra_variant
+
+! layout        = symbols
+  *             = default_symbols
+
+! model         = types
+  *             = default_types
+
+! model         = compat
+  *             = default_compat
+
+! option        = compat
+  my_option     = |some:compat

--- a/test/data/rules/inc-src-before-after
+++ b/test/data/rules/inc-src-before-after
@@ -1,0 +1,7 @@
+! model         = keycodes
+  before_model  = my_keycodes
+
+! include %S/inc-dst-simple
+
+! layout        = symbols
+  after_layout  = my_symbols

--- a/test/data/rules/inc-src-loop-twice
+++ b/test/data/rules/inc-src-loop-twice
@@ -1,0 +1,4 @@
+! model         = keycodes
+  my_model      = my_keycodes
+
+! include %S/inc-dst-loop-twice

--- a/test/data/rules/inc-src-looped
+++ b/test/data/rules/inc-src-looped
@@ -1,0 +1,1 @@
+! include %S/inc-src-looped

--- a/test/data/rules/inc-src-nested
+++ b/test/data/rules/inc-src-nested
@@ -1,0 +1,1 @@
+! include %S/inc-src-simple

--- a/test/data/rules/inc-src-options
+++ b/test/data/rules/inc-src-options
@@ -1,0 +1,10 @@
+! option        = compat
+  option111     = +substring
+  option1       = +some:compat
+  option11      = +group(bla)
+
+! include %S/inc-dst-simple
+
+! option        = symbols
+  option3       = +compose(foo)+keypad(bar)
+  colon:opt     = +altwin(menu)

--- a/test/data/rules/inc-src-simple
+++ b/test/data/rules/inc-src-simple
@@ -1,0 +1,4 @@
+! layout        = symbols
+  my_layout     = my_symbols
+
+! include %S/inc-dst-simple

--- a/test/rules-file-includes.c
+++ b/test/rules-file-includes.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2012 Ran Benita <ran234@gmail.com>
+ * Copyright © 2019 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "test-config.h"
+
+#include "test.h"
+#include "xkbcomp/xkbcomp-priv.h"
+#include "xkbcomp/rules.h"
+
+struct test_data {
+    /* Rules file */
+    const char *rules;
+
+    /* Input */
+    const char *model;
+    const char *layout;
+    const char *variant;
+    const char *options;
+
+    /* Expected output */
+    const char *keycodes;
+    const char *types;
+    const char *compat;
+    const char *symbols;
+
+    /* Or set this if xkb_components_from_rules() should fail. */
+    bool should_fail;
+};
+
+static bool
+test_rules(struct xkb_context *ctx, struct test_data *data)
+{
+    bool passed;
+    const struct xkb_rule_names rmlvo = {
+        data->rules, data->model, data->layout, data->variant, data->options
+    };
+    struct xkb_component_names kccgst;
+
+    fprintf(stderr, "\n\nChecking : %s\t%s\t%s\t%s\t%s\n", data->rules,
+            data->model, data->layout, data->variant, data->options);
+
+    if (data->should_fail)
+        fprintf(stderr, "Expecting: FAILURE\n");
+    else
+        fprintf(stderr, "Expecting: %s\t%s\t%s\t%s\n",
+                data->keycodes, data->types, data->compat, data->symbols);
+
+    if (!xkb_components_from_rules(ctx, &rmlvo, &kccgst)) {
+        fprintf(stderr, "Received : FAILURE\n");
+        return data->should_fail;
+    }
+
+    fprintf(stderr, "Received : %s\t%s\t%s\t%s\n",
+            kccgst.keycodes, kccgst.types, kccgst.compat, kccgst.symbols);
+
+    passed = streq(kccgst.keycodes, data->keycodes) &&
+             streq(kccgst.types, data->types) &&
+             streq(kccgst.compat, data->compat) &&
+             streq(kccgst.symbols, data->symbols);
+
+    free(kccgst.keycodes);
+    free(kccgst.types);
+    free(kccgst.compat);
+    free(kccgst.symbols);
+
+    return passed;
+}
+
+int
+main(int argc, char *argv[])
+{
+    struct xkb_context *ctx;
+
+    setenv("XKB_CONFIG_ROOT", TEST_XKB_CONFIG_ROOT, 1);
+
+    ctx = test_get_context(0);
+    assert(ctx);
+
+    struct test_data test1 = {
+        .rules = "inc-src-simple",
+
+        .model = "my_model", .layout = "my_layout", .variant = "", .options = "",
+
+        .keycodes = "my_keycodes", .types = "default_types",
+        .compat = "default_compat", .symbols = "my_symbols",
+    };
+    assert(test_rules(ctx, &test1));
+
+    struct test_data test2 = {
+        .rules = "inc-src-nested",
+
+        .model = "my_model", .layout = "my_layout", .variant = "", .options = "",
+
+        .keycodes = "my_keycodes", .types = "default_types",
+        .compat = "default_compat", .symbols = "my_symbols",
+    };
+    assert(test_rules(ctx, &test2));
+
+    struct test_data test3 = {
+        .rules = "inc-src-looped",
+
+        .model = "my_model", .layout = "my_layout", .variant = "", .options = "",
+
+        .should_fail = true,
+    };
+    assert(test_rules(ctx, &test3));
+
+    struct test_data test4 = {
+        .rules = "inc-src-before-after",
+
+        .model = "before_model", .layout = "my_layout", .variant = "", .options = "",
+
+        .keycodes = "my_keycodes", .types = "default_types",
+        .compat = "default_compat", .symbols = "default_symbols",
+    };
+    assert(test_rules(ctx, &test4));
+
+    struct test_data test5 = {
+        .rules = "inc-src-options",
+
+        .model = "my_model", .layout = "my_layout", .variant = "my_variant",
+        .options = "option11,my_option,colon:opt,option111",
+
+        .keycodes = "my_keycodes", .types = "default_types",
+        .compat = "default_compat+substring+group(bla)|some:compat",
+        .symbols = "my_symbols+extra_variant+altwin(menu)",
+    };
+    assert(test_rules(ctx, &test5));
+
+    struct test_data test6 = {
+        .rules = "inc-src-loop-twice",
+
+        .model = "my_model", .layout = "my_layout", .variant = "", .options = "",
+
+        .keycodes = "my_keycodes", .types = "default_types",
+        .compat = "default_compat", .symbols = "my_symbols",
+    };
+    assert(test_rules(ctx, &test6));
+
+    xkb_context_unref(ctx);
+    return 0;
+}


### PR DESCRIPTION
This adds an `! include /path/to/rulesfile` directive for rules files. The simplest case would be to ship `xkeyboard-config` with an extra line at the end in the form of:
```
! include %h/.xkb/rules/myrules
```

Then that file can contain something like this:
```
! option      = symbols
  custom:foo  = +custom(foo)
```
and resolve accordingly. This allows for simple additions of local configurations without having to modify the parsers too much. Conveniently, `xkbcomp` ignores the `! include` directive though this is still an API break for the rules files so distributions need to figure out what to do here. We do need to get this into xkbcomp/libxkbfile too though to have the same behaviour for wayland and xorg.

The directive is simple and currently only allows for `%h` to resolve to `$HOME`. Failures are basically ignored.

I've tested this under Wayland on a F30 and it works as expected: 
```gsettings set org.gnome.desktop.input-sources xkb-options "['terminate:ctrl_alt_bksp', 'compose:caps', 'custom:foo', 'custom:bar']"```

There's a bit of cleanup left and there may be some other state that I'm not aware of that needs to be considered. Needs more tests etc. but overall I think this is the best solution for #99 since it doesn't touch any of the hairer code and immediately gives us access to all of kcgcst.

This doesn't yet handle the `evdev.xml`/`evdev.lst` situation, not sure what to do here.

Fixes #99 

cc @svu, @bluetech, @fooishbar 