### PR TITLE
tools/interactive-x11: use keysym to look for Esc

### DIFF
--- a/tools/interactive-x11.c
+++ b/tools/interactive-x11.c
@@ -246,7 +246,7 @@ process_event(xcb_generic_event_t *gevent, struct keyboard *kbd)
                                   XKB_CONSUMED_MODE_XKB);
 
         /* Exit on ESC. */
-        if (keycode == 9)
+        if (xkb_state_key_get_one_sym(kbd->state, keycode) == XKB_KEY_Escape)
             terminate = true;
         break;
     }


### PR DESCRIPTION
Don't assume that keycode 9 means Escape. Instead, use the keymap
to check for Esc.

Logic copied from the Wayland version.

Signed-off-by: Simon Ser <contact@emersion.fr>