### PR TITLE
Meson: Allow building as subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -253,8 +253,11 @@ install_headers(
     'xkbcommon/xkbcommon-names.h',
     subdir: 'xkbcommon',
 )
+
+# This variable may be used to build as a subproject and should not be renamed.
 libxkbcommon_dep = declare_dependency(
     link_with: libxkbcommon,
+    include_directories: include_directories('.'),
 )
 pkgconfig.generate(
     libxkbcommon,
@@ -310,8 +313,10 @@ You can disable X11 support with -Denable-x11=false.''')
         'xkbcommon/xkbcommon-x11.h',
         subdir: 'xkbcommon',
     )
+    # This variable may be used to build as a subproject and should not be renamed.
     libxkbcommon_x11_dep = declare_dependency(
         link_with: libxkbcommon_x11,
+        include_directories: include_directories('.'),
     )
     pkgconfig.generate(
         libxkbcommon_x11,
@@ -363,8 +368,9 @@ if get_option('enable-xkbregistry')
         description: 'XKB API to query available rules, models, layouts, variants and options',
     )
 
-    dep_libxkbregistry = declare_dependency(
-                                include_directories: include_directories('xkbcommon'),
+    # This variable may be used to build as a subproject and should not be renamed.
+    libxkbregistry_dep = declare_dependency(
+                                include_directories: include_directories('.'),
                                 link_with: libxkbregistry
                                 )
 endif
@@ -477,7 +483,7 @@ You can disable the Wayland xkbcli programs with -Denable-wayland=false.''')
         configh_data.set10('HAVE_XKBCLI_LIST', true)
         executable('xkbcli-list',
                    'tools/registry-list.c',
-                   dependencies: dep_libxkbregistry,
+                   dependencies: libxkbregistry_dep,
                    install: true,
                    install_dir: dir_libexec)
         install_man('tools/xkbcli-list.1')
@@ -648,7 +654,7 @@ if get_option('enable-xkbregistry')
         'registry',
         executable('test-registry', 'test/registry.c',
                    include_directories: include_directories('src'),
-                   dependencies: dep_libxkbregistry),
+                   dependencies: libxkbregistry_dep),
         env: test_env,
     )
 endif


### PR DESCRIPTION
Specify where to find the headers for `libxkbcommon_dep`, which allows other projects to correctly locate the headers when `libxkbcommon` is being built as a Meson subproject.