### PR TITLE
Support translation Unicode codepoints to keysyms

### DIFF
--- a/xkbcommon.map
+++ b/xkbcommon.map
@@ -103,3 +103,8 @@ global:
 	xkb_keysym_to_lower;
 	xkb_keysym_to_upper;
 } V_0.7.0;
+
+V_0.11.0 {
+global:
+	xkb_utf32_to_keysym;
+} V_0.8.0;

--- a/xkbcommon/xkbcommon.h
+++ b/xkbcommon/xkbcommon.h
@@ -494,6 +494,28 @@ uint32_t
 xkb_keysym_to_utf32(xkb_keysym_t keysym);
 
 /**
+ * Get the keysym corresponding to a Unicode/UTF-32 codepoint.
+ *
+ * @returns The keysym corresponding to the specified Unicode
+ * codepoint, or XKB_KEY_NoSymbol if there is none.
+ *
+ * This function is the inverse of @ref xkb_keysym_to_utf32. In cases
+ * where a single codepoint corresponds to multiple keysyms, returns
+ * the keysym with the lowest value.
+ * 
+ * Unicode codepoints which do not have a special (legacy) keysym
+ * encoding use a direct encoding scheme. These keysyms don't usually
+ * have an associated keysym constant (XKB_KEY_*).
+ *
+ * For noncharacter Unicode codepoints and codepoints outside of the
+ * defined Unicode planes this function returns XKB_KEY_NoSymbol.
+ *
+ * @sa xkb_keysym_to_utf32()
+ */
+xkb_keysym_t
+xkb_utf32_to_keysym(uint32_t ucs);
+
+/**
  * Convert a keysym to its uppercase form.
  *
  * If there is no such form, the keysym is returned unchanged.


### PR DESCRIPTION
In order to support features like auto-type and UI automation, the
relevant tools need to be able to invert the keycode->keysym->text
transformation. In order to facilitate that, a new API was added.
It allows querying the keysyms that correspond to particular Unicode
codepoints. For all practical purposes, it can be thought of as an
inverse of xkb_keysym_to_utf32().