### PR TITLE
interactive-evdev: switch from epoll(2) to poll(2)

### DIFF
--- a/tools/xkbcli-interactive-evdev.1
+++ b/tools/xkbcli-interactive-evdev.1
@@ -14,7 +14,7 @@
 .Nm
 is a commandline tool to interactively debug XKB keymaps by listening to
 .Pa /dev/input/eventX
-evdev devices (Linux).
+evdev devices.
 .
 .Pp
 .Nm

--- a/tools/xkbcli.1
+++ b/tools/xkbcli.1
@@ -40,7 +40,7 @@ Interactive debugger for XKB keymaps for Wayland, see
 .Xr xkbcli\-interactive\-wayland 1
 .
 .It Ic interactive\-evdev
-Interactive debugger for XKB keymaps for evdev (Linux), see
+Interactive debugger for XKB keymaps for evdev, see
 .Xr xkbcli\-interactive\-evdev 1
 .
 .It Ic list

--- a/tools/xkbcli.c
+++ b/tools/xkbcli.c
@@ -55,7 +55,7 @@ usage(void)
 #endif
 #if HAVE_XKBCLI_INTERACTIVE_EVDEV
            "  interactive-evdev\n"
-           "    Interactive debugger for XKB keymaps for evdev (Linux)\n"
+           "    Interactive debugger for XKB keymaps for evdev\n"
            "\n"
 #endif
 #if HAVE_XKBCLI_COMPILE_KEYMAP


### PR DESCRIPTION
Turns out FreeBSD supports evdev, so this toll can work on it; however
it does not support epoll, so switch to poll, which is portable.

Reported-by: Evgeniy Khramtsov <evgeniy@khramtsov.org>
Signed-off-by: Ran Benita <ran@unusedvar.com>