### PR TITLE
meson: add enable-tests option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -531,6 +531,9 @@ configure_file(input: 'test/xkeyboard-config-test.py.in',
                configuration: xkct_config)
 
 # Tests
+
+if get_option('enable-tests')
+
 test_env = environment()
 test_env.set('XKB_LOG_LEVEL', 'debug')
 test_env.set('XKB_LOG_VERBOSITY', '10')
@@ -767,6 +770,7 @@ if get_option('enable-x11')
   )
 endif
 
+endif
 
 # Documentation.
 if get_option('enable-docs')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -50,6 +50,12 @@ option(
     description: 'Enable building tools',
 )
 option(
+    'enable-tests',
+    type: 'boolean',
+    value: true,
+    description: 'Enable building of the tests',
+)
+option(
     'enable-x11',
     type: 'boolean',
     value: true,


### PR DESCRIPTION
Add option to disable building of the tests.

This is a patch that I've been carrying locally for some time. Originally implemented to work around some build failure on tests that I don't need anyway, but might be more generally useful.