### PR TITLE
Remove bogus euro sign entry from keysymtab

### DIFF
--- a/src/keysym-utf.c
+++ b/src/keysym-utf.c
@@ -819,7 +819,6 @@ static const struct codepair keysymtab[] = {
     { 0x0ef9, 0x11f0 }, /*  Hangul_J_KkogjiDalrinIeung ᇰ HANGUL JONGSEONG YESIEUNG */
     { 0x0efa, 0x11f9 }, /*        Hangul_J_YeorinHieuh ᇹ HANGUL JONGSEONG YEORINHIEUH */
     { 0x0eff, 0x20a9 }, /*                  Korean_Won ₩ WON SIGN */
-    { 0x13a4, 0x20ac }, /*                        Euro € EURO SIGN */
     { 0x13bc, 0x0152 }, /*                          OE Œ LATIN CAPITAL LIGATURE OE */
     { 0x13bd, 0x0153 }, /*                          oe œ LATIN SMALL LIGATURE OE */
     { 0x13be, 0x0178 }, /*                  Ydiaeresis Ÿ LATIN CAPITAL LETTER Y WITH DIAERESIS */

--- a/test/keysym.c
+++ b/test/keysym.c
@@ -252,6 +252,7 @@ main(void)
     assert(test_utf32_to_keysym(0xd7, XKB_KEY_multiply));
     assert(test_utf32_to_keysym('-', XKB_KEY_minus));
     assert(test_utf32_to_keysym(0x10fffd, 0x110fffd));
+    assert(test_utf32_to_keysym(0x20ac, XKB_KEY_EuroSign));
 
     // Unicode non-characters
     assert(test_utf32_to_keysym(0xfdd0, XKB_KEY_NoSymbol));


### PR DESCRIPTION
Not sure what it's doing here, but converting "€" to a keysym
doesn't work with this entry. 0x13a4 doesn't appear in
xkbcommon-keysyms.h. 0x20ac is the keysym documented in the
header (and it's the last entry in the table).

It's been in the table since it was introduced
in e0524296d2e0 ("Add API for getting unicode representation of a
keysym").