### PR TITLE
meson.build: define PATH_MAX where it's missing

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -124,6 +124,14 @@ else
 endif
 have_getopt_long = cc.has_header_symbol('getopt.h', 'getopt_long',
                                         prefix: '#define _GNU_SOURCE')
+if not cc.has_header_symbol('limits.h', 'PATH_MAX', prefix: system_ext_define)
+    if host_machine.system() == 'windows'
+        # see https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#maximum-path-length-limitation
+        configh_data.set('PATH_MAX', 260)
+    else
+        configh_data.set('PATH_MAX', 4096)
+    endif
+endif
 
 # Silence some security & deprecation warnings on MSVC
 # for some unix/C functions we use.

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -42,9 +42,6 @@
 #ifdef _MSC_VER
 #include <io.h>
 #include <windows.h>
-#ifndef PATH_MAX
-#define PATH_MAX MAX_PATH
-#endif
 #else
 #include <unistd.h>
 #include <termios.h>


### PR DESCRIPTION
PATH_MAX not POSIX and can be missing on some systems, notably Windows (which
provides MAX_PATH instead tough) and Hurd. Let's define it to a sane value where
missing, i.e.  the one it's defined as in limits.h

Fixes https://github.com/xkbcommon/libxkbcommon/issues/180