### PR TITLE
two coverity fixes

### DIFF
--- a/test/common.c
+++ b/test/common.c
@@ -165,7 +165,7 @@ test_get_path(const char *path_rel)
         return strdup(path_rel);
 
     path_len = strlen(srcdir ? srcdir : ".") +
-               strlen(path_rel ? path_rel : "") + 12;
+               strlen(path_rel) + 12;
     path = malloc(path_len);
     if (!path) {
         fprintf(stderr, "Failed to allocate path (%d chars) for %s\n",

--- a/test/common.c
+++ b/test/common.c
@@ -247,8 +247,10 @@ test_get_context(enum test_context_flags test_flags)
         return NULL;
 
     path = test_get_path("");
-    if (!path)
+    if (!path) {
+        xkb_context_unref(ctx);
         return NULL;
+    }
 
     xkb_context_include_path_append(ctx, path);
     free(path);


### PR DESCRIPTION
Coverity actually complains about a few others but many of those are false positives. And others are largely in the test code - these two are the only ones that I could justify writing a patch for (i.e. where it doesn't get more convoluted afterwards). And IMO only the memleak patch is really one that's worth merging.