### PR TITLE
ci: store the logs on failure and split test and valgrind-test

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -41,3 +41,10 @@ jobs:
       - name: Test with valgrind
         run:
           meson test -C build --print-errorlogs --setup=valgrind --no-suite python-tests
+      - name: Upload test logs
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: test logs
+          path: |
+            build/meson-logs/

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,4 +37,7 @@ jobs:
           meson compile -C build
       - name: Test
         run:
+          meson test -C build --print-errorlogs --no-suite python-tests
+      - name: Test with valgrind
+        run:
           meson test -C build --print-errorlogs --setup=valgrind --no-suite python-tests


### PR DESCRIPTION
Let's keep the test logs so we can figure *why* a test failed. And since valgrind tends to spam the logs, let's run a normal test run first to catch any actual test case failures that aren't valgrind-related.