### PR TITLE
Fallback to Compose file in locale directory if no mapping exists in compose.dir

### DIFF
--- a/src/compose/paths.c
+++ b/src/compose/paths.c
@@ -200,8 +200,9 @@ get_locale_compose_file_path(struct xkb_context *ctx, const char *locale)
         locale = "en_US.UTF-8";
 
     resolved = resolve_name(ctx, "compose.dir", RIGHT_TO_LEFT, locale);
-    if (!resolved)
-        return NULL;
+    if (!resolved) {
+        return asprintf_safe("%s/%s/Compose", get_xlocaledir_path(ctx), locale);
+    }
 
     if (resolved[0] == '/') {
         path = resolved;


### PR DESCRIPTION
I've created and distribute a custom locale that a mix between my native language's locale and en_US. There unfortunately seems to be no way for me to extend the `compose.dir` file to include a mapping for my new locale.  

This MR add a new fallback in case a `compose.dir` entry is missing for the current locale and will cause libxkbcommon to use the compose file at:
`/usr/share/X11/locale/en_XX.UTF-8/Compose`
In this case en_XX is missing from `compose.dir`.