### PR TITLE
Windows: Pass list of symbols to export to MSVC

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -152,6 +152,7 @@ have_version_script = cc.links(
     name: '-Wl,--version-script',
 )
 
+map_to_def = find_program('scripts/map-to-def')
 
 # libxkbcommon.
 # Note: we use some yacc extensions, which work with either GNU bison
@@ -231,15 +232,25 @@ libxkbcommon_sources = [
     'src/utils.h',
 ]
 libxkbcommon_link_args = []
+libxkbcommon_link_deps = []
 if have_version_script
     libxkbcommon_link_args += '-Wl,--version-script=' + meson.source_root()/'xkbcommon.map'
+    libxkbcommon_link_deps += 'xkbcommon.map'
+elif cc.get_argument_syntax() == 'msvc'
+    libxkbcommon_def = custom_target('xkbcommon.def',
+        command: [map_to_def, '@INPUT@', '@OUTPUT@'],
+        input: 'xkbcommon.map',
+        output: 'kxbcommon.def',
+    )
+    libxkbcommon_link_deps += libxkbcommon_def
+    libxkbcommon_link_args += '/DEF:' + libxkbcommon_def.full_path()
 endif
 libxkbcommon = library(
     'xkbcommon',
     'xkbcommon/xkbcommon.h',
     libxkbcommon_sources,
     link_args: libxkbcommon_link_args,
-    link_depends: 'xkbcommon.map',
+    link_depends: libxkbcommon_link_deps,
     gnu_symbol_visibility: 'hidden',
     version: '0.0.0',
     install: true,
@@ -287,15 +298,25 @@ You can disable X11 support with -Denable-x11=false.''')
         'src/atom.c',
     ]
     libxkbcommon_x11_link_args = []
+    libxkbcommon_x11_link_deps = []
     if have_version_script
         libxkbcommon_x11_link_args += '-Wl,--version-script=' + meson.source_root()/'xkbcommon-x11.map'
+        libxkbcommon_x11_link_deps += 'xkbcommon-x11.map'
+    elif cc.get_argument_syntax() == 'msvc'
+        libxkbcommon_x11_def = custom_target('xkbcommon-x11.def',
+            command: [map_to_def, '@INPUT@', '@OUTPUT@'],
+            input: 'xkbcommon-x11.map',
+            output: 'xkbcommon-x11.def',
+        )
+        libxkbcommon_x11_link_deps += libxkbcommon_x11_def
+        libxkbcommon_x11_link_args += '/DEF:' + libxkbcommon_x11_def.full_path()
     endif
     libxkbcommon_x11 = library(
         'xkbcommon-x11',
         'xkbcommon/xkbcommon-x11.h',
         libxkbcommon_x11_sources,
         link_args: libxkbcommon_x11_link_args,
-        link_depends: 'xkbcommon-x11.map',
+        link_depends: libxkbcommon_x11_link_deps,
         gnu_symbol_visibility: 'hidden',
         version: '0.0.0',
         install: true,
@@ -336,15 +357,25 @@ if get_option('enable-xkbregistry')
         'src/util-list.c',
     ]
     libxkbregistry_link_args = []
+    libxkbregistry_link_deps = []
     if have_version_script
         libxkbregistry_link_args += '-Wl,--version-script=' + meson.source_root()/'xkbregistry.map'
+        libxkbregistry_link_deps += 'xkbregistry.map'
+    elif cc.get_argument_syntax() == 'msvc'
+        libxkbregistry_def = custom_target('xkbregistry.def',
+            command: [map_to_def, '@INPUT@', '@OUTPUT@'],
+            input: 'xkbregistry.map',
+            output: 'xkbregistry.def',
+        )
+        libxkbregistry_link_deps += libxkbregistry_def
+        libxkbregistry_link_args += '/DEF:' + libxkbregistry_def.full_path()
     endif
     libxkbregistry = library(
         'xkbregistry',
         'xkbcommon/xkbregistry.h',
         libxkbregistry_sources,
         link_args: libxkbregistry_link_args,
-        link_depends: 'xkbregistry.map',
+        link_depends: libxkbregistry_link_deps,
         gnu_symbol_visibility: 'hidden',
         dependencies: deps_libxkbregistry,
         version: '0.0.0',

--- a/scripts/map-to-def
+++ b/scripts/map-to-def
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+"""A script to generate MSVC Module-Definition files from version-script
+files (which are maintained manually)."""
+
+import re
+import sys
+import pathlib
+
+
+def symbols_from_map(path):
+    return re.findall(r'^\s+(r?xkb_.*);', path.read_text('utf-8'), re.MULTILINE)
+
+
+if 2 > len(sys.argv) > 3:
+    raise SystemExit("Usage: {} file.map [file.def]".format(sys.argv[0]))
+
+
+map_file = pathlib.Path(sys.argv[1])
+map_symbols = set(symbols_from_map(map_file))
+
+if len(sys.argv) == 3:
+    def_file = open(sys.argv[2], "w", encoding="utf-8")
+else:
+    def_file = sys.stdout
+
+def_file.write("LIBRARY {}\n".format(map_file.stem))
+def_file.write("EXPORTS\n")
+for symbol in sorted(map_symbols):
+    def_file.write("\t{}\n".format(symbol))


### PR DESCRIPTION
Arrange for passing `.def` files with the lists of symbols to export from DLLs when building on Windows with MSVC. Without this no symbols were being exported at all.

