### PR TITLE
keymap: don't forget about fallback mappings in xkb_keymap_key_get_mods_for_level()

### DIFF
--- a/test/keymap.c
+++ b/test/keymap.c
@@ -69,7 +69,8 @@ main(void)
 
     // AC01 level 0 ('a') requires no modifiers on us-pc104
     mask_count = xkb_keymap_key_get_mods_for_level(keymap, kc, 0, 0, masks_out, 4);
-    assert(mask_count == 0);
+    assert(mask_count == 1);
+    assert(masks_out[0] == 0);
 
     shift_mask = 1 << xkb_keymap_mod_get_index(keymap, "Shift");
     lock_mask = 1 << xkb_keymap_mod_get_index(keymap, "Lock");


### PR DESCRIPTION
Fixes https://github.com/xkbcommon/libxkbcommon/issues/140.

If the active set of modifiers doesn't match any explicit entry of the
key type, the resulting level is 0 (i.e. Level 1). Some key types don't
explicitly map Level 1, taking advantage of this fallback.

Previously, xkb_keymap_key_get_mods_for_level didn't consider this, and
only reported masks for explicit mappings. But this causes some glaring
omissions, like matching "a" in the "us" keymap returning not results.

Since every mask which isn't explicitly mapped falls back to 0, we can't
return the all. Almost always the best choice for this is the empty
mask, so return that, when applicable.