### PR TITLE
registry: skip over invalid ISO639 or ISO3166 entries

### DIFF
--- a/src/registry.c
+++ b/src/registry.c
@@ -808,6 +808,11 @@ parse_language_list(xmlNode *language_list, struct rxkb_layout *layout)
             char *str = extract_text(node);
             struct rxkb_object *parent;
 
+            if (!str || strlen(str) != 3) {
+                free(str);
+                continue;
+            }
+
             parent = &layout->base;
             code = rxkb_iso639_code_create(parent);
             code->code = str;
@@ -826,6 +831,11 @@ parse_country_list(xmlNode *country_list, struct rxkb_layout *layout)
         if (is_node(node, "iso3166Id")) {
             char *str = extract_text(node);
             struct rxkb_object *parent;
+
+            if (!str || strlen(str) != 2) {
+                free(str);
+                continue;
+            }
 
             parent = &layout->base;
             code = rxkb_iso3166_code_create(parent);


### PR DESCRIPTION
If the XML file is somehow off, don't load entries that are against the spec.

Note that the new tests will fail once #266 works since they don't handle merging yet.