### PR TITLE
Reduce number of X11 round trips

### DIFF
--- a/src/x11/keymap.c
+++ b/src/x11/keymap.c
@@ -893,8 +893,10 @@ get_type_names(struct xkb_keymap *keymap, struct x11_atom_interner *interner,
         ALLOC_OR_FAIL(type->level_names, type->num_levels);
 
         x11_atom_interner_adopt_atom(interner, wire_type_name, &type->name);
-        x11_atom_interner_adopt_atoms(interner, kt_level_names_iter,
-                                     type->level_names, wire_num_levels);
+        for (size_t j = 0; j < wire_num_levels; j++) {
+            x11_atom_interner_adopt_atom(interner, kt_level_names_iter[j],
+                                         &type->level_names[j]);
+        }
 
         type->num_level_names = type->num_levels;
         kt_level_names_iter += wire_num_levels;
@@ -975,7 +977,10 @@ get_group_names(struct xkb_keymap *keymap, struct x11_atom_interner *interner,
     keymap->num_group_names = msb_pos(reply->groupNames);
     ALLOC_OR_FAIL(keymap->group_names, keymap->num_group_names);
 
-    x11_atom_interner_adopt_atoms(interner, iter, keymap->group_names, length);
+    for (size_t i = 0; i < length; i++) {
+        x11_atom_interner_adopt_atom(interner, iter[i],
+                                     &keymap->group_names[i]);
+    }
 
     return true;
 

--- a/src/x11/keymap.c
+++ b/src/x11/keymap.c
@@ -1079,36 +1079,21 @@ get_names(struct xkb_keymap *keymap, struct x11_atom_interner *interner,
                                         reply->which,
                                         &list);
 
-    xcb_get_atom_name_cookie_t cookies[4];
-    get_atom_name(conn, list.keycodesName, &cookies[0]);
-    get_atom_name(conn, list.symbolsName, &cookies[1]);
-    get_atom_name(conn, list.typesName, &cookies[2]);
-    get_atom_name(conn, list.compatName, &cookies[3]);
-
-    /* We need to ensure all replies are collected and thus no short-circuit */
-    bool atom_success = true;
-    atom_success &= get_atom_name_reply(conn, list.keycodesName, cookies[0],
-                                        &keymap->keycodes_section_name);
-    atom_success &= get_atom_name_reply(conn, list.symbolsName, cookies[1],
-                                        &keymap->symbols_section_name);
-    atom_success &= get_atom_name_reply(conn, list.typesName, cookies[2],
-                                        &keymap->types_section_name);
-    atom_success &= get_atom_name_reply(conn, list.compatName, cookies[3],
-                                        &keymap->compat_section_name);
-
-    if (!atom_success ||
-        !get_type_names(keymap, interner, reply, &list) ||
+    x11_atom_interner_get_escaped_atom_name(interner, list.keycodesName,
+                                            &keymap->keycodes_section_name);
+    x11_atom_interner_get_escaped_atom_name(interner, list.symbolsName,
+                                            &keymap->symbols_section_name);
+    x11_atom_interner_get_escaped_atom_name(interner, list.typesName,
+                                            &keymap->types_section_name);
+    x11_atom_interner_get_escaped_atom_name(interner, list.compatName,
+                                            &keymap->compat_section_name);
+    if (!get_type_names(keymap, interner, reply, &list) ||
         !get_indicator_names(keymap, interner, reply, &list) ||
         !get_vmod_names(keymap, interner, reply, &list) ||
         !get_group_names(keymap, interner, reply, &list) ||
         !get_key_names(keymap, conn, reply, &list) ||
         !get_aliases(keymap, conn, reply, &list))
         goto fail;
-
-    XkbEscapeMapName(keymap->keycodes_section_name);
-    XkbEscapeMapName(keymap->symbols_section_name);
-    XkbEscapeMapName(keymap->types_section_name);
-    XkbEscapeMapName(keymap->compat_section_name);
 
     free(reply);
     return true;

--- a/src/x11/util.c
+++ b/src/x11/util.c
@@ -124,20 +124,31 @@ xkb_x11_get_core_keyboard_device_id(xcb_connection_t *conn)
     return device_id;
 }
 
-bool
-get_atom_name(xcb_connection_t *conn, xcb_atom_t atom, char **out)
+void
+get_atom_name(xcb_connection_t *conn, xcb_atom_t atom,
+              xcb_get_atom_name_cookie_t *cookie)
 {
-    xcb_get_atom_name_cookie_t cookie;
+    if (atom == 0) {
+        cookie->sequence = 0;
+    } else {
+        *cookie = xcb_get_atom_name(conn, atom);
+    }
+}
+
+bool
+get_atom_name_reply(xcb_connection_t *conn, xcb_atom_t atom,
+                    xcb_get_atom_name_cookie_t cookie, char **out)
+{
     xcb_get_atom_name_reply_t *reply;
     int length;
     char *name;
 
     if (atom == 0) {
         *out = NULL;
+        assert(cookie.sequence == 0);
         return true;
     }
 
-    cookie = xcb_get_atom_name(conn, atom);
     reply = xcb_get_atom_name_reply(conn, cookie, NULL);
     if (!reply)
         return false;

--- a/src/x11/util.c
+++ b/src/x11/util.c
@@ -212,16 +212,6 @@ retry:
     interner->pending[idx].cookie = xcb_get_atom_name(interner->conn, atom);
 }
 
-void
-x11_atom_interner_adopt_atoms(struct x11_atom_interner *interner,
-                              const xcb_atom_t *from, xkb_atom_t *to,
-                              size_t count)
-{
-    for (size_t i = 0; i < count; i++) {
-        x11_atom_interner_adopt_atom(interner, from[i], &to[i]);
-    }
-}
-
 void x11_atom_interner_round_trip(struct x11_atom_interner *interner) {
     struct xkb_context *ctx = interner->ctx;
     xcb_connection_t *conn = interner->conn;

--- a/src/x11/x11-priv.h
+++ b/src/x11/x11-priv.h
@@ -29,9 +29,15 @@
 #include "keymap.h"
 #include "xkbcommon/xkbcommon-x11.h"
 
+/* Preparation for get_atom_name_reply() */
+void
+get_atom_name(xcb_connection_t *conn, xcb_atom_t atom,
+              xcb_get_atom_name_cookie_t *cookie);
+
 /* Get a strdup'd name of an X atom. */
 bool
-get_atom_name(xcb_connection_t *conn, xcb_atom_t atom, char **out);
+get_atom_name_reply(xcb_connection_t *conn, xcb_atom_t atom,
+                    xcb_get_atom_name_cookie_t cookie, char **out);
 
 struct x11_atom_interner {
     struct xkb_context *ctx;

--- a/src/x11/x11-priv.h
+++ b/src/x11/x11-priv.h
@@ -69,12 +69,6 @@ void
 x11_atom_interner_adopt_atom(struct x11_atom_interner *interner,
                              const xcb_atom_t atom, xkb_atom_t *out);
 
-
-void
-x11_atom_interner_adopt_atoms(struct x11_atom_interner *interner,
-                              const xcb_atom_t *from, xkb_atom_t *to,
-                              size_t count);
-
 /*
  * Get a strdup'd and XkbEscapeMapName'd name of an X atom. The actual write is
  * delayed until the next call to x11_atom_interner_round_trip().

--- a/src/x11/x11-priv.h
+++ b/src/x11/x11-priv.h
@@ -33,22 +33,44 @@
 bool
 get_atom_name(xcb_connection_t *conn, xcb_atom_t atom, char **out);
 
-/*
- * Make a xkb_atom_t's from X atoms (prefer to send as many as possible
- * at once, to avoid many roundtrips).
- *
- * TODO: We can make this more flexible, such that @to doesn't have to
- *       be sequential. Then we can convert most adopt_atom() calls to
- *       adopt_atoms().
- *       Atom caching would also likely be useful for avoiding quite a
- *       few requests.
- */
-bool
-adopt_atoms(struct xkb_context *ctx, xcb_connection_t *conn,
-            const xcb_atom_t *from, xkb_atom_t *to, size_t count);
+struct x11_atom_interner {
+    struct xkb_context *ctx;
+    xcb_connection_t *conn;
+    bool had_error;
+    /* Atoms for which we send a GetAtomName request */
+    struct {
+        xcb_atom_t from;
+        xkb_atom_t *out;
+        xcb_get_atom_name_cookie_t cookie;
+    } pending[128];
+    size_t num_pending;
+    /* Atoms which were already pending but queried again */
+    struct {
+        xcb_atom_t from;
+        xkb_atom_t *out;
+    } copies[128];
+    size_t num_copies;
+};
 
-bool
-adopt_atom(struct xkb_context *ctx, xcb_connection_t *conn, xcb_atom_t atom,
-           xkb_atom_t *out);
+void
+x11_atom_interner_init(struct x11_atom_interner *interner,
+                       struct xkb_context *ctx, xcb_connection_t *conn);
+
+void
+x11_atom_interner_round_trip(struct x11_atom_interner *interner);
+
+/*
+ * Make a xkb_atom_t's from X atoms. The actual write is delayed until the next
+ * call to x11_atom_interner_round_trip() or when too many atoms are pending.
+ */
+void
+x11_atom_interner_adopt_atom(struct x11_atom_interner *interner,
+                             const xcb_atom_t atom, xkb_atom_t *out);
+
+
+void
+x11_atom_interner_adopt_atoms(struct x11_atom_interner *interner,
+                              const xcb_atom_t *from, xkb_atom_t *to,
+                              size_t count);
 
 #endif


### PR DESCRIPTION
This is my attempt at fixing #216.

As written there, before this PR I got this output and saw 78 round trips just for `xkb_x11_keymap_new_from_device`:

```
Needed 0.104062 for xcb_connect()
Needed 0.201753 for xkb_x11_setup_xkb_extension()
Needed 0.100868 for xkb_x11_get_core_keyboard_device_id()
Needed 7.851895 for xkb_x11_keymap_new_from_device()
Needed 0.100844 for xkb_x11_state_new_from_device()
Needed 0.003317 for xkb_keymap_get_as_string()
Needed 0.000224 for cleanup()
```

With this PR, my output is (and there are only three round trips for `new_from_device`):

```
Needed 0.104250 for xcb_connect()
Needed 0.201609 for xkb_x11_setup_xkb_extension()
Needed 0.100910 for xkb_x11_get_core_keyboard_device_id()
Needed 0.348044 for xkb_x11_keymap_new_from_device()
Needed 0.100926 for xkb_x11_state_new_from_device()
Needed 0.003080 for xkb_keymap_get_as_string()
Needed 0.000198 for cleanup()
```

Via gdb I looked at where the round trips during `test/x11` happen (just have the TCP proxy delay things by a second and then you have enough time to `ctrl+c` and `bt` in gdb to see where the test is waiting):
1. `xcb_connect` needs one round trip to set up the connection
2. Using the XKB extension requires a round trip in `xcb_get_extension_data` for the QueryExtension reply (this is internal to libxcb)
3. `xkb_x11_setup_xkb_extension` sends an XKB UseExtension request and waits for the reply
4. `xkb_x11_get_core_keyboard_device_id` obviously needs one round trip
5. the requests in `xkb_x11_keymap_new_from_device` need a round trip (the backtrace actually points at waiting for the XKB GetMap reply) [this is the first round trip in `xkb_x11_keymap_new_from_device`
6. getting the atom names in `get_names()` uses a round trip
7. getting the atom names in `x11_atom_interner_round_trip()` uses a round trip [this is the last round trip from `xkb_x11_keymap_new_from_device`]
8. `xkb_x11_state_new_from_device()` needs a round trip for an XKB GetState request

The above looks quite good. It would be possible to merge get GetAtomName stuff in step 6 and 7 in a single round trip, but at this point I stop caring. I got `xkb_x11_keymap_new_from_device` down from 78 round trips to three. Getting this down to the theoretical minimum of two round trips is left as an exercise to the reader. ;-)

## Thoughts on correctness

- I am fairly sure that the code does not actually look at any of the atoms and hence my approach to batch `GetAtomName` requests should not cause issue. Still, please double-check this.
- The new error handling here is obviously untested. To simplify the error handling, I no longer "bail out" after the first error (which would require doing the right amount of `xcb_discard_reply()` calls), but instead continue through and only "bail out" at the end. IMHO this should not be much of a downside.

I tried to follow the coding style of the surrounding code, but I did not try too hard. Feel free to tell me how to change things so that they better fit.