### PR TITLE
doc: fix user-configuration sample file

### DIFF
--- a/doc/user-configuration.md
+++ b/doc/user-configuration.md
@@ -197,8 +197,10 @@ $ cat $XDG_CONFIG_HOME/xkb/rules/evdev.xml
             <name>orange</name>
             <shortDescription>or</shortDescription>
             <description>Orange (Banana)</description>
-          </variant>
+          </configItem>
+        </variant>
       </variantList>
+    </layout>
   </layoutList>
   <optionList>
     <group allowMultipleSelection="true">


### PR DESCRIPTION
Support copy-pasting from the docs to get something functional.
Parsing errors may end up in the journal, where they are not super easy to find.