### PR TITLE
Rename eof() as s_eof() to avoid conflicts with mingw-w64 eof()

### DIFF
--- a/src/compose/parser.c
+++ b/src/compose/parser.c
@@ -137,7 +137,7 @@ skip_more_whitespace_and_comments:
     }
 
     /* See if we're done. */
-    if (eof(s)) return TOK_END_OF_FILE;
+    if (s_eof(s)) return TOK_END_OF_FILE;
 
     /* New token. */
     s->token_line = s->line;
@@ -146,7 +146,7 @@ skip_more_whitespace_and_comments:
 
     /* LHS Keysym. */
     if (chr(s, '<')) {
-        while (peek(s) != '>' && !eol(s) && !eof(s))
+        while (peek(s) != '>' && !eol(s) && !s_eof(s))
             buf_append(s, next(s));
         if (!chr(s, '>')) {
             scanner_err(s, "unterminated keysym literal");
@@ -171,7 +171,7 @@ skip_more_whitespace_and_comments:
 
     /* String literal. */
     if (chr(s, '\"')) {
-        while (!eof(s) && !eol(s) && peek(s) != '\"') {
+        while (!s_eof(s) && !eol(s) && peek(s) != '\"') {
             if (chr(s, '\\')) {
                 uint8_t o;
                 if (chr(s, '\\')) {
@@ -256,7 +256,7 @@ lex_include_string(struct scanner *s, struct xkb_compose_table *table,
         return TOK_ERROR;
     }
 
-    while (!eof(s) && !eol(s) && peek(s) != '\"') {
+    while (!s_eof(s) && !eol(s) && peek(s) != '\"') {
         if (chr(s, '%')) {
             if (chr(s, '%')) {
                 buf_append(s, '%');

--- a/src/scanner-utils.h
+++ b/src/scanner-utils.h
@@ -93,7 +93,7 @@ peek(struct scanner *s)
 }
 
 static inline bool
-eof(struct scanner *s)
+s_eof(struct scanner *s)
 {
     return s->pos >= s->len;
 }
@@ -116,7 +116,7 @@ skip_to_eol(struct scanner *s)
 static inline char
 next(struct scanner *s)
 {
-    if (unlikely(eof(s)))
+    if (unlikely(s_eof(s)))
         return '\0';
     if (unlikely(eol(s))) {
         s->line++;

--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -112,7 +112,7 @@ skip_more_whitespace_and_comments:
     }
 
     /* See if we're done. */
-    if (eof(s)) return TOK_END_OF_FILE;
+    if (s_eof(s)) return TOK_END_OF_FILE;
 
     /* New token. */
     s->token_line = s->line;
@@ -376,7 +376,7 @@ matcher_include(struct matcher *m, struct scanner *parent_scanner,
         return;
     }
 
-    while (!eof(&s) && !eol(&s)) {
+    while (!s_eof(&s) && !eol(&s)) {
         if (chr(&s, '%')) {
             if (chr(&s, '%')) {
                 buf_append(&s, '%');

--- a/src/xkbcomp/scanner.c
+++ b/src/xkbcomp/scanner.c
@@ -78,7 +78,7 @@ skip_more_whitespace_and_comments:
     }
 
     /* See if we're done. */
-    if (eof(s)) return END_OF_FILE;
+    if (s_eof(s)) return END_OF_FILE;
 
     /* New token. */
     s->token_line = s->line;
@@ -87,7 +87,7 @@ skip_more_whitespace_and_comments:
 
     /* String literal. */
     if (chr(s, '\"')) {
-        while (!eof(s) && !eol(s) && peek(s) != '\"') {
+        while (!s_eof(s) && !eol(s) && peek(s) != '\"') {
             if (chr(s, '\\')) {
                 uint8_t o;
                 if      (chr(s, '\\')) buf_append(s, '\\');


### PR DESCRIPTION
Another patch that I have had locally for some time.

I'm now guessing that I've meant 's_' -prefix to mean 'static' as the function is local to modules using it.