### PR TITLE
Fix failing evdev-interactive test cases

### DIFF
--- a/test/tool-option-parsing.py
+++ b/test/tool-option-parsing.py
@@ -261,7 +261,7 @@ class TestXkbcli(unittest.TestCase):
     def test_interactive_evdev_rmlvo(self):
         for rmlvo in rmlvos:
             with self.subTest(rmlvo=rmlvo):
-                self.xkbcli_interactive_evdev.run_command_success(rmlvos)
+                self.xkbcli_interactive_evdev.run_command_success(rmlvo)
 
     def test_interactive_evdev(self):
         # Note: --enable-compose fails if $prefix doesn't have the compose tables

--- a/test/tool-option-parsing.py
+++ b/test/tool-option-parsing.py
@@ -31,8 +31,19 @@ import tempfile
 import unittest
 
 
-top_builddir = os.environ['top_builddir']
-top_srcdir = os.environ['top_srcdir']
+try:
+    top_builddir = os.environ['top_builddir']
+    top_srcdir = os.environ['top_srcdir']
+except KeyError:
+    print('Required environment variables not found: top_srcdir/top_builddir', file=sys.stderr)
+    from pathlib import Path
+    top_srcdir = '.'
+    try:
+        top_builddir = next(Path('.').glob('**/meson-logs/')).parent
+    except StopIteration:
+        sys.exit(1)
+    print('Using srcdir "{}", builddir "{}"'.format(top_srcdir, top_builddir), file=sys.stderr)
+
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger('test')


### PR DESCRIPTION
Just a typo. whoops.

Together with a change to make this test easier to run from the git tree.

Fixes #206 