### PR TITLE
US-intl AC11 key is broken.

### DIFF
--- a/test/data/symbols/us
+++ b/test/data/symbols/us
@@ -125,7 +125,7 @@ xkb_symbols "intl" {
 
     key <AC09> { [	   l,          L,        oslash,         Ooblique ] };
     key <AC10> { [ semicolon,      colon,     paragraph,           degree ] };
-    key <AC11> { [dead_acute, dead_diaeresis, apostrophe,        quotedbl ] };
+    key <AC11> { [dead_apostrophe, dead_quotedbl, dead_acute, dead_diaeresis ] };
 
     key <AB01> { [	   z,          Z,            ae,               AE ] };
     key <AB02> { [	   x,          X,             x,                X ] };


### PR DESCRIPTION
Recent upgrade in Arch package showed that for the US Intl layout, configuration is broken.
While typing the AC11 deadkey, you will obtain  `´` instead of `'`
I´m not sure to fully understand the code but maybe changing the order of this file might resolve this issue.