### PR TITLE
Possible fix for non-MSVC windows compilers

### DIFF
--- a/bench/bench.c
+++ b/bench/bench.c
@@ -30,7 +30,7 @@
 #include "bench.h"
 #include "../src/utils.h"
 
-#ifndef _MSC_VER
+#ifndef _WIN32
 #include <sys/time.h>
 #else
 #include <windows.h>

--- a/src/utils.h
+++ b/src/utils.h
@@ -40,7 +40,7 @@
 # define F_OK    0               /* Test for existence.  */
 #endif
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 # include <direct.h>
 # include <io.h>
 # ifndef S_ISDIR

--- a/test/common.c
+++ b/test/common.c
@@ -37,7 +37,7 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <io.h>
 #include <windows.h>
 #else
@@ -171,7 +171,7 @@ test_makedir(const char *parent, const char *path)
 
     dirname = asprintf_safe("%s/%s", parent, path);
     assert(dirname);
-#ifdef _MSC_VER
+#ifdef _WIN32
     err = _mkdir(dirname);
 #else
     err = mkdir(dirname, 0777);
@@ -184,7 +184,7 @@ test_makedir(const char *parent, const char *path)
 char *
 test_maketempdir(const char *template)
 {
-#ifdef _MSC_VER
+#ifdef _WIN32
     const char *basetmp = getenv("TMP");
     if (basetmp == NULL) {
         basetmp = getenv("TEMP");

--- a/test/test.h
+++ b/test/test.h
@@ -88,7 +88,7 @@ test_compile_rules(struct xkb_context *context, const char *rules,
                    const char *options);
 
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #define setenv(varname, value, overwrite) _putenv_s((varname), (value))
 #define unsetenv(varname) _putenv_s(varname, "")
 #endif

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -39,7 +39,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <io.h>
 #include <windows.h>
 #else
@@ -160,7 +160,7 @@ tools_print_state_changes(enum xkb_state_component changed)
     printf("]\n");
 }
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 void
 tools_disable_stdin_echo(void)
 {

--- a/tools/tools-common.h
+++ b/tools/tools-common.h
@@ -54,7 +54,7 @@ tools_enable_stdin_echo(void);
 int
 tools_exec_command(const char *prefix, int argc, char **argv);
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #define setenv(varname, value, overwrite) _putenv_s((varname), (value))
 #define unsetenv(varname) _putenv_s(varname, "")
 #endif


### PR DESCRIPTION
`_MSC_VER` is specific to MSVC, but there can be other compilers targeting windows. Hopefully they do define `_WIN32`, so let's use that.

Refs: https://github.com/xkbcommon/libxkbcommon/issues/305