### PR TITLE
Fix segmentation fault with wlroots/sway in xkb_keymap_num_layouts

### DIFF
--- a/src/keymap.c
+++ b/src/keymap.c
@@ -299,7 +299,11 @@ xkb_keymap_mod_get_index(struct xkb_keymap *keymap, const char *name)
 XKB_EXPORT xkb_layout_index_t
 xkb_keymap_num_layouts(struct xkb_keymap *keymap)
 {
-    return keymap->num_groups;
+    if(keymap){
+        return keymap->num_groups;
+    }else{
+        return 0
+    }
 }
 
 /**

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -302,7 +302,7 @@ xkb_keymap_num_layouts(struct xkb_keymap *keymap)
     if(keymap){
         return keymap->num_groups;
     }else{
-        return 0
+        return 0;
     }
 }
 


### PR DESCRIPTION
xkb_keymap_num_layouts should be called only if keymap is not NULL, but for some reason wlroots and sway does call it with NULL after waking up from suspend on my hardware. This lets the function at least recover in edge cases by not accessing a null pointer and shouldn't affect well behaving applications.