### PR TITLE
Add xdg base directory support to Compose

### DIFF
--- a/src/compose/paths.c
+++ b/src/compose/paths.c
@@ -143,10 +143,10 @@ resolve_locale(const char *locale)
     return alias ? alias : strdup(locale);
 }
 
-const char *
+char *
 get_xcomposefile_path(void)
 {
-    return secure_getenv("XCOMPOSEFILE");
+    return strdup_safe(secure_getenv("XCOMPOSEFILE"));
 }
 
 char *

--- a/src/compose/paths.c
+++ b/src/compose/paths.c
@@ -150,6 +150,23 @@ get_xcomposefile_path(void)
 }
 
 char *
+get_xdg_xcompose_file_path(void)
+{
+    const char *xdg_config_home;
+    const char *home;
+
+    xdg_config_home = secure_getenv("XDG_CONFIG_HOME");
+    if (!xdg_config_home || xdg_config_home[0] != '/') {
+        home = secure_getenv("HOME");
+        if (!home)
+            return NULL;
+        return asprintf_safe("%s/.config/XCompose", home);
+    }
+
+    return asprintf_safe("%s/XCompose", xdg_config_home);
+}
+
+char *
 get_home_xcompose_file_path(void)
 {
     const char *home;

--- a/src/compose/paths.h
+++ b/src/compose/paths.h
@@ -34,6 +34,9 @@ const char *
 get_xcomposefile_path(void);
 
 char *
+get_xdg_xcompose_file_path(void);
+
+char *
 get_home_xcompose_file_path(void);
 
 char *

--- a/src/compose/paths.h
+++ b/src/compose/paths.h
@@ -30,7 +30,7 @@ resolve_locale(const char *locale);
 const char *
 get_xlocaledir_path(void);
 
-const char *
+char *
 get_xcomposefile_path(void);
 
 char *

--- a/src/compose/table.c
+++ b/src/compose/table.c
@@ -161,8 +161,7 @@ xkb_compose_table_new_from_locale(struct xkb_context *ctx,
                                   enum xkb_compose_compile_flags flags)
 {
     struct xkb_compose_table *table;
-    char *path = NULL;
-    const char *cpath;
+    char *path;
     FILE *file;
     bool ok;
 
@@ -176,48 +175,47 @@ xkb_compose_table_new_from_locale(struct xkb_context *ctx,
     if (!table)
         return NULL;
 
-    cpath = get_xcomposefile_path();
-    if (cpath) {
-        file = fopen(cpath, "rb");
-        if (file)
-            goto found_path;
-    }
-
-    cpath = path = get_xdg_xcompose_file_path();
+    path = get_xcomposefile_path();
     if (path) {
         file = fopen(path, "rb");
         if (file)
             goto found_path;
     }
     free(path);
-    path = NULL;
 
-    cpath = path = get_home_xcompose_file_path();
+    path = get_xdg_xcompose_file_path();
     if (path) {
         file = fopen(path, "rb");
         if (file)
             goto found_path;
     }
     free(path);
-    path = NULL;
 
-    cpath = path = get_locale_compose_file_path(table->locale);
+    path = get_home_xcompose_file_path();
     if (path) {
         file = fopen(path, "rb");
         if (file)
             goto found_path;
     }
     free(path);
-    path = NULL;
+
+    path = get_locale_compose_file_path(table->locale);
+    if (path) {
+        file = fopen(path, "rb");
+        if (file)
+            goto found_path;
+    }
+    free(path);
 
     log_err(ctx, "couldn't find a Compose file for locale \"%s\"\n", locale);
     xkb_compose_table_unref(table);
     return NULL;
 
 found_path:
-    ok = parse_file(table, file, cpath);
+    ok = parse_file(table, file, path);
     fclose(file);
     if (!ok) {
+        free(path);
         xkb_compose_table_unref(table);
         return NULL;
     }

--- a/src/compose/table.c
+++ b/src/compose/table.c
@@ -183,6 +183,15 @@ xkb_compose_table_new_from_locale(struct xkb_context *ctx,
             goto found_path;
     }
 
+    cpath = path = get_xdg_xcompose_file_path();
+    if (path) {
+        file = fopen(path, "rb");
+        if (file)
+            goto found_path;
+    }
+    free(path);
+    path = NULL;
+
     cpath = path = get_home_xcompose_file_path();
     if (path) {
         file = fopen(path, "rb");

--- a/xkbcommon/xkbcommon-compose.h
+++ b/xkbcommon/xkbcommon-compose.h
@@ -204,8 +204,15 @@ enum xkb_compose_format {
  * affected by the following environment variables:
  *
  * 1. `XCOMPOSEFILE` - see Compose(5).
- * 2. `HOME` - see Compose(5).
- * 3. `XLOCALEDIR` - if set, used as the base directory for the system's
+ * 2. `XDG_CONFIG_HOME` - before `$HOME/.XCompose` is checked,
+ *    `$XDG_CONFIG_HOME/XCompose` is checked (with a fall back to
+ *    `$HOME/.config/XCompose` if `XDG_CONFIG_HOME` is not defined).
+ *    This is a libxkbcommon extension to the search procedure in
+ *    Compose(5) (since libxkbcommon 0.11.0). Note that other
+ *    implementations, such as libX11, might not find a Compose file in
+ *    this path.
+ * 3. `HOME` - see Compose(5).
+ * 4. `XLOCALEDIR` - if set, used as the base directory for the system's
  *    X locale files, e.g. `/usr/share/X11/locale`, instead of the
  *    preconfigured directory.
  *


### PR DESCRIPTION
Before reading `~/.XCompose`, try to read `$XDG_CONFIG_HOME/XCompose` (falling back to `~/.config/XCompose`).

This helps unclutter the home directory of users who want that.