### PR TITLE
xkbcomp: where a keysym cannot be resolved, set it to NoSymbol

### DIFF
--- a/src/xkbcomp/parser.y
+++ b/src/xkbcomp/parser.y
@@ -726,8 +726,10 @@ KeySyms         :       OBRACE KeySymList CBRACE
 
 KeySym          :       IDENT
                         {
-                            if (!resolve_keysym($1, &$$))
+                            if (!resolve_keysym($1, &$$)) {
                                 parser_warn(param, "unrecognized keysym \"%s\"", $1);
+                                $$ = XKB_KEY_NoSymbol;
+                            }
                             free($1);
                         }
                 |       SECTION { $$ = XKB_KEY_section; }

--- a/test/data/symbols/garbage
+++ b/test/data/symbols/garbage
@@ -1,0 +1,14 @@
+default alphanumeric_keys
+xkb_symbols "garbage" {
+    include "us"
+
+    name[Group1]= "My garbage Layout";
+
+    // The garbage keysym will *not* override the corresponding symbol from the
+    // 'us' layout
+    key <TLDE> { [ keysym_is_garbage, exclam ] };
+
+    // AE13 is unused by 'us', use it to avoid fallback to the 'us' definition.
+    // Define with 2 levels but first level is a garbage symbol.
+    key <AE13> { [ keysym_is_garbage, asciitilde ] };
+};


### PR DESCRIPTION
Where resolve_keysym fails we warn but use the otherwise uninitialized variable
as our keysym. That later ends up in the keymap as random garbage hex value.

Simplest test case, set this in the 'us' keymap:
```
    key <TLDE>               {      [        xyz ] };
```
And without this patch we get random garbage:
```
./build/xkbcli-compile-keymap --layout us | grep TLDE:
    key <TLDE>               {      [      0x018a5cf0 ] };
```
With this patch, we now get NoSymbol:
```
./build/xkbcli-compile-keymap --layout us | grep TLDE:
    key <TLDE>               {      [        NoSymbol ] };
```