### PR TITLE
Enabled fine-grained warnings for parser

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,7 @@ max_line_length = 80
 [*.yml]
 indent_style = space
 indent_size = 2
+
+[*.map]
+indent_style = tab
+indent_size = 4

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -650,6 +650,116 @@ xkb_context_set_user_data(struct xkb_context *context, void *user_data);
 void *
 xkb_context_get_user_data(struct xkb_context *context);
 
+/**
+ * Control the enabled warnings.
+ *
+ * @since 1.6.0
+**/
+enum xkb_warning_flags {
+    /** No warning */
+    XKB_WARNING_NONE = 0,
+    /** Warn on unrecognized keysyms */
+    XKB_WARNING_UNRECOGNIZED_KEYSYM = (1 << 1),
+    /** Warn on numeric keysym (other than 0-9) */
+    XKB_WARNING_NUMERIC_KEYSYM = (1 << 2),
+    /** Warn if there are conflicting key types while merging groups. */
+    XKB_WARNING_CONFLICTING_KEY_TYPE = (1 << 3),
+    /** Warn if there are conflicting actions while merging keys. */
+    XKB_WARNING_CONFLICTING_KEY_ACTION = (1 << 4),
+    /** Warn if there are conflicting keysyms while merging keys. */
+    XKB_WARNING_CONFLICTING_KEY_KEYSYM = (1 << 5),
+    /** Warn if there are conflicting fields while merging keys. */
+    XKB_WARNING_CONFLICTING_KEY_SYMBOL_MAP_FIELDS = (1 << 6),
+    /** Warn if there are conflicting modmap definitions. */
+    XKB_WARNING_CONFLICTING_MODMAP = (1 << 7),
+    /** Warn if a group name was defined for group other than the first one. */
+    XKB_WARNING_GROUP_NAME_FOR_NON_BASE_GROUP = (1 << 8),
+    /** Warn if a key defines multiple groups at once. */
+    XKB_WARNING_MULTIPLE_GROUP_AT_ONCE = (1 << 9),
+    /** Warn if no key type can be inferred. */
+    XKB_WARNING_CANNOT_INFER_KEY_TYPE = (1 << 10),
+    /** Warn if using an undefined key type. */
+    XKB_WARNING_UNDEFINED_KEY_TYPE = (1 << 11),
+    /** Warn if using a symbol not defined in the keymap. */
+    XKB_WARNING_UNRESOLVED_KEYMAP_SYMBOL = (1 << 12),
+    // TODO:
+    XKB_WARNING_EXTRA_SYMBOLS_IGNORED = (1 << 13),
+    // TODO:
+    XKB_WARNING_UNDEFINED_KEYCODE = (1 << 14),
+    // TODO: deprecated keysym
+    // TODO: unicode keysym when named and recommended keysym exists
+    /** Default warnings */
+    XKB_WARNING_DEFAULT = ( \
+        XKB_WARNING_UNRECOGNIZED_KEYSYM | \
+        XKB_WARNING_CONFLICTING_KEY_TYPE | \
+        XKB_WARNING_CONFLICTING_KEY_ACTION | \
+        XKB_WARNING_CONFLICTING_KEY_KEYSYM | \
+        XKB_WARNING_CONFLICTING_KEY_SYMBOL_MAP_FIELDS | \
+        XKB_WARNING_CONFLICTING_MODMAP | \
+        XKB_WARNING_GROUP_NAME_FOR_NON_BASE_GROUP | \
+        XKB_WARNING_MULTIPLE_GROUP_AT_ONCE | \
+        XKB_WARNING_CANNOT_INFER_KEY_TYPE | \
+        XKB_WARNING_UNDEFINED_KEY_TYPE | \
+        XKB_WARNING_UNRESOLVED_KEYMAP_SYMBOL | \
+        XKB_WARNING_EXTRA_SYMBOLS_IGNORED | \
+        XKB_WARNING_UNDEFINED_KEYCODE \
+    ),
+    /** All the previous warnings */
+    XKB_WARNING_ALL = ( \
+        XKB_WARNING_DEFAULT | \
+        XKB_WARNING_NUMERIC_KEYSYM \
+    ),
+};
+
+/** Default errors */
+#define XKB_ERROR_DEFAULT 0
+
+/**
+ * Store warning flags in the context.
+ *
+ * @memberof xkb_context
+ *
+ * @since 1.6.0
+**/
+void
+xkb_context_set_warning_flags(struct xkb_context *context,
+                              enum xkb_warning_flags warning_flags);
+
+/**
+* Retrieves the warning flags from the context.
+ *
+ * @returns The current warning flags.
+ *
+ * @memberof xkb_context
+ *
+ * @since 1.6.0
+*/
+enum xkb_warning_flags
+xkb_context_get_warning_flags(struct xkb_context *context);
+
+/**
+ * Store error flags in the context.
+ *
+ * @memberof xkb_context
+ *
+ * @since 1.6.0
+**/
+void
+xkb_context_set_error_flags(struct xkb_context *context,
+                            enum xkb_warning_flags error_flags);
+
+/**
+* Retrieves the error flags from the context.
+ *
+ * @returns The current error flags.
+ *
+ * @memberof xkb_context
+ *
+ * @since 1.6.0
+*/
+enum xkb_warning_flags
+xkb_context_get_error_flags(struct xkb_context *context);
+
 /** @} */
 
 /**

--- a/src/context.c
+++ b/src/context.c
@@ -290,6 +290,8 @@ xkb_context_new(enum xkb_context_flags flags)
     ctx->log_fn = default_log_fn;
     ctx->log_level = XKB_LOG_LEVEL_ERROR;
     ctx->log_verbosity = 0;
+    ctx->warning_flags = XKB_WARNING_DEFAULT;
+    ctx->error_flags = XKB_ERROR_DEFAULT;
     ctx->use_environment_names = !(flags & XKB_CONTEXT_NO_ENVIRONMENT_NAMES);
     ctx->use_secure_getenv = !(flags & XKB_CONTEXT_NO_SECURE_GETENV);
 
@@ -366,4 +368,36 @@ XKB_EXPORT void
 xkb_context_set_user_data(struct xkb_context *ctx, void *user_data)
 {
     ctx->user_data = user_data;
+}
+
+XKB_EXPORT enum xkb_warning_flags
+xkb_context_get_warning_flags(struct xkb_context *ctx)
+{
+    if (ctx)
+        return ctx->warning_flags;
+    return -1;
+}
+
+XKB_EXPORT void
+xkb_context_set_warning_flags(struct xkb_context *ctx,
+                              enum xkb_warning_flags warning_flags)
+{
+    ctx->warning_flags = warning_flags;
+    ctx->error_flags &= ~warning_flags;
+}
+
+XKB_EXPORT enum xkb_warning_flags
+xkb_context_get_error_flags(struct xkb_context *ctx)
+{
+    if (ctx)
+        return ctx->error_flags;
+    return -1;
+}
+
+XKB_EXPORT void
+xkb_context_set_error_flags(struct xkb_context *ctx,
+                            enum xkb_warning_flags error_flags)
+{
+    ctx->warning_flags &= ~error_flags;
+    ctx->error_flags = error_flags;
 }

--- a/src/context.h
+++ b/src/context.h
@@ -27,6 +27,7 @@
 #define CONTEXT_H
 
 #include "atom.h"
+#include "xkbcommon/xkbcommon.h"
 
 struct xkb_context {
     int refcnt;
@@ -54,6 +55,9 @@ struct xkb_context {
 
     unsigned int use_environment_names : 1;
     unsigned int use_secure_getenv : 1;
+
+    enum xkb_warning_flags warning_flags;
+    enum xkb_warning_flags error_flags;
 };
 
 char *

--- a/src/xkbcomp/scanner.c
+++ b/src/xkbcomp/scanner.c
@@ -100,7 +100,7 @@ skip_more_whitespace_and_comments:
                 else if (scanner_chr(s, 'e'))  scanner_buf_append(s, '\033');
                 else if (scanner_oct(s, &o))   scanner_buf_append(s, (char) o);
                 else {
-                    scanner_warn(s, "unknown escape sequence in string literal");
+                    scanner_warn(s, "unknown escape sequence in string literal %c", scanner_peek(s));
                     /* Ignore. */
                 }
             } else {

--- a/test/xkeyboard-config-test.py.in
+++ b/test/xkeyboard-config-test.py.in
@@ -112,6 +112,8 @@ class XkbCompInvocation(Invocation):
 
 
 class XkbcommonInvocation(Invocation):
+    ERROR_TAGS = ('WARNING', 'ERROR', 'CRITICAL')
+
     def run(self):
         r, m, l, v, o = self.rmlvo
         args = [
@@ -125,15 +127,32 @@ class XkbcommonInvocation(Invocation):
             args += ['--variant', v]
         if o is not None:
             args += ['--options', o]
+        args += [
+            '--Wall',
+            '--Wno-unresolved-keymap-symbol',
+            '--Wno-conflicting-key-type',
+            '--Wno-conflicting-key-keysym',
+            '--Wno-numeric-keysym',
+            '--Wno-extra-symbols-ignored',
+            '--Wno-conflicting-key-symbol-map-fields',
+            '--Wno-undefined-keycode',
+            '--Wno-conflicting-modmap',
+        ]
 
         self.command = " ".join(args)
         try:
             output = subprocess.check_output(args, stderr=subprocess.STDOUT,
                                              universal_newlines=True)
-            if "unrecognized keysym" in output:
-                for line in output.split('\n'):
-                    if "unrecognized keysym" in line:
-                        self.error = line
+            if any(msg in output for msg in self.ERROR_TAGS):
+            # if "unrecognized keysym" in output:
+            #     for line in output.split('\n'):
+            #         if "unrecognized keysym" in line:
+            #             self.error = line
+                self.error = "\n".join(
+                    line
+                    for line in output.split('\n')
+                    if any(msg in line for msg in self.ERROR_TAGS)
+                )
                 self.exitstatus = 99  # tool doesn't generate this one
             else:
                 self.exitstatus = 0

--- a/xkbcommon.map
+++ b/xkbcommon.map
@@ -9,6 +9,10 @@ global:
 	xkb_context_unref;
 	xkb_context_set_user_data;
 	xkb_context_get_user_data;
+	xkb_context_set_warning_flags;
+	xkb_context_get_warning_flags;
+	xkb_context_set_error_flags;
+	xkb_context_get_error_flags;
 	xkb_context_include_path_append;
 	xkb_context_include_path_append_default;
 	xkb_context_include_path_reset_defaults;


### PR DESCRIPTION
I am trying to make it easier to spot errors in `xkeyboard-config`.

I think fine-grained could help us with this:
- Allow to enable/disable single warnings.
- WIP: Allow to convert warnings to errors. It does not seem easy to implement this feature.
- Add new parser warning for numeric keysyms (except 0-9).

@bluetech @whot 