### PR TITLE
test: ignore the real XDG_CONFIG_HOME during tests

### DIFF
--- a/test/tool-option-parsing.py
+++ b/test/tool-option-parsing.py
@@ -27,6 +27,7 @@ import resource
 import sys
 import subprocess
 import logging
+import tempfile
 
 try:
     import pytest
@@ -299,4 +300,10 @@ def test_interactive_wayland(xkbcli_interactive_wayland):
 
 
 if __name__ == '__main__':
-    sys.exit(pytest.main(args=[__file__]))
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # libxkbcommon has fallbacks when XDG_CONFIG_HOME isn't set so we need
+        # to override it with a known (empty) directory. Otherwise our test
+        # behavior depends on the system the test is run on.
+        os.environ['XDG_CONFIG_HOME'] = tmpdir
+
+        sys.exit(pytest.main(args=[__file__]))


### PR DESCRIPTION
Let's not have our tests fail if the user has an incompatible `$XDG_CONFIG_HOME/xkb` directory.

libxkbcommon has fallbacks when XDG_CONFIG_HOME isn't set so we need to override this with a real directory instead of just unsetting it.



But how can this happen? Well, for example if you're trying to run the test suite on git master when you already have a xkb directory for #162 :)