### PR TITLE
Add xkb_library_version()

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -59,6 +59,9 @@ endif
 configh_data = configuration_data()
 configh_data.set('EXIT_INVALID_USAGE', '2')
 configh_data.set_quoted('LIBXKBCOMMON_VERSION', meson.project_version())
+configh_data.set('LIBXKBCOMMON_VERSION_MAJOR', meson.project_version().split('.')[0])
+configh_data.set('LIBXKBCOMMON_VERSION_MINOR', meson.project_version().split('.')[1])
+configh_data.set('LIBXKBCOMMON_VERSION_PATCH', meson.project_version().split('.')[2])
 configh_data.set_quoted('LIBXKBCOMMON_TOOL_PATH', dir_libexec)
 # Like AC_USE_SYSTEM_EXTENSIONS, what #define to use to get extensions
 # beyond the base POSIX function set.
@@ -213,6 +216,7 @@ libxkbcommon_sources = [
     'src/utf8.h',
     'src/utils.c',
     'src/utils.h',
+    'src/version.c',
 ]
 libxkbcommon_link_args = []
 if have_version_script

--- a/src/version.c
+++ b/src/version.c
@@ -1,0 +1,14 @@
+#include "config.h"
+
+#include "xkbcommon/xkbcommon.h"
+#include "utils.h"
+
+XKB_EXPORT struct xkb_library_version
+xkb_get_library_version() {
+    struct xkb_library_version version = {
+        .major = LIBXKBCOMMON_VERSION_MAJOR,
+        .minor = LIBXKBCOMMON_VERSION_MINOR,
+        .patch = LIBXKBCOMMON_VERSION_PATCH,
+    };
+    return version;
+}

--- a/test/tool-option-parsing.py
+++ b/test/tool-option-parsing.py
@@ -169,7 +169,7 @@ def test_invalid_option(tool):
 # xkbcli --version
 def test_xkbcli_version(xkbcli):
     stdout, stderr = xkbcli.run_command_success(['--version'])
-    assert stdout.startswith('0')
+    assert stdout.startswith('xkbcli 0')
     assert stderr == ''
 
 

--- a/tools/xkbcli.c
+++ b/tools/xkbcli.c
@@ -79,6 +79,7 @@ main(int argc, char **argv)
         OPT_VERSION,
     };
     int option_index = 0;
+    struct xkb_library_version version;
 
     while (1) {
         int c;
@@ -99,7 +100,9 @@ main(int argc, char **argv)
                 return EXIT_SUCCESS;
             case 'V':
             case OPT_VERSION:
-                printf("%s\n", LIBXKBCOMMON_VERSION);
+                printf("xkbcli %s\n", LIBXKBCOMMON_VERSION);
+                version = xkb_get_library_version();
+                printf("libxkbcommon %d.%d.%d\n", version.major, version.minor, version.patch);
                 return EXIT_SUCCESS;
             default:
                 usage();

--- a/xkbcommon.map
+++ b/xkbcommon.map
@@ -108,4 +108,5 @@ V_0.11.0 {
 global:
 	xkb_utf32_to_keysym;
 	xkb_keymap_key_get_mods_for_level;
+	xkb_get_library_version;
 } V_0.8.0;

--- a/xkbcommon/xkbcommon.h
+++ b/xkbcommon/xkbcommon.h
@@ -98,6 +98,15 @@ extern "C" {
  */
 
 /**
+ * A library version.
+ *
+ * The fields correspond to major.minor.patch, e.g. 0.20.10.
+ */
+struct xkb_library_version {
+    uint32_t major, minor, patch;
+};
+
+/**
  * @struct xkb_context
  * Opaque top level library context object.
  *
@@ -365,6 +374,26 @@ struct xkb_rule_names {
      */
     const char *options;
 };
+
+/**
+ * @defgroup general General
+ * General functions.
+ *
+ * @{
+ */
+
+/**
+ * Get the version of the library.
+ *
+ * This returns the runtime version, not the build-time version.
+ *
+ * @since 0.11.0
+ */
+struct xkb_library_version
+xkb_get_library_version(void);
+
+/** @} */
+
 
 /**
  * @defgroup keysyms Keysyms


### PR DESCRIPTION
Useful when wanting to query the version that is linked.

Fixes: https://github.com/xkbcommon/libxkbcommon/issues/171
Signed-off-by: Ran Benita <ran@unusedvar.com>