### PR TITLE
tools: convert man pages from man format to mdoc format

### DIFF
--- a/tools/xkbcli-compile-keymap.1
+++ b/tools/xkbcli-compile-keymap.1
@@ -1,70 +1,62 @@
-.TH "XKBCLI\-COMPILE\-KEYMAP" "1" "" "" "libxkbcommon manual"
+.Dd July 27, 2020
+.Dt XKBCLI\-COMPILE\-KEYMAP 1
+.Os
 .
-.SH "NAME"
-\fBxkbcli\-compile\-keymap\fR \- compile an XKB keymap
+.Sh NAME
+.Nm "xkbcli compile\-keymap"
+.Nd compile an XKB keymap
 .
-.SH "SYNOPSIS"
-\fBxkbcli\fR compile\-keymap [\-\-help] [OPTIONS]
+.Sh SYNOPSIS
+.Nm
+.Op Ar options
 .
-.SH "DESCRIPTION"
-\fBxkbcli compile\-keymap\fR compiles and prints a keymap based on the given options.
+.Sh DESCRIPTION
+.Nm
+compiles and prints a keymap based on the given options.
 .
-.SH "OPTIONS"
-.
-.TP
-\fB\-\-help\fR
+.Bl -tag -width Ds
+.It Fl \-help
 Print help and exit
 .
-.TP
-.B \-\-verbose
+.It Fl \-verbose
 Enable verbose debugging output
 .
-.TP
-.B \-\-rmlvo
+.It Fl \-rmlvo
 Print the full RMLVO with the defaults filled in for missing elements
 .
-.TP
-.B \-\-from\-xkb
+.It Fl \-from\-xkb
 Load the XKB file from stdin, ignore RMLVO options.
-This option must not be used with \fB\-\-kccgst\fR.
+This option must not be used with
+.Fl \-kccgst .
 .
-.TP
-.B \-\-include=PATH
+.It Fl \-include Ar PATH
 Add the given path to the include path list.
 This option is order\-dependent, include paths given first are searched first.
 If an include path is given, the default include path list is not used.
-Use \fB\-\-include\-defaults\fR to add the default include paths.
+Use
+.Fl -\-include\-defaults
+to add the default include paths.
 .
-.TP
-.B \-\-include\-defaults
+.It Fl \-include\-defaults
 Add the default set of include directories.
 This option is order-dependent, include paths given first are searched first.
 .
-.TP
-.B \-\-rules=<rules>
+.It Fl \-rules Ar rules
 The XKB ruleset
 .
-.TP
-.B \-\-model=<model>
+.It Fl \-model Ar model
 The XKB model
 .
-.TP
-.B \-\-layout=<layout>
+.It Fl \-layout Ar layout
 The XKB layout
 .
-.TP
-.B \-\-variant=<variant>
+.It Fl \-variant Ar variant
 The XKB layout variant
 .
-.TP
-.B \-\-options=<options>
+.It Fl \-options Ar options
 The XKB options
+.El
 .
-.SH "SEE ALSO"
-\fBxkbcli\fR(1)
-.
-.P
-The
-.UR https://xkbcommon.org
-libxkbcommon online documentation
-.UE
+.Sh SEE ALSO
+.Xr xkbcli 1 ,
+.Lk https://xkbcommon.org "The libxkbcommon online documentation"

--- a/tools/xkbcli-how-to-type.1
+++ b/tools/xkbcli-how-to-type.1
@@ -1,44 +1,41 @@
-.TH "XKBCLI\-HOW\-TO\-TYPE" "1" "" "" "libxkbcommon manual"
+.Dd July 27, 2020
+.Dt XKBCLI\-HOW\-TO\-TYPE 1
+.Os
 .
-.SH "NAME"
-\fBxkbcli\-how\-to\-type\fR \- query how to type a given Unicode codepoint
+.Sh NAME
+.Nm "xkbcli how\-to\-type"
+.Nd query how to type a given Unicode codepoint
 .
-.SH "SYNOPSIS"
-\fBxkbcli\fR how\-to\-type [OPTIONS] <codepoint>
+.Sh SYNOPSIS
+.Nm
+.Op options
+.Ar codepoint
 .
-.SH "DESCRIPTION"
-\fBxkbcli how\-to\-type\fR prints key sequences to type the given Unicode codepoint.
+.Sh DESCRIPTION
+.Nm
+prints key sequences to type the given Unicode codepoint.
+.Pp
+Pipe into
+.Dq "column \-ts $\'\e\et\'"
+for nicely aligned output.
 .
-.P
-Pipe into \fBcolumn \-ts $\'\e\et\'\fR for nicely aligned output.
-.
-.SH "OPTIONS"
-.
-.TP
-.B \-\-rules=<rules>
+.Bl -tag -width Ds
+.It Fl \-rules Ar rules
 The XKB ruleset
 .
-.TP
-.B \-\-model=<model>
+.It Fl \-model Ar model
 The XKB model
 .
-.TP
-.B \-\-layout=<layout>
+.It Fl \-layout Ar layout
 The XKB layout
 .
-.TP
-.B \-\-variant=<variant>
+.It Fl \-variant Ar variant
 The XKB layout variant
 .
-.TP
-.B \-\-options=<options>
+.It Fl \-options Ar options
 The XKB options
+.El
 .
-.SH "SEE ALSO"
-\fBxkbcli\fR(1)
-.
-.P
-The
-.UR https://xkbcommon.org
-libxkbcommon online documentation
-.UE
+.Sh SEE ALSO
+.Xr xkbcli 1 ,
+.Lk https://xkbcommon.org "The libxkbcommon online documentation"

--- a/tools/xkbcli-interactive-evdev.1
+++ b/tools/xkbcli-interactive-evdev.1
@@ -1,78 +1,77 @@
-.TH "XKBCLI\-INTERACTIVE\-EVDEV" "1" "" "" "libxkbcommon manual"
+.Dd July 27, 2020
+.Dt XKBCLI\-INTERACTIVE\-EVDEV 1
+.Os
 .
-.SH "NAME"
-\fBxkbcli\-interactive\-evdev\fR \- interactive debugger for XKB keymaps
+.Sh NAME
+.Nm "xkbcli interactive\-evdev"
+.Nd interactive debugger for XKB keymaps
 .
-.SH "SYNOPSIS"
-\fBxkbcli\fR interactive\-evdev [\-\-help] [OPTIONS]
+.Sh SYNOPSIS
+.Nm
+.Op Ar options
 .
-.SH "DESCRIPTION"
-\fBxkbcli interactive\-evdev\fR is a commandline tool to interactively debug XKB keymaps by listening to \fB/dev/input/eventX\fR evdev devices (Linux).
+.Sh DESCRIPTION
+.Nm
+is a commandline tool to interactively debug XKB keymaps by listening to
+.Pa /dev/input/eventX
+evdev devices (Linux).
 .
-.P
-.B xkbcli interactive\-evdev
+.Pp
+.Nm
 requires permission to open the evdev device nodes.
-This usually requires being the \fBroot\fR user or belonging to the \fBinput\fR group.
+This usually requires being the
+.Dq root
+user or belonging to the
+.Dq input
+group.
 .
-.P
-Press the Escape key to exit.
+.Pp
+Press the
+.Aq Escape
+key to exit.
 .
-.P
+.Pp
 This is a debugging tool, its behavior or output is not guaranteed to be stable.
 .
-.SH "OPTIONS"
-.
-.TP
-.B \-\-help
+.Bl -tag -width Ds
+.It Fl \-help
 Print help and exit
 .
-.TP
-.B \-\-rules=<rules>
+.It Fl \-rules Ar rules
 The XKB ruleset
 .
-.TP
-.B \-\-model=<model>
+.It Fl \-model Ar model
 The XKB model
 .
-.TP
-.B \-\-layout=<layout>
+.It Fl \-layout Ar layout
 The XKB layout
 .
-.TP
-.B \-\-variant=<variant>
+.It Fl \-variant Ar variant
 The XKB layout variant
 .
-.TP
-.B \-\-options=<options>
+.It Fl \-option Ar options
 The XKB options
 .
-.TP
-.B \-\-keymap=PATH
+.It Fl \-keymap Ar file
 Specify a keymap path.
 This option is mutually exclusive with the RMLVO options.
 .
-.TP
-.B \-\-report\-state\-changes
+.It Fl \-report\-state\-changes
 Report changes to the keyboard state
 .
-.TP
-.B \-\-enable\-compose
+.It Fl \-enable\-compose
 Enable Compose functionality
 .
-.TP
-.B \-\-consumed\-mode={xkb|gtk}
+.It Fl \-consumed\-mode Brq xkb|gtk
 Set the consumed modifiers mode (default: xkb)
 .
-.TP
-.B \-\-without\-x11\-offset
+.It Fl \-without\-x11\-offset
 Don't add an offset of 8 when converting an evdev keycode to an XKB keycode.
 You probably don't want this option.
+.El
 .
-.SH "SEE ALSO"
-\fBxkbcli\fR(1), \fBxkbcli\-interactive\-wayland\fR(1), \fBxkbcli\-interactive\-x11\fR(1)
-.
-.P
-The
-.UR https://xkbcommon.org
-libxkbcommon online documentation
-.UE
+.Sh SEE ALSO
+.Xr xkbcli 1 ,
+.Xr xkbcli\-interactive\-wayland 1 ,
+.Xr xkbcli\-interactive\-x11 1 ,
+.Lk https://xkbcommon.org "The libxkbcommon online documentation"

--- a/tools/xkbcli-interactive-wayland.1
+++ b/tools/xkbcli-interactive-wayland.1
@@ -1,34 +1,37 @@
-.TH "XKBCLI\-INTERACTIVE\-WAYLAND" "1" "" "" "libxkbcommon manual"
+.Dd July 27, 2020
+.Dt XKBCLI\-INTERACTIVE\-WAYLAND 1
+.Os
 .
-.SH "NAME"
-\fBxkbcli\-interactive\-wayland\fR \- interactive debugger for XKB keymaps
+.Sh NAME
+.Nm "xkbcli interactive\-wayland"
+.Nd interactive debugger for XKB keymaps
 .
-.SH "SYNOPSIS"
-\fBxkbcli\fR interactive\-wayland [\-\-help] [OPTIONS]
+.Sh SYNOPSIS
+.Nm
+.Op Ar options
 .
-.SH "DESCRIPTION"
-\fBxkbcli interactive\-wayland\fR is a commandline tool to interactively debug XKB keymaps by listening to wayland events.
+.Sh DESCRIPTION
+.Nm
+is a commandline tool to interactively debug XKB keymaps by listening to Wayland events.
 .
-.P
+.Pp
 This requires a Wayland compositor to be running.
 .
-.P
-Press the Escape key to exit.
+.Pp
+Press the
+.Aq Escape
+key to exit.
 .
-.P
+.Pp
 This is a debugging tool, its behavior or output is not guaranteed to be stable.
 .
-.SH "OPTIONS"
-.
-.TP
-.B \-\-help
+.Bl -tag -width Ds
+.It Fl \-help
 Print help and exit
+.El
 .
-.SH "SEE ALSO"
-\fBxkbcli\fR(1), \fBxkbcli\-interactive\-evdev\fR(1), \fBxkbcli\-interactive\-x11\fR(1)
-.
-.P
-The
-.UR https://xkbcommon.org
-libxkbcommon online documentation
-.UE
+.Sh SEE ALSO
+.Xr xkbcli 1 ,
+.Xr xkbcli\-interactive\-evdev 1 ,
+.Xr xkbcli\-interactive\-x11 1 ,
+.Lk https://xkbcommon.org "The libxkbcommon online documentation"

--- a/tools/xkbcli-interactive-x11.1
+++ b/tools/xkbcli-interactive-x11.1
@@ -1,34 +1,37 @@
-.TH "XKBCLI\-INTERACTIVE\-X11" "1" "" "" "libxkbcommon manual"
+.Dd July 27, 2020
+.Dt XKBCLI\-INTERACTIVE\-X11 1
+.Os
 .
-.SH "NAME"
-\fBxkbcli\-interactive\-x11\fR \- interactive debugger for XKB keymaps
+.Sh NAME
+.Nm "xkbcli interactive\-x11"
+.Nd interactive debugger for XKB keymaps
 .
-.SH "SYNOPSIS"
-\fBxkbcli\fR interactive\-x11 [\-\-help] [OPTIONS]
+.Sh SYNOPSIS
+.Nm
+.Op Ar options
 .
-.SH "DESCRIPTION"
-\fBxkbcli interactive\-x11\fR is a commandline tool to interactively debug XKB keymaps by listening to X11 events.
+.Sh DESCRIPTION
+.Nm
+is a commandline tool to interactively debug XKB keymaps by listening to X11 events.
 .
-.P
+.Pp
 This requires an X server to be running.
 .
-.P
-Press the Escape key to exit.
+.Pp
+Press the
+.Aq Escape
+key to exit.
 .
-.P
+.Pp
 This is a debugging tool, its behavior or output is not guaranteed to be stable.
 .
-.SH "OPTIONS"
-.
-.TP
-.B \-\-help
+.Bl -tag -width Ds
+.It Fl \-help
 Print help and exit
+.El
 .
-.SH "SEE ALSO"
-\fBxkbcli\fR(1), \fBxkbcli\-interactive\-evdev\fR(1), \fBxkbcli\-interactive\-wayland\fR(1)
-.
-.P
-The
-.UR https://xkbcommon.org
-libxkbcommon online documentation
-.UE
+.Sh SEE ALSO
+.Xr xkbcli 1 ,
+.Xr xkbcli\-interactive\-evdev 1 ,
+.Xr xkbcli\-interactive\-wayland 1 ,
+.Lk https://xkbcommon.org "The libxkbcommon online documentation"

--- a/tools/xkbcli-list.1
+++ b/tools/xkbcli-list.1
@@ -1,44 +1,39 @@
-.TH "XKBCLI\-LIST" "1" "" "" "libxkbcommon manual"
+.Dd July 27, 2020
+.Dt XKBCLI\-LIST 1
+.Os
 .
-.SH "NAME"
-\fBxkbcli\-list\fR \- list available XKB models, layouts, variants and options
+.Sh NAME
+.Nm "xkbcli list"
+.Nd list available XKB models, layouts, variants and options
 .
-.SH "SYNOPSIS"
-\fBxkbcli\fR list [\-\-help] [/path/to/xkbbase [/path/to/xkbbase] ...]
+.Sh SYNOPSIS
+.Nm
+.Op Pa /path/to/xkbbase Oo Pa /path/to/xkbbase Oc ...
 .
-.SH "DESCRIPTION"
-\fBxkbcli list\fR is a commandline tool to list available model, layout, variant and option (MLVO) values from the XKB registry.
+.Sh DESCRIPTION
+.Nm
+is a commandline tool to list available model, layout, variant and option (MLVO) values from the XKB registry.
 .
-.P
-Arguments provided on the commandline are treated as XKB base directory installations.
+.Pp
+Positional arguments provided on the commandline are treated as XKB base directory installations.
 .
-.SH "OPTIONS"
-.
-.TP
-.B \-\-help
+.Bl -tag -width Ds
+.It Fl \-help
 Print help and exit
 .
-.TP
-.B \-v, \-\-verbose
+.It Fl \-verbose
 Increase verbosity, use multiple times for debugging output
 .
-.TP
-.B \-\-ruleset=<name>
+.It Fl \-ruleset Ar name
 Load the ruleset with the given name
 .
-.TP
-.B \-\-skip\-default\-paths
+.It Fl \-skip\-default\-paths
 Do not load the default XKB include paths
 .
-.TP
-.B \-\-load\-exotic
+.It Fl \-load\-exotic
 Load exotic (extra) layouts
+.El
 .
-.SH "SEE ALSO"
-\fBxkbcli\fR(1)
-.
-.P
-The
-.UR https://xkbcommon.org
-libxkbcommon online documentation
-.UE
+.Sh SEE ALSO
+.Xr xkbcli 1 ,
+.Lk https://xkbcommon.org "The libxkbcommon online documentation"

--- a/tools/xkbcli.1
+++ b/tools/xkbcli.1
@@ -1,65 +1,65 @@
-.TH "XKBCLI" "1" "" "" "libxkbcommon manual"
+.Dd July 27, 2020
+.Dt XKBCLI 1
+.Os
 .
-.SH "NAME"
-\fBxkbcli\fR \- tool to interact with XKB keymaps
+.Sh NAME
+.Nm xkbcli
+.Nd tool to interact with XKB keymaps
 .
-.SH "SYNOPSIS"
-\fBxkbcli\fR [\-\-help|\-\-version] <command> [\fIargs\fR]
+.Sh SYNOPSIS
+.Nm
+.Ar command Bo arguments Bc
 .
-.SH "DESCRIPTION"
-\fBxkbcli\fR is a commandline tool to query, compile and test XKB keymaps, layouts and other elements.
+.Nm
+.Op Fl \-help | Fl \-version
 .
-.SH "OPTIONS"
+.Sh DESCRIPTION
+.Nm
+is a commandline tool to query, compile and test XKB keymaps, layouts and other elements.
 .
-.TP
-.B \-\-help
+.Bl -tag -width Ds
+.It Fl \-help
 Print help and exit
 .
-.TP
-.B \-\-version
+.It Fl \-version
 Print the version and exit
+.El
 .
-.SH "COMMANDS"
+.Ss COMMANDS
+.Bl -tag -width Ds
+.It Ic how\-to\-type
+Show how to type a given Unicode codepoint, see
+.Xr xkbcli\-how\-to\-type 1
 .
-.TP
-.B how\-to\-type
-Show how to type a given Unicode codepoint, see \fBxkbcli\-how\-to\-type\fR(1)
+.It Ic interactive\-x11
+Interactive debugger for XKB keymaps for X11, see
+.Xr xkbcli\-interactive\-x11 1
 .
-.TP
-.B interactive\-x11
-Interactive debugger for XKB keymaps for X11, see \fBxbkcli\-interactive\-x11\fR(1)
+.It Ic interactive\-wayland
+Interactive debugger for XKB keymaps for Wayland, see
+.Xr xkbcli\-interactive\-wayland 1
 .
-.TP
-.B interactive\-wayland
-Interactive debugger for XKB keymaps for Wayland, see \fBxkbcli\-interactive\-wayland\fR(1)
+.It Ic interactive\-evdev
+Interactive debugger for XKB keymaps for evdev (Linux), see
+.Xr xkbcli\-interactive\-evdev 1
 .
-.TP
-.B interactive\-evdev
-Interactive debugger for XKB keymaps for evdev (Linux), see \fBxkbcli\-interactive\-evdev\fR
+.It Ic list
+List available layouts and more, see
+.Xr xkbcli\-list 1
+.El
 .
-.TP
-.B list
-List available layouts and more, see \fBxkbcli\-list\fR(1)
-.
-.P
+.Pp
 Note that not all tools may be available on your system.
 .
-.SH "EXIT STATUS"
-.
-.TP
-0
+.Sh EXIT STATUS
+.Bl -tag -compact -width Ds
+.It 0
 exited successfully
-.
-.TP
-1
+.It 1
 an error occured
-.
-.TP
-2
+.It 2
 program was called with invalid arguments
+.El
 .
-.SH "SEE ALSO"
-The
-.UR https://xkbcommon.org
-libxkbcommon online documentation
-.UE
+.Sh SEE ALSO
+.Lk https://xkbcommon.org "The libxkbcommon online documentation"


### PR DESCRIPTION
The mdoc is more semantic and consistent.

Signed-off-by: Ran Benita <ran@unusedvar.com>