### PR TITLE
registry: don't call xmlCleanupParser()

### DIFF
--- a/src/registry.c
+++ b/src/registry.c
@@ -1197,7 +1197,6 @@ parse(struct rxkb_context *ctx, const char *path,
     success = true;
 error:
     xmlFreeDoc(doc);
-    xmlCleanupParser();
 
     return success;
 }


### PR DESCRIPTION
From the documentation:
> It does not clean up parser state, it cleans up memory allocated by the library
> itself. It is a cleanup function for the XML library. It tries to reclaim all
> related global memory allocated for the library processing. [...]
> One should call xmlCleanupParser() only when the process has finished using the library.

http://xmlsoft.org/html/libxml-parser.html#xmlCleanupParser

Since we're a library ourselves we cannot know if something else in the same
proces uses the parser, so we must not call this.

Reported-by: M Hickford

cc @hickford 

Fixes #273 