### PR TITLE
doc/keymap: add documentation for xkb_symbols

### DIFF
--- a/doc/keymap-format-text-v1.md
+++ b/doc/keymap-format-text-v1.md
@@ -351,6 +351,8 @@ satisfied the LED is lit.
 
 ## The `xkb_symbols` section
 
+NOTE: This section is incomplete.
+
 This section is the fourth to be processed, after `xkb_keycodes`, `xkb_types`
 and `xkb_compat`.
 
@@ -360,21 +362,23 @@ Statements of the form:
         ...
     }
 
-Declares a symbols map named `basic`. Statements inside the curly braces will
-affect only affect the symbol map.
+Declare a symbols map named `basic`. Statements inside the curly braces will
+affect only affect the symbols map.
 
-Options can be specified above the statement, separated by one space:
+A map can have various flags applied to it above the statement, separated by
+whitespace:
 
     partial alphanumeric_keys
     xkb_symbols "basic" {
         ...
     }
 
-The possible options are the following:
+The possible flags are the following:
 
   * `partial` - Indicates that the map doesn't cover a complete keyboard
-  * `default` - Marks the symbol map as the default variant when no variant is
-    specified
+  * `default` - Marks the symbol map as the default map in the file when no
+  explicit map is specified. If no map is marked as a default, the first map in
+  the file is the default.
   * `hidden` - Variant that can only be used internally
   * `alphanumeric_keys` - Indicates that the map contains alphanumeric keys
   * `modifier_keys` - Indicates that the map contains modifier keys
@@ -383,18 +387,25 @@ The possible options are the following:
   * `alternate_group` - Indicates that the map contains keys for an alternate
     group
 
-If no `*_keys` options is supplied, then the map is assumed to cover a complete
+If no `*_keys` flags are supplied, then the map is assumed to cover a complete
 keyboard.
+
+At present, except for `default`, none of the flags affect key processing in
+libxkbcommon, and only serve as metadata.
 
 ### Name statements
 
 Statements of the form:
 
     name[Group1] = "US/ASCII";
+    groupName[1] = "US/ASCII";
 
 Gives the name "US/ASCII" to the first group of symbols. Other groups can be
 named using a different group index (ex: `Group2`), and with a different name.
 A group must be named.
+
+`group` and `groupName` mean the same thing, and the `Group` in `Group1` is
+optional.
 
 ### Include statements
 
@@ -402,10 +413,10 @@ Statements of the form:
 
     include "nokia_vndr/rx-51(nordic_base)
 
-Will include data from another `xkb_symbols` section, located in another file.
-Here it would include the `xkb_symbols` section called `nordic_base`, from the
-file `rx-51` located in the `nokia_vndr` folder, itself located in the
-`/usr/share/X11` folder.
+Will include data from another `xkb_symbols` section, possibly located in
+another file. Here it would include the `xkb_symbols` section called
+`nordic_base`, from the file `rx-51` located in the `nokia_vndr` folder, itself
+located in an XKB include path.
 
 ### Key statement
 
@@ -418,9 +429,10 @@ symbols are `q` and `Q` in this example.
 
 The possible keycodes are the keycodes defined in the `xkb_keycodes` section.
 
-Symbols are named using the symbolic names from the `keysymdef.h` file. A group
-of symbols is enclosed in brackets and separated by commas. Each element of the
-symbol arrays corresponds to a different modifier level.
+Symbols are named using the symbolic names from the
+`xkbcommon/xkbcommon-keysyms.h` file. A group of symbols is enclosed in brackets
+and separated by commas. Each element of the symbol arrays corresponds to a
+different modifier level.
 
 #### Groups
 
@@ -440,7 +452,7 @@ The long-form syntax can also be used to represent groups:
     };
 
 Groups can also be omitted, but the brackets must be present. The following
-statement will only defines the Group3 of a mapping
+statement only defines the Group3 of a mapping:
 
     key <AD01> { [], [], [ q, Q ] };
 

--- a/doc/keymap-format-text-v1.md
+++ b/doc/keymap-format-text-v1.md
@@ -351,11 +351,98 @@ satisfied the LED is lit.
 
 ## The `xkb_symbols` section
 
-This section is the fourth to be processed, after `xkb_keycodes`,
-`xkb_types` and `xkb_compat`.
+This section is the fourth to be processed, after `xkb_keycodes`, `xkb_types`
+and `xkb_compat`.
 
-TODO
+Statements of the form:
 
+    xkb_symbols "basic" {
+        ...
+    }
+
+Declares a symbols map named `basic`. Statements inside the curly braces will
+affect only affect the symbol map.
+
+Options can be specified above the statement, separated by one space:
+
+    partial alphanumeric_keys
+    xkb_symbols "basic" {
+        ...
+    }
+
+The possible options are the following:
+
+  * `partial` - Indicates that the map doesn't cover a complete keyboard
+  * `default` - Marks the symbol map as the default variant when no variant is
+    specified
+  * `hidden` - Variant that can only be used internally
+  * `alphanumeric_keys` - Indicates that the map contains alphanumeric keys
+  * `modifier_keys` - Indicates that the map contains modifier keys
+  * `keypad_keys` - Indicates that the map contains keypad keys
+  * `function_keys` - Indicates that the map contains function keys
+  * `alternate_group` - Indicates that the map contains keys for an alternate
+    group
+
+If no `*_keys` options is supplied, then the map is assumed to cover a complete
+keyboard.
+
+### Name statements
+
+Statements of the form:
+
+    name[Group1] = "US/ASCII";
+
+Gives the name "US/ASCII" to the first group of symbols. Other groups can be
+named using a different group index (ex: `Group2`), and with a different name.
+A group must be named.
+
+### Include statements
+
+Statements of the form:
+
+    include "nokia_vndr/rx-51(nordic_base)
+
+Will include data from another `xkb_symbols` section, located in another file.
+Here it would include the `xkb_symbols` section called `nordic_base`, from the
+file `rx-51` located in the `nokia_vndr` folder, itself located in the
+`/usr/share/X11` folder.
+
+### Key statement
+
+Statements of the form:
+
+    key <AD01> { [ q, Q ] };
+
+Describes the mapping of a keycode `<AD01>` to a given group of symbols. The
+symbols are `q` and `Q` in this example.
+
+The possible keycodes are the keycodes defined in the `xkb_keycodes` section.
+
+Symbols are named using the symbolic names from the `keysymdef.h` file. A group
+of symbols is enclosed in brackets and separated by commas. Each element of the
+symbol arrays corresponds to a different modifier level.
+
+#### Groups
+
+Each group represents a list of symbols mapped to a keycode:
+
+    name[Group1]= "US/ASCII";
+    name[Group2]= "Russian";
+    ...
+    key <AD01> { [ q, Q ],
+                 [ Cyrillic_shorti, Cyrillic_SHORTI ] };
+
+The long-form syntax can also be used to represent groups:
+
+    key <AD01> {
+        symbols[Group1]= [ q, Q ],
+        symbols[Group2]= [ Cyrillic_shorti, Cyrillic_SHORTI ]
+    };
+
+Groups can also be omitted, but the brackets must be present. The following
+statement will only defines the Group3 of a mapping
+
+    key <AD01> { [], [], [ q, Q ] };
 
 ## Virtual modifier statements
 
@@ -366,3 +453,4 @@ Statements of the form:
 Can appear in the `xkb_types`, `xkb_compat`, `xkb_symbols` sections.
 
 TODO
+


### PR DESCRIPTION
Fixes #198 

I apologise in advance for the grammatical mistakes, English is not my main language. I took the content from [An Unreliable Guide to XKB Configuration][1] and reworded most of it.

[1]: https://www.charvolant.org/doug/xkb/
