### PR TITLE
test: fix the xkeyboard-config test for the prefixed tool name

### DIFF
--- a/test/xkeyboard-config-test.py.in
+++ b/test/xkeyboard-config-test.py.in
@@ -41,7 +41,7 @@ def xkbcommontool(rmlvo):
         v = rmlvo.get('v', None)
         o = rmlvo.get('o', None)
         args = [
-            'rmlvo-to-keymap',
+            'xkbcommon-rmlvo-to-keymap',
             '--rules', r,
             '--model', m,
             '--layout', l,


### PR DESCRIPTION
Regression introduced in 362130debb5d90d77f0d4f7549880b5f9699f647