### PR TITLE
build: override dependency for use as subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -266,6 +266,9 @@ dep_libxkbcommon = declare_dependency(
     link_with: libxkbcommon,
     include_directories: include_directories('include'),
 )
+if meson.version().version_compare('>= 0.54.0')
+    meson.override_dependency('xkbcommon', dep_libxkbcommon)
+endif
 pkgconfig.generate(
     libxkbcommon,
     name: 'xkbcommon',
@@ -334,6 +337,9 @@ You can disable X11 support with -Denable-x11=false.''')
         link_with: libxkbcommon_x11,
         include_directories: include_directories('include'),
     )
+    if meson.version().version_compare('>= 0.54.0')
+        meson.override_dependency('xkbcommon-x11', dep_libxkbcommon_x11)
+    endif
     pkgconfig.generate(
         libxkbcommon_x11,
         name: 'xkbcommon-x11',
@@ -398,6 +404,9 @@ if get_option('enable-xkbregistry')
         link_with: libxkbregistry,
         include_directories: include_directories('include'),
     )
+    if meson.version().version_compare('>= 0.54.0')
+        meson.override_dependency('xkbregistry', dep_libxkbregistry)
+    endif
 endif
 
 man_pages = []


### PR DESCRIPTION
This allows xkbcommon to be used as a subproject.