### PR TITLE
scripts/makeheader: allow overriding the prefix path of the X11 headers

### DIFF
--- a/scripts/makeheader
+++ b/scripts/makeheader
@@ -2,14 +2,18 @@
 
 from __future__ import print_function
 import re
+import os
 
+prefix = os.environ.get('X11_HEADERS_PREFIX')
+if not prefix:
+    prefix = '/usr'
 
 HEADERS = [
-    '/usr/include/X11/keysymdef.h',
-    '/usr/include/X11/XF86keysym.h',
-    '/usr/include/X11/Sunkeysym.h',
-    '/usr/include/X11/DECkeysym.h',
-    '/usr/include/X11/HPkeysym.h',
+    prefix + '/include/X11/keysymdef.h',
+    prefix + '/include/X11/XF86keysym.h',
+    prefix + '/include/X11/Sunkeysym.h',
+    prefix + '/include/X11/DECkeysym.h',
+    prefix + '/include/X11/HPkeysym.h',
 ]
 
 print('''#ifndef _XKBCOMMON_KEYSYMS_H


### PR DESCRIPTION
with X11_HEADERS_PREFIX

Signed-off-by: Sebastian Wick <sebastian@sebastianwick.net>