### PR TITLE
x11: cache X11 atoms

### DIFF
--- a/bench/x11.c
+++ b/bench/x11.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2020 Ran Benita <ran@unusedvar.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "config.h"
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include <xcb/xkb.h>
+
+#include "xkbcommon/xkbcommon.h"
+#include "xkbcommon/xkbcommon-x11.h"
+
+#include "bench.h"
+
+#define BENCHMARK_ITERATIONS 2500
+
+int
+main(void)
+{
+    int ret;
+    xcb_connection_t *conn;
+    int32_t device_id;
+    struct xkb_context *ctx;
+    struct bench bench;
+    char *elapsed;
+
+    conn = xcb_connect(NULL, NULL);
+    if (!conn || xcb_connection_has_error(conn)) {
+        fprintf(stderr, "Couldn't connect to X server: error code %d\n",
+                conn ? xcb_connection_has_error(conn) : -1);
+        ret = -1;
+        goto err_out;
+    }
+
+    ret = xkb_x11_setup_xkb_extension(conn,
+                                      XKB_X11_MIN_MAJOR_XKB_VERSION,
+                                      XKB_X11_MIN_MINOR_XKB_VERSION,
+                                      XKB_X11_SETUP_XKB_EXTENSION_NO_FLAGS,
+                                      NULL, NULL, NULL, NULL);
+    if (!ret) {
+        fprintf(stderr, "Couldn't setup XKB extension\n");
+        goto err_conn;
+    }
+
+    device_id = xkb_x11_get_core_keyboard_device_id(conn);
+    if (device_id == -1) {
+        ret = -1;
+        fprintf(stderr, "Couldn't find core keyboard device\n");
+        goto err_conn;
+    }
+
+    ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    if (!ctx) {
+        ret = -1;
+        fprintf(stderr, "Couldn't create xkb context\n");
+        goto err_conn;
+    }
+
+    bench_start(&bench);
+    for (int i = 0; i < BENCHMARK_ITERATIONS; i++) {
+        struct xkb_keymap *keymap;
+        struct xkb_state *state;
+
+        keymap = xkb_x11_keymap_new_from_device(ctx, conn, device_id,
+                                                XKB_KEYMAP_COMPILE_NO_FLAGS);
+        assert(keymap);
+
+        state = xkb_x11_state_new_from_device(keymap, conn, device_id);
+        assert(state);
+
+        xkb_state_unref(state);
+        xkb_keymap_unref(keymap);
+    }
+    bench_stop(&bench);
+    ret = 0;
+
+    elapsed = bench_elapsed_str(&bench);
+    fprintf(stderr, "retrieved %d keymaps from X in %ss\n",
+            BENCHMARK_ITERATIONS, elapsed);
+    free(elapsed);
+
+    xkb_context_unref(ctx);
+err_conn:
+    xcb_disconnect(conn);
+err_out:
+    return ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/meson.build
+++ b/meson.build
@@ -701,6 +701,13 @@ benchmark(
     executable('bench-compose', 'bench/compose.c', dependencies: test_dep),
     env: bench_env,
 )
+if get_option('enable-x11')
+  benchmark(
+      'x11',
+      executable('bench-x11', 'bench/x11.c', dependencies: x11_test_dep),
+      env: bench_env,
+  )
+endif
 
 
 # Documentation.

--- a/src/context.c
+++ b/src/context.c
@@ -210,6 +210,7 @@ xkb_context_unref(struct xkb_context *ctx)
     if (!ctx || --ctx->refcnt > 0)
         return;
 
+    free(ctx->x11_atom_cache);
     xkb_context_include_path_clear(ctx);
     atom_table_free(ctx->atom_table);
     free(ctx);
@@ -322,6 +323,8 @@ xkb_context_new(enum xkb_context_flags flags)
         xkb_context_unref(ctx);
         return NULL;
     }
+
+    ctx->x11_atom_cache = NULL;
 
     return ctx;
 }

--- a/src/context.h
+++ b/src/context.h
@@ -45,6 +45,9 @@ struct xkb_context {
 
     struct atom_table *atom_table;
 
+    /* Used and allocated by xkbcommon-x11, free()d with the context. */
+    void *x11_atom_cache;
+
     /* Buffer for the *Text() functions. */
     char text_buffer[2048];
     size_t text_next;


### PR DESCRIPTION
On every keymap notify event, the keymap should be refreshed, which fetches the required X11 atoms. A big keymap might have a few hundred of atoms.

A [profile by a user](https://github.com/i3/i3/issues/3924#issuecomment-729890732) has shown this *might* be slow when some intensive amount of keymap activity is occurring. It might also be slow on a remote X server.

While I'm not really sure this is the actual bottleneck, caching the atoms is easy enough and only needs a couple kb of memory, so do that.

On the added bench-x11:

```
Before: retrieved 2500 keymaps from X in 11.233237s
After : retrieved 2500 keymaps from X in 1.592339s
```