### PR TITLE
test: xkeyboard-config: invoke the python3 command

### DIFF
--- a/test/xkeyboard-config-test.py.in
+++ b/test/xkeyboard-config-test.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import subprocess
 import os


### PR DESCRIPTION
python3 is always python3, but python could be python2 in some cases. Or just
missing (e.g. RHEL8).

I don't think there's any distro where `python` is available (and is python3) but the `python3` command isn't.