### PR TITLE
x11: fix xkb_x11_keymap_new_from_device failing when a level name is empty

### DIFF
--- a/src/x11/util.c
+++ b/src/x11/util.c
@@ -169,7 +169,10 @@ void
 x11_atom_interner_adopt_atom(struct x11_atom_interner *interner,
                              const xcb_atom_t atom, xkb_atom_t *out)
 {
-    *out = 0;
+    *out = XKB_ATOM_NONE;
+
+    if (atom == XCB_ATOM_NONE)
+        return;
 
     /* Can be NULL in case the malloc failed. */
     struct x11_atom_cache *cache = get_cache(interner->ctx, interner->conn);


### PR DESCRIPTION
The numpad:mac option doesn't specify a name for the first level:

    // On Mac keypads, level 1 and 2 are swapped.
    partial xkb_types "mac" {
        type "KEYPAD" {
            modifiers = None;
            map[None] = Level2;
            level_name[Level2] = "Number";
        };
        include "extra(keypad)"
    };

This means the atom for level name is XCB_ATOM_NONE. We tried to get its
name, which fails. This regressed in 40c00b472144d1684d2fb97cafef39.

Instead, translate it to XKB_ATOM_NONE, same as the previous behavior.

Fixes: https://github.com/xkbcommon/libxkbcommon/issues/229
Signed-off-by: Ran Benita <ran@unusedvar.com>