### PR TITLE
Add meson option to specify a native wayland-scanner

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -423,7 +423,7 @@ if get_option('enable-wayland')
 You can disable the Wayland demo programs with -Denable-wayland=false.''')
     endif
 
-    wayland_scanner = find_program(wayland_scanner_dep.get_pkgconfig_variable('wayland_scanner'))
+    wayland_scanner = find_program(get_option('wayland-scanner'))
     wayland_scanner_code_gen = generator(
         wayland_scanner,
         output: '@BASENAME@-protocol.c',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -56,3 +56,9 @@ option(
     value: true,
     description: 'Enable support for Wayland utility programs',
 )
+option(
+  'wayland-scanner',
+  type: 'string',
+  value: 'wayland-scanner',
+  description: 'Path to native wayland-scanner',
+)


### PR DESCRIPTION
When Wayland is enabled, it's not possible to cross-compile this library because it requires a native `wayland-scanner` that can be run on the build system.

Instead of looking for `wayland-scanner` in the pkgconfig file, this PR allows setting from the command line the path (or just the name if it's in the `PATH`) to a native `wayland-scanner` that can be used for the build.

I've used this patch to successfully cross-compile this library for 9 different platforms using Julia's [`BinaryBuilder.jl`](https://github.com/JuliaPackaging/BinaryBuilder.jl):  https://github.com/JuliaPackaging/Yggdrasil/pull/147