### PR TITLE
tools: enclose the layout name in quotes

### DIFF
--- a/tools/registry-list.c
+++ b/tools/registry-list.c
@@ -140,11 +140,12 @@ main(int argc, char **argv)
     m = rxkb_model_first(ctx);
     assert(m); /* Empty model list is usually a bug or a bad xml file */
     while (m) {
+        const char *vendor = rxkb_model_get_vendor(m);
         printf("- name: %s\n"
                "  vendor: %s\n"
                "  description: %s\n",
                rxkb_model_get_name(m),
-               rxkb_model_get_vendor(m),
+               vendor ? vendor : "''",
                rxkb_model_get_description(m));
         m = rxkb_model_next(m);
     }

--- a/tools/registry-list.c
+++ b/tools/registry-list.c
@@ -159,12 +159,12 @@ main(int argc, char **argv)
         const char *variant = rxkb_layout_get_variant(l);
         const char *brief = rxkb_layout_get_brief(l);
 
-        printf("- layout: %s\n"
-               "  variant: %s\n"
-               "  brief: %s\n"
+        printf("- layout: '%s'\n"
+               "  variant: '%s'\n"
+               "  brief: '%s'\n"
                "  description: %s\n",
                rxkb_layout_get_name(l),
-               variant ? variant : "''",
+               variant ? variant : "",
                brief ? brief : "''",
                rxkb_layout_get_description(l));
 
@@ -173,7 +173,7 @@ main(int argc, char **argv)
         if (iso639) {
             const char *sep = "";
             while (iso639) {
-                printf("%s%s", sep, rxkb_iso639_code_get_code(iso639));
+                printf("%s'%s'", sep, rxkb_iso639_code_get_code(iso639));
                 iso639 = rxkb_iso639_code_next(iso639);
                 sep = ", ";
             }
@@ -184,7 +184,7 @@ main(int argc, char **argv)
         if (iso3166) {
             const char *sep = "";
             while (iso3166) {
-                printf("%s%s", sep, rxkb_iso3166_code_get_code(iso3166));
+                printf("%s'%s'", sep, rxkb_iso3166_code_get_code(iso3166));
                 iso3166 = rxkb_iso3166_code_next(iso3166);
                 sep = ", ";
             }
@@ -199,7 +199,7 @@ main(int argc, char **argv)
     while (g) {
         struct rxkb_option *o;
 
-        printf("- name: %s\n"
+        printf("- name: '%s'\n"
                "  description: %s\n"
                "  allows_multiple: %s\n"
                "  options:\n",


### PR DESCRIPTION
Because otherwise the 'no' layout is treated as disagreement with whatever is to
be disagreed with. Fixed in YAML 1.2 but that's not universally supported.

Fixes #268