### PR TITLE
Add the (v)asprintf_safe helper function

### DIFF
--- a/src/compose/paths.c
+++ b/src/compose/paths.c
@@ -25,6 +25,7 @@
 
 #include "utils.h"
 #include "paths.h"
+#include "utils.h"
 
 enum resolve_name_direction {
     LEFT_TO_RIGHT,
@@ -151,19 +152,13 @@ get_xcomposefile_path(void)
 char *
 get_home_xcompose_file_path(void)
 {
-    int ret;
     const char *home;
-    char *path;
 
     home = secure_getenv("HOME");
     if (!home)
         return NULL;
 
-    ret = asprintf(&path, "%s/.XCompose", home);
-    if (ret <0)
-        return NULL;
-
-    return path;
+    return asprintf_safe("%s/.XCompose", home);
 }
 
 char *
@@ -195,10 +190,8 @@ get_locale_compose_file_path(const char *locale)
     }
     else {
         const char *xlocaledir = get_xlocaledir_path();
-        int ret = asprintf(&path, "%s/%s", xlocaledir, resolved);
+        path = asprintf_safe("%s/%s", xlocaledir, resolved);
         free(resolved);
-        if (ret < 0)
-            return NULL;
     }
 
     return path;

--- a/src/context.c
+++ b/src/context.c
@@ -98,30 +98,29 @@ xkb_context_include_path_append_default(struct xkb_context *ctx)
 {
     const char *home, *xdg, *root;
     char *user_path;
-    int err;
     int ret = 0;
 
     home = secure_getenv("HOME");
 
     xdg = secure_getenv("XDG_CONFIG_HOME");
     if (xdg != NULL) {
-        err = asprintf(&user_path, "%s/xkb", xdg);
-        if (err >= 0) {
+        user_path = asprintf_safe("%s/xkb", xdg);
+        if (user_path) {
             ret |= xkb_context_include_path_append(ctx, user_path);
             free(user_path);
         }
     } else if (home != NULL) {
         /* XDG_CONFIG_HOME fallback is $HOME/.config/ */
-        err = asprintf(&user_path, "%s/.config/xkb", home);
-        if (err >= 0) {
+        user_path = asprintf_safe("%s/.config/xkb", home);
+        if (user_path) {
             ret |= xkb_context_include_path_append(ctx, user_path);
             free(user_path);
         }
     }
 
     if (home != NULL) {
-        err = asprintf(&user_path, "%s/.xkb", home);
-        if (err >= 0) {
+        user_path = asprintf_safe("%s/.xkb", home);
+        if (user_path) {
             ret |= xkb_context_include_path_append(ctx, user_path);
             free(user_path);
         }

--- a/src/registry.c
+++ b/src/registry.c
@@ -585,7 +585,6 @@ rxkb_context_include_path_append_default(struct rxkb_context *ctx)
 {
     const char *home, *xdg, *root;
     char *user_path;
-    int err;
     bool ret = false;
 
     if (ctx->context_state != CONTEXT_NEW) {
@@ -597,23 +596,23 @@ rxkb_context_include_path_append_default(struct rxkb_context *ctx)
 
     xdg = secure_getenv("XDG_CONFIG_HOME");
     if (xdg != NULL) {
-        err = asprintf(&user_path, "%s/xkb", xdg);
-        if (err >= 0) {
+        user_path = asprintf_safe("%s/xkb", xdg);
+        if (user_path) {
             ret |= rxkb_context_include_path_append(ctx, user_path);
             free(user_path);
         }
     } else if (home != NULL) {
         /* XDG_CONFIG_HOME fallback is $HOME/.config/ */
-        err = asprintf(&user_path, "%s/.config/xkb", home);
-        if (err >= 0) {
+        user_path = asprintf_safe("%s/.config/xkb", home);
+        if (user_path) {
             ret |= rxkb_context_include_path_append(ctx, user_path);
             free(user_path);
         }
     }
 
     if (home != NULL) {
-        err = asprintf(&user_path, "%s/.xkb", home);
-        if (err >= 0) {
+        user_path = asprintf_safe("%s/.xkb", home);
+        if (user_path) {
             ret |= rxkb_context_include_path_append(ctx, user_path);
             free(user_path);
         }

--- a/src/utils.h
+++ b/src/utils.h
@@ -313,4 +313,36 @@ snprintf_safe(char *buf, size_t sz, const char *format, ...)
     return rc >= 0 && (size_t)rc < sz;
 }
 
+static inline char *
+ATTR_PRINTF(1, 0)
+vasprintf_safe(const char *fmt, va_list args)
+{
+    char *str;
+    int len;
+
+    len = vasprintf(&str, fmt, args);
+
+    if (len == -1)
+        return NULL;
+
+    return str;
+}
+
+/**
+ * A version of asprintf that returns the allocated string or NULL on error.
+ */
+static inline char *
+ATTR_PRINTF(1, 2)
+asprintf_safe(const char *fmt, ...)
+{
+    va_list args;
+    char *str;
+
+    va_start(args, fmt);
+    str = vasprintf_safe(fmt, args);
+    va_end(args);
+
+    return str;
+}
+
 #endif /* UTILS_H */

--- a/src/xkbcomp/include.c
+++ b/src/xkbcomp/include.c
@@ -267,7 +267,7 @@ ProcessIncludeFile(struct xkb_context *ctx, IncludeStmt *stmt,
 
     file = FindFileInXkbPath(ctx, stmt->file, file_type, NULL);
     if (!file)
-        return false;
+        return NULL;
 
     xkb_file = XkbParseFile(ctx, file, stmt->file, stmt->map);
     fclose(file);

--- a/test/common.c
+++ b/test/common.c
@@ -165,7 +165,6 @@ test_key_seq(struct xkb_keymap *keymap, ...)
 char *
 test_get_path(const char *path_rel)
 {
-    int ret;
     char *path;
     const char *srcdir;
 
@@ -176,9 +175,9 @@ test_get_path(const char *path_rel)
     if (path_rel[0] == '/')
         return strdup(path_rel);
 
-    ret = asprintf(&path, "%s/test/data%s%s", srcdir,
-                   path_rel[0] ? "/" : "", path_rel);
-    if (ret < 0) {
+    path = asprintf_safe("%s/test/data%s%s", srcdir,
+                         path_rel[0] ? "/" : "", path_rel);
+    if (!path) {
         fprintf(stderr, "Failed to allocate path for %s\n", path_rel);
         return NULL;
     }

--- a/test/compose.c
+++ b/test/compose.c
@@ -485,18 +485,16 @@ static void
 test_include(struct xkb_context *ctx)
 {
     char *path, *table_string;
-    int ret;
 
     path = test_get_path("compose/en_US.UTF-8/Compose");
     assert(path);
 
     /* We don't have a mechanism to change the include paths like we
      * have for keymaps. So we must include the full path. */
-    ret = asprintf(&table_string,
-        "<dead_tilde> <space>   : \"foo\" X\n"
-        "include \"%s\"\n"
-        "<dead_tilde> <dead_tilde> : \"bar\" Y\n", path);
-    assert(ret >= 0);
+    table_string = asprintf_safe("<dead_tilde> <space>   : \"foo\" X\n"
+                                 "include \"%s\"\n"
+                                 "<dead_tilde> <dead_tilde> : \"bar\" Y\n", path);
+    assert(table_string);
 
     assert(test_compose_seq_buffer(ctx, table_string,
         /* No conflict. */

--- a/test/context.c
+++ b/test/context.c
@@ -85,8 +85,8 @@ static const char *makedir(const char *parent, const char *path)
     char *dirname;
     int err;
 
-    err = asprintf(&dirname, "%s/%s", parent, path);
-    assert(err >= 0);
+    dirname = asprintf_safe("%s/%s", parent, path);
+    assert(dirname);
     err = mkdir(dirname, 0777);
     assert(err == 0);
 

--- a/test/registry.c
+++ b/test/registry.c
@@ -104,8 +104,8 @@ test_create_rules(const char *ruleset,
     int rc;
     FILE *fp;
 
-    rc = asprintf(&tmpdir, "/tmp/%s.%d.XXXXXX", ruleset, iteration++);
-    assert(rc > 0);
+    tmpdir = asprintf_safe("/tmp/%s.%d.XXXXXX", ruleset, iteration++);
+    assert(tmpdir);
     assert(mkdtemp(tmpdir) == tmpdir);
 
     rc = snprintf_safe(buf, sizeof(buf), "%s/rules", tmpdir);


### PR DESCRIPTION
Return the allocated string or NULL which is a much better interface than the `asprintf` "return length or -1 and the string pointer is undefined". And use that in xkbcomp's include buffer handling because there's no real need for realloc here.

Edit: this is split out from #162 