### PR TITLE
Meson: Handle absolute sysconfdir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -49,7 +49,11 @@ endif
 
 XKBCONFIGEXTRAPATH = get_option('xkb-config-extra-path')
 if XKBCONFIGEXTRAPATH == ''
-    XKBCONFIGEXTRAPATH = get_option('prefix')/get_option('sysconfdir')/'xkb'
+    sysconfdir = get_option('sysconfdir')
+    if not sysconfdir.startswith('/')
+        sysconfdir = get_option('prefix') / sysconfdir
+    endif
+    XKBCONFIGEXTRAPATH = sysconfdir / 'xkb'
 endif
 
 # The X locale directory for compose.


### PR DESCRIPTION
From doc[1], the default sysconfdir is 'etc', but when the prefix is
'/usr', it defaults to '/etc'. So we should prepend it with prefix only
when is relative. This also adds the possibility to have an odd prefix,
say '/opt/libxkbcommon', with '/etc' instead of '/opt/libxkbcommon/etc'
as sysconfdir. This approach is inspired from glib with
localstatedir[2].

[1] https://mesonbuild.com/Builtin-options.html#universal-options
[2] https://gitlab.gnome.org/GNOME/glib/-/blob/2.68.3/meson.build#L90