### PR TITLE
test: show the tool exit status on failure

### DIFF
--- a/test/tool-option-parsing.py
+++ b/test/tool-option-parsing.py
@@ -100,7 +100,7 @@ class XkbcliTool:
             for testfunc, reason in self.skipError:
                 if testfunc(rc, stdout, stderr):
                     raise unittest.SkipTest(reason)
-        assert rc == 0, (stdout, stderr)
+        assert rc == 0, (rc, stdout, stderr)
         return stdout, stderr
 
     def run_command_invalid(self, args):


### PR DESCRIPTION
We already do so for the non-successful cases, let's do this here too so we know
whether it was a signal or a normal exit.


This should help debugging errors such as [#266 ](https://github.com/xkbcommon/libxkbcommon/pull/266#discussion_r781636339)

cc @hickford 