### PR TITLE
keysym: handle ssharp in XConvertCase()

### DIFF
--- a/src/keysym.c
+++ b/src/keysym.c
@@ -478,6 +478,8 @@ UCSConvertCase(uint32_t code, xkb_keysym_t *lower, xkb_keysym_t *upper)
             *upper = 0x0178;
         else if (code == 0x00b5)      /* micro sign */
             *upper = 0x039c;
+        else if (code == 0x00df)      /* ssharp */
+            *upper = 0x1e9e;
 	return;
     }
 
@@ -607,6 +609,8 @@ UCSConvertCase(uint32_t code, xkb_keysym_t *lower, xkb_keysym_t *upper)
         }
         else if (code == 0x1e9b)
             *upper = 0x1e60;
+        else if (code == 0x1e9e)
+            *lower = 0x00df; /* ssharp */
     }
 
     /* Greek Extended, U+1F00 to U+1FFF */


### PR DESCRIPTION
lowercase: LATIN SMALL LETTER SHARP S (U+00DF)
uppercase: LATIN CAPITAL LETTER SHARP S (U+1E9E)

The uppercase sharp s (XK_ssharp) is a relatively recent addition to unicode
but was added to the relevant keyboard layouts in xkeyboard-config-2.25
(d1411e5e95c)
https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/issues/144

Alas, the CapsLock behavior was broken on the finnish layout (maybe others).
This was due XConvertCase() never returning the uppercase characters.

Let's make this function return the right lower/upper symbols for the sharp s
and hope that the world won't get any worse because of it.

Corresponding Xlib issue:
https://gitlab.freedesktop.org/xorg/lib/libx11/issues/110