### PR TITLE
change the xkbcli list output to YAML

### DIFF
--- a/tools/registry-list.c
+++ b/tools/registry-list.c
@@ -136,11 +136,13 @@ main(int argc, char **argv)
         goto err;
     }
 
-    printf("Models:\n");
+    printf("models:\n");
     m = rxkb_model_first(ctx);
     assert(m); /* Empty model list is usually a bug or a bad xml file */
     while (m) {
-        printf("- %s:%s:%s\n",
+        printf("- name: %s\n"
+               "  vendor: %s\n"
+               "  description: %s\n",
                rxkb_model_get_name(m),
                rxkb_model_get_vendor(m),
                rxkb_model_get_description(m));
@@ -148,7 +150,7 @@ main(int argc, char **argv)
     }
 
     printf("\n");
-    printf("Layouts:\n");
+    printf("layouts:\n");
     l = rxkb_layout_first(ctx);
     assert(l); /* Empty layout list is usually a bug or a bad xml file */
     while (l) {
@@ -157,56 +159,62 @@ main(int argc, char **argv)
         const char *variant = rxkb_layout_get_variant(l);
         const char *brief = rxkb_layout_get_brief(l);
 
-        printf("- %s%s%s%s:%s:%s",
+        printf("- layout: %s\n"
+               "  variant: %s\n"
+               "  brief: %s\n"
+               "  description: %s\n",
                rxkb_layout_get_name(l),
-               variant ? "(" : "",
-               variant ? variant : "",
-               variant ? ")" : "",
-               brief ? brief : "",
+               variant ? variant : "''",
+               brief ? brief : "''",
                rxkb_layout_get_description(l));
 
+        printf("  iso639: [");
         iso639 = rxkb_layout_get_iso639_first(l);
         if (iso639) {
             const char *sep = "";
-            printf(":iso639-");
             while (iso639) {
                 printf("%s%s", sep, rxkb_iso639_code_get_code(iso639));
                 iso639 = rxkb_iso639_code_next(iso639);
-                sep = ",";
+                sep = ", ";
             }
         }
+        printf("]\n");
+        printf("  iso3166: [");
         iso3166 = rxkb_layout_get_iso3166_first(l);
         if (iso3166) {
             const char *sep = "";
-            printf(":iso3166-");
             while (iso3166) {
                 printf("%s%s", sep, rxkb_iso3166_code_get_code(iso3166));
                 iso3166 = rxkb_iso3166_code_next(iso3166);
-                sep = ",";
+                sep = ", ";
             }
         }
-
-        printf("\n");
+        printf("]\n");
         l = rxkb_layout_next(l);
     }
     printf("\n");
-    printf("Options:\n");
+    printf("option_groups:\n");
     g = rxkb_option_group_first(ctx);
     assert(g); /* Empty option goups list is usually a bug or a bad xml file */
     while (g) {
         struct rxkb_option *o;
 
-        printf("- %s:%s (%s)\n",
+        printf("- name: %s\n"
+               "  description: %s\n"
+               "  allows_multiple: %s\n"
+               "  options:\n",
                rxkb_option_group_get_name(g),
                rxkb_option_group_get_description(g),
-               rxkb_option_group_allows_multiple(g) ? "multiple" : "single");
+               rxkb_option_group_allows_multiple(g) ? "true" : "false");
 
         o = rxkb_option_first(g);
         assert(o); /* Empty option list is usually a bug or a bad xml file */
         while (o) {
             const char *brief = rxkb_option_get_brief(o);
 
-            printf("  - %s:%s:%s\n",
+            printf("  - name: '%s'\n"
+                   "    brief: '%s'\n"
+                   "    description: '%s'\n",
                    rxkb_option_get_name(o),
                    brief ? brief : "",
                    rxkb_option_get_description(o));

--- a/tools/registry-list.c
+++ b/tools/registry-list.c
@@ -156,7 +156,6 @@ main(int argc, char **argv)
         struct rxkb_iso3166_code *iso3166;
         const char *variant = rxkb_layout_get_variant(l);
         const char *brief = rxkb_layout_get_brief(l);
-        bool first;
 
         printf("- %s%s%s%s:%s:%s",
                rxkb_layout_get_name(l),
@@ -167,22 +166,24 @@ main(int argc, char **argv)
                rxkb_layout_get_description(l));
 
         iso639 = rxkb_layout_get_iso639_first(l);
-        if (iso639)
+        if (iso639) {
+            const char *sep = "";
             printf(":iso639-");
-        first = true;
-        while (iso639) {
-            printf("%s%s", first ? "" : ",", rxkb_iso639_code_get_code(iso639));
-            iso639 = rxkb_iso639_code_next(iso639);
-            first = false;
+            while (iso639) {
+                printf("%s%s", sep, rxkb_iso639_code_get_code(iso639));
+                iso639 = rxkb_iso639_code_next(iso639);
+                sep = ",";
+            }
         }
         iso3166 = rxkb_layout_get_iso3166_first(l);
-        if (iso3166)
+        if (iso3166) {
+            const char *sep = "";
             printf(":iso3166-");
-        first = true;
-        while (iso3166) {
-            printf("%s%s", first ? "" : ",", rxkb_iso3166_code_get_code(iso3166));
-            iso3166 = rxkb_iso3166_code_next(iso3166);
-            first = false;
+            while (iso3166) {
+                printf("%s%s", sep, rxkb_iso3166_code_get_code(iso3166));
+                iso3166 = rxkb_iso3166_code_next(iso3166);
+                sep = ",";
+            }
         }
 
         printf("\n");


### PR DESCRIPTION
We have a lot of keyboard layouts and the current output format is virtually
useless at searching for a specific one to debug any issues with either the
layout list or the output from libxkbregistry.

Let's use YAML instead because that can easily be post-processed to extract the
specific layouts wanted, e.g. to get the list of all layouts:
  `xkbcli-list | yq -r ".layouts[].layout"`
to get the list of all variants of the "us" layout:
  `xkbcli-list | yq -r '.layouts[] | select(.layout == "us") | .variant`
and the number of option groups:
  `xkbcli-list | yq -r '.option_groups[] | length'`

Note that the top-level nodes have been de-capitalized, so where it was "Models"
before it is now "models" and the "Options" node is now "option_groups".

**Note:** this is a breaking change, but I'm not sure anyone cares. Plus, anyone who does care is up-to-date enough that they can switch their code around ;)