### PR TITLE
test: fix the xkeyboard-config test

### DIFF
--- a/test/xkeyboard-config-test.py.in
+++ b/test/xkeyboard-config-test.py.in
@@ -41,8 +41,7 @@ def xkbcommontool(rmlvo):
         v = rmlvo.get('v', None)
         o = rmlvo.get('o', None)
         args = [
-            'xkbcli',
-            'compile-keymap',
+            'xkbcli-compile-keymap',  # this is run in the builddir
             '--rules', r,
             '--model', m,
             '--layout', l,


### PR DESCRIPTION
`xkbcli compile-keymap` doesn't work unless we ninja install first. But for a
test that's to be run from the test directory, that's not a useful option so
let's call the binary directly. The script adds the meson builddir to the PATH
anyway.