### PR TITLE
meson.build: register libxkbcommon.dylib link

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -423,6 +423,7 @@ if build_tools
     tools_dep = declare_dependency(
         include_directories: [include_directories('tools', 'include')],
         link_with: libxkbcommon_tools_internal,
+        dependencies: dep_libxkbcommon,
     )
 
     executable('xkbcli', 'tools/xkbcli.c',


### PR DESCRIPTION
meson needs to know that the executable tools link against libxkbcommon.dylib so that the
@rpath references used during the build/test phases can be rewritten to full path names on install

Fixes: #327 