### PR TITLE
registry: translate briefs and descriptions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,11 @@ jobs:
           sudo apt update
           sudo apt install -y \
             doxygen libxcb-xkb-dev valgrind ninja-build \
-            libwayland-dev wayland-protocols bison graphviz
+            libwayland-dev wayland-protocols bison graphviz \
+            xkb-data
+      - name: Install languages for i18n test
+        run: |
+          sudo apt install -y language-pack-de language-pack-es language-pack-fr
       - name: Setup
         run: |
           meson setup build

--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,13 @@ cflags = [
 ]
 add_project_arguments(cc.get_supported_arguments(cflags), language: 'c')
 
+libintl_dep = []
+if not cc.has_function('dgettext')
+    libintl_dep = cc.find_library('intl')
+    if not cc.has_function('dgettext', dependencies: libintl_dep)
+        error('libintl found but it does not provide dgettext()')
+    endif
+endif
 
 # The XKB config root.
 XKBCONFIGROOT = get_option('xkb-config-root')
@@ -253,6 +260,7 @@ libxkbcommon = library(
     version: '0.0.0',
     install: true,
     include_directories: include_directories('src', 'include'),
+    dependencies: [libintl_dep],
 )
 install_headers(
     'include/xkbcommon/xkbcommon.h',

--- a/src/registry.c
+++ b/src/registry.c
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include <libintl.h>
 #include <libxml/parser.h>
 
 #include "xkbcommon/xkbregistry.h"
@@ -708,6 +709,20 @@ extract_text(xmlNode *node)
     return NULL;
 }
 
+static char *
+extract_i18n_text(xmlNode *node)
+{
+    char *result = extract_text(node);
+
+    if (result) {
+        char *translated = strdup(dgettext("xkeyboard-config", result));
+        free(result);
+        result = translated;
+    }
+
+    return result;
+}
+
 static bool
 parse_config_item(struct rxkb_context *ctx,
                   xmlNode *parent,
@@ -730,9 +745,9 @@ parse_config_item(struct rxkb_context *ctx,
                 if (is_node(node, "name"))
                     *name = extract_text(node);
                 else if (is_node(node, "description"))
-                    *description = extract_text(node);
+                    *description = extract_i18n_text(node);
                 else if (is_node(node, "shortDescription"))
-                    *brief = extract_text(node);
+                    *brief = extract_i18n_text(node); /* Never actually translated */
                 else if (is_node(node, "vendor"))
                     *vendor = extract_text(node);
                 /* Note: the DTD allows for vendor + brief but models only use


### PR DESCRIPTION
Filing this as Draft for now because I reckon this is an API break. It may be be better to add `rxkb_*_get_description_i18n()` or something. As it is the returned string changes, so if you're e.g. libgnome-desktop you then pump that again into `gettext()` and get the already-translated string translated. This could lead to breakage.

Alternatively, if we don't want a new API we could make this a flag at context creation.

Fixes #293

cc @bluetech, @tari01