### PR TITLE
README: use meson compile/test over ninja

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ See [Quick Guide](doc/quick-guide.md).
 libxkbcommon is built with [Meson](http://mesonbuild.com/):
 
     meson setup build
-    ninja -C build
-    ninja -C build test  # Run the tests.
+    meson compile -C build
+    meson test -C build # Run the tests.
 
 To build for use with Wayland, you can disable X11 support while still
 using the X11 keyboard configuration resource files thusly:
@@ -24,7 +24,7 @@ using the X11 keyboard configuration resource files thusly:
         -Denable-x11=false \
         -Dxkb-config-root=/usr/share/X11/xkb \
         -Dx-locale-root=/usr/share/X11/locale
-    ninja -C build
+    meson compile -C build
 
 ## API
 

--- a/fuzz/fuzz.sh
+++ b/fuzz/fuzz.sh
@@ -13,5 +13,5 @@ esac
 export CC=afl-clang-fast
 export AFL_HARDEN=1
 test -d fuzz/build || meson setup -Db_lto=true fuzz/build
-ninja -C fuzz/build
+meson compile -C fuzz/build
 afl-fuzz -i fuzz/$1/testcases -x fuzz/$1/dict -o fuzz/$1/findings -t 200 -m 10 -- ./fuzz/build/fuzz-$1 @@


### PR DESCRIPTION
This is backend-agnostic and the recommended way to invoke compilation.

This requires meson 0.55 (July 2020) and we only require 0.51 but at this point I'm expecting most users who require the README instructions will have a recent-enough meson anyway.