### PR TITLE
context: add XKB_CONTEXT_NO_SECURE_GETENV flag

### DIFF
--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -585,8 +585,7 @@ enum xkb_context_flags {
     XKB_CONTEXT_NO_ENVIRONMENT_NAMES = (1 << 1),
     /**
      * Disable the use of secure_getenv for this context, so that privileged
-     * processes can use XKB configuration environment variables. Client uses at
-     * their own risk.
+     * processes can use environment variables. Client uses at their own risk.
      */
     XKB_CONTEXT_NO_SECURE_GETENV = (1 << 2)
 };

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -580,12 +580,15 @@ enum xkb_context_flags {
     XKB_CONTEXT_NO_DEFAULT_INCLUDES = (1 << 0),
     /**
      * Don't take RMLVO names from the environment.
+     *
      * @since 0.3.0
      */
     XKB_CONTEXT_NO_ENVIRONMENT_NAMES = (1 << 1),
     /**
      * Disable the use of secure_getenv for this context, so that privileged
      * processes can use environment variables. Client uses at their own risk.
+     *
+     * @since 1.5.0
      */
     XKB_CONTEXT_NO_SECURE_GETENV = (1 << 2)
 };

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -582,7 +582,13 @@ enum xkb_context_flags {
      * Don't take RMLVO names from the environment.
      * @since 0.3.0
      */
-    XKB_CONTEXT_NO_ENVIRONMENT_NAMES = (1 << 1)
+    XKB_CONTEXT_NO_ENVIRONMENT_NAMES = (1 << 1),
+    /**
+     * Disable the use of secure_getenv for this context, so that privileged
+     * processes can use XKB configuration environment variables. Client uses at
+     * their own risk.
+     */
+    XKB_CONTEXT_NO_SECURE_GETENV = (1 << 2)
 };
 
 /**

--- a/include/xkbcommon/xkbregistry.h
+++ b/include/xkbcommon/xkbregistry.h
@@ -164,7 +164,8 @@ enum rxkb_context_flags {
      */
     RXKB_CONTEXT_LOAD_EXOTIC_RULES = (1 << 1),
     /**
-     * Disable the use of secure_getenv.
+     * Disable the use of secure_getenv for this context, so that privileged
+     * processes can use environment variables. Client uses at their own risk.
      */
     RXKB_CONTEXT_NO_SECURE_GETENV = (1 << 2)
 };

--- a/include/xkbcommon/xkbregistry.h
+++ b/include/xkbcommon/xkbregistry.h
@@ -166,6 +166,8 @@ enum rxkb_context_flags {
     /**
      * Disable the use of secure_getenv for this context, so that privileged
      * processes can use environment variables. Client uses at their own risk.
+     *
+     * @since 1.5.0
      */
     RXKB_CONTEXT_NO_SECURE_GETENV = (1 << 2)
 };

--- a/include/xkbcommon/xkbregistry.h
+++ b/include/xkbcommon/xkbregistry.h
@@ -163,6 +163,10 @@ enum rxkb_context_flags {
      * on the lookup behavior.
      */
     RXKB_CONTEXT_LOAD_EXOTIC_RULES = (1 << 1),
+    /**
+     * Disable the use of secure_getenv.
+     */
+    RXKB_CONTEXT_NO_SECURE_GETENV = (1 << 2)
 };
 
 /**

--- a/src/compose/parser.c
+++ b/src/compose/parser.c
@@ -262,7 +262,7 @@ lex_include_string(struct scanner *s, struct xkb_compose_table *table,
                 scanner_buf_append(s, '%');
             }
             else if (scanner_chr(s, 'H')) {
-                const char *home = secure_getenv("HOME");
+                const char *home = xkb_context_getenv(table->ctx, "HOME");
                 if (!home) {
                     scanner_err(s, "%%H was used in an include statement, but the HOME environment variable is not set");
                     return TOK_ERROR;
@@ -273,7 +273,7 @@ lex_include_string(struct scanner *s, struct xkb_compose_table *table,
                 }
             }
             else if (scanner_chr(s, 'L')) {
-                char *path = get_locale_compose_file_path(table->locale);
+                char *path = get_locale_compose_file_path(table->ctx, table->locale);
                 if (!path) {
                     scanner_err(s, "failed to expand %%L to the locale Compose file");
                     return TOK_ERROR;
@@ -286,7 +286,7 @@ lex_include_string(struct scanner *s, struct xkb_compose_table *table,
                 free(path);
             }
             else if (scanner_chr(s, 'S')) {
-                const char *xlocaledir = get_xlocaledir_path();
+                const char *xlocaledir = get_xlocaledir_path(table->ctx);
                 if (!scanner_buf_appends(s, xlocaledir)) {
                     scanner_err(s, "include path after expanding %%S is too long");
                     return TOK_ERROR;

--- a/src/compose/paths.h
+++ b/src/compose/paths.h
@@ -25,21 +25,21 @@
 #define COMPOSE_RESOLVE_H
 
 char *
-resolve_locale(const char *locale);
+resolve_locale(struct xkb_context *ctx, const char *locale);
 
 const char *
-get_xlocaledir_path(void);
+get_xlocaledir_path(struct xkb_context *ctx);
 
 char *
-get_xcomposefile_path(void);
+get_xcomposefile_path(struct xkb_context *ctx);
 
 char *
-get_xdg_xcompose_file_path(void);
+get_xdg_xcompose_file_path(struct xkb_context *ctx);
 
 char *
-get_home_xcompose_file_path(void);
+get_home_xcompose_file_path(struct xkb_context *ctx);
 
 char *
-get_locale_compose_file_path(const char *locale);
+get_locale_compose_file_path(struct xkb_context *ctx, const char *locale);
 
 #endif

--- a/src/compose/table.c
+++ b/src/compose/table.c
@@ -38,7 +38,7 @@ xkb_compose_table_new(struct xkb_context *ctx,
     struct xkb_compose_table *table;
     struct compose_node dummy;
 
-    resolved_locale = resolve_locale(locale);
+    resolved_locale = resolve_locale(ctx, locale);
     if (!resolved_locale)
         return NULL;
 
@@ -174,7 +174,7 @@ xkb_compose_table_new_from_locale(struct xkb_context *ctx,
     if (!table)
         return NULL;
 
-    path = get_xcomposefile_path();
+    path = get_xcomposefile_path(ctx);
     if (path) {
         file = fopen(path, "rb");
         if (file)
@@ -182,7 +182,7 @@ xkb_compose_table_new_from_locale(struct xkb_context *ctx,
     }
     free(path);
 
-    path = get_xdg_xcompose_file_path();
+    path = get_xdg_xcompose_file_path(ctx);
     if (path) {
         file = fopen(path, "rb");
         if (file)
@@ -190,7 +190,7 @@ xkb_compose_table_new_from_locale(struct xkb_context *ctx,
     }
     free(path);
 
-    path = get_home_xcompose_file_path();
+    path = get_home_xcompose_file_path(ctx);
     if (path) {
         file = fopen(path, "rb");
         if (file)
@@ -198,7 +198,7 @@ xkb_compose_table_new_from_locale(struct xkb_context *ctx,
     }
     free(path);
 
-    path = get_locale_compose_file_path(table->locale);
+    path = get_locale_compose_file_path(ctx, table->locale);
     if (path) {
         file = fopen(path, "rb");
         if (file)

--- a/src/context-priv.c
+++ b/src/context-priv.c
@@ -34,6 +34,16 @@
 #include "utils.h"
 #include "context.h"
 
+char *
+xkb_context_getenv(struct xkb_context *ctx, const char *name)
+{
+    if (ctx->use_secure_getenv) {
+        return secure_getenv(name);
+    } else {
+        return getenv(name);
+    }
+}
+
 unsigned int
 xkb_context_num_failed_include_paths(struct xkb_context *ctx)
 {
@@ -105,7 +115,7 @@ xkb_context_get_default_rules(struct xkb_context *ctx)
     const char *env = NULL;
 
     if (ctx->use_environment_names)
-        env = secure_getenv("XKB_DEFAULT_RULES");
+        env = xkb_context_getenv(ctx, "XKB_DEFAULT_RULES");
 
     return env ? env : DEFAULT_XKB_RULES;
 }
@@ -116,7 +126,7 @@ xkb_context_get_default_model(struct xkb_context *ctx)
     const char *env = NULL;
 
     if (ctx->use_environment_names)
-        env = secure_getenv("XKB_DEFAULT_MODEL");
+        env = xkb_context_getenv(ctx, "XKB_DEFAULT_MODEL");
 
     return env ? env : DEFAULT_XKB_MODEL;
 }
@@ -127,7 +137,7 @@ xkb_context_get_default_layout(struct xkb_context *ctx)
     const char *env = NULL;
 
     if (ctx->use_environment_names)
-        env = secure_getenv("XKB_DEFAULT_LAYOUT");
+        env = xkb_context_getenv(ctx, "XKB_DEFAULT_LAYOUT");
 
     return env ? env : DEFAULT_XKB_LAYOUT;
 }
@@ -136,12 +146,12 @@ static const char *
 xkb_context_get_default_variant(struct xkb_context *ctx)
 {
     const char *env = NULL;
-    const char *layout = secure_getenv("XKB_DEFAULT_LAYOUT");
+    const char *layout = xkb_context_getenv(ctx, "XKB_DEFAULT_LAYOUT");
 
     /* We don't want to inherit the variant if they haven't also set a
      * layout, since they're so closely paired. */
     if (layout && ctx->use_environment_names)
-        env = secure_getenv("XKB_DEFAULT_VARIANT");
+        env = xkb_context_getenv(ctx, "XKB_DEFAULT_VARIANT");
 
     return env ? env : DEFAULT_XKB_VARIANT;
 }
@@ -152,7 +162,7 @@ xkb_context_get_default_options(struct xkb_context *ctx)
     const char *env = NULL;
 
     if (ctx->use_environment_names)
-        env = secure_getenv("XKB_DEFAULT_OPTIONS");
+        env = xkb_context_getenv(ctx, "XKB_DEFAULT_OPTIONS");
 
     return env ? env : DEFAULT_XKB_OPTIONS;
 }

--- a/src/context.c
+++ b/src/context.c
@@ -77,14 +77,16 @@ err:
 const char *
 xkb_context_include_path_get_extra_path(struct xkb_context *ctx)
 {
-    const char *extra = secure_getenv("XKB_CONFIG_EXTRA_PATH");
+    bool secure = ctx->use_secure_getenv;
+    const char *extra = xkb_context_getenv("XKB_CONFIG_EXTRA_PATH", secure);
     return extra ? extra : DFLT_XKB_CONFIG_EXTRA_PATH;
 }
 
 const char *
 xkb_context_include_path_get_system_path(struct xkb_context *ctx)
 {
-    const char *root = secure_getenv("XKB_CONFIG_ROOT");
+    bool secure = ctx->use_secure_getenv;
+    const char *root = xkb_context_getenv("XKB_CONFIG_ROOT", secure);
     return root ? root : DFLT_XKB_CONFIG_ROOT;
 }
 
@@ -97,10 +99,11 @@ xkb_context_include_path_append_default(struct xkb_context *ctx)
     const char *home, *xdg, *root, *extra;
     char *user_path;
     int ret = 0;
+    bool secure = ctx->use_secure_getenv;
 
-    home = secure_getenv("HOME");
+    home = xkb_context_getenv("HOME", secure);
 
-    xdg = secure_getenv("XDG_CONFIG_HOME");
+    xdg = xkb_context_getenv("XDG_CONFIG_HOME", secure);
     if (xdg != NULL) {
         user_path = asprintf_safe("%s/xkb", xdg);
         if (user_path) {
@@ -291,11 +294,12 @@ xkb_context_new(enum xkb_context_flags flags)
     ctx->log_verbosity = 0;
 
     /* Environment overwrites defaults. */
-    env = secure_getenv("XKB_LOG_LEVEL");
+    bool secure = ctx->use_secure_getenv;
+    env = xkb_context_getenv("XKB_LOG_LEVEL", secure);
     if (env)
         xkb_context_set_log_level(ctx, log_level(env));
 
-    env = secure_getenv("XKB_LOG_VERBOSITY");
+    env = xkb_context_getenv("XKB_LOG_VERBOSITY", secure);
     if (env)
         xkb_context_set_log_verbosity(ctx, log_verbosity(env));
 
@@ -308,6 +312,7 @@ xkb_context_new(enum xkb_context_flags flags)
     }
 
     ctx->use_environment_names = !(flags & XKB_CONTEXT_NO_ENVIRONMENT_NAMES);
+    ctx->use_secure_getenv = !(flags & XKB_CONTEXT_NO_SECURE_GETENV);
 
     ctx->atom_table = atom_table_new();
     if (!ctx->atom_table) {

--- a/src/context.h
+++ b/src/context.h
@@ -53,6 +53,7 @@ struct xkb_context {
     size_t text_next;
 
     unsigned int use_environment_names : 1;
+    unsigned int use_secure_getenv : 1;
 };
 
 unsigned int

--- a/src/context.h
+++ b/src/context.h
@@ -56,6 +56,9 @@ struct xkb_context {
     unsigned int use_secure_getenv : 1;
 };
 
+char *
+xkb_context_getenv(struct xkb_context *ctx, const char *name);
+
 unsigned int
 xkb_context_num_failed_include_paths(struct xkb_context *ctx);
 

--- a/src/registry.c
+++ b/src/registry.c
@@ -438,6 +438,17 @@ DECLARE_REF_UNREF_FOR_TYPE(rxkb_context);
 DECLARE_CREATE_FOR_TYPE(rxkb_context);
 DECLARE_TYPED_GETTER_FOR_TYPE(rxkb_context, log_level, enum rxkb_log_level);
 
+static char *
+rxkb_context_getenv(struct rxkb_context *ctx, const char *name)
+{
+    if (ctx->use_secure_getenv) {
+        return secure_getenv(name);
+    } else {
+        return getenv(name);
+    }
+}
+
+
 XKB_EXPORT void
 rxkb_context_set_log_level(struct rxkb_context *ctx,
                            enum rxkb_log_level level)
@@ -514,8 +525,7 @@ rxkb_context_new(enum rxkb_context_flags flags)
     ctx->log_level = RXKB_LOG_LEVEL_ERROR;
 
     /* Environment overwrites defaults. */
-    bool secure = ctx->use_secure_getenv;
-    env = xkb_context_getenv("RXKB_LOG_LEVEL", secure);
+    env = rxkb_context_getenv(ctx, "RXKB_LOG_LEVEL");
     if (env)
         rxkb_context_set_log_level(ctx, log_level(env));
 
@@ -596,10 +606,9 @@ rxkb_context_include_path_append_default(struct rxkb_context *ctx)
         return false;
     }
 
-    bool secure = ctx->use_secure_getenv;
-    home = xkb_context_getenv("HOME", secure);
+    home = rxkb_context_getenv(ctx, "HOME");
 
-    xdg = xkb_context_getenv("XDG_CONFIG_HOME", secure);
+    xdg = rxkb_context_getenv(ctx, "XDG_CONFIG_HOME");
     if (xdg != NULL) {
         user_path = asprintf_safe("%s/xkb", xdg);
         if (user_path) {
@@ -623,13 +632,13 @@ rxkb_context_include_path_append_default(struct rxkb_context *ctx)
         }
     }
 
-    extra = xkb_context_getenv("XKB_CONFIG_EXTRA_PATH", secure);
+    extra = rxkb_context_getenv(ctx, "XKB_CONFIG_EXTRA_PATH");
     if (extra != NULL)
         ret |= rxkb_context_include_path_append(ctx, extra);
     else
         ret |= rxkb_context_include_path_append(ctx, DFLT_XKB_CONFIG_EXTRA_PATH);
 
-    root = xkb_context_getenv("XKB_CONFIG_ROOT", secure);
+    root = rxkb_context_getenv(ctx, "XKB_CONFIG_ROOT");
     if (root != NULL)
         ret |= rxkb_context_include_path_append(ctx, root);
     else

--- a/src/utils.h
+++ b/src/utils.h
@@ -251,17 +251,6 @@ check_eaccess(const char *path, int mode)
 # define secure_getenv getenv
 #endif
 
-static inline char *
-xkb_context_getenv(const char *name, bool secure)
-{
-    if (secure) {
-        return secure_getenv(name);
-    } else {
-        return getenv(name);
-    }
-}
-
-
 #if defined(HAVE___BUILTIN_EXPECT)
 # define likely(x)   __builtin_expect(!!(x), 1)
 # define unlikely(x) __builtin_expect(!!(x), 0)

--- a/src/utils.h
+++ b/src/utils.h
@@ -251,6 +251,17 @@ check_eaccess(const char *path, int mode)
 # define secure_getenv getenv
 #endif
 
+static inline char *
+xkb_context_getenv(const char *name, bool secure)
+{
+    if (secure) {
+        return secure_getenv(name);
+    } else {
+        return getenv(name);
+    }
+}
+
+
 #if defined(HAVE___BUILTIN_EXPECT)
 # define likely(x)   __builtin_expect(!!(x), 1)
 # define unlikely(x) __builtin_expect(!!(x), 0)

--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -382,7 +382,7 @@ matcher_include(struct matcher *m, struct scanner *parent_scanner,
                 scanner_buf_append(&s, '%');
             }
             else if (scanner_chr(&s, 'H')) {
-                const char *home = secure_getenv("HOME");
+                const char *home = xkb_context_getenv(m->ctx, "HOME");
                 if (!home) {
                     scanner_err(&s, "%%H was used in an include statement, but the HOME environment variable is not set");
                     return;


### PR DESCRIPTION
This flag is useful for clients that may have relatively benign capabilities set, like CAP_SYS_NICE, that also want to use the xkb configuration from the environment and user configs in XDG_CONFIG_HOME.

Fixes #308