### PR TITLE
Add support for :all in rules

### DIFF
--- a/bench/rules.c
+++ b/bench/rules.c
@@ -53,7 +53,8 @@ main(int argc, char *argv[])
     for (i = 0; i < BENCHMARK_ITERATIONS; i++) {
         struct xkb_component_names kccgst;
 
-        assert(xkb_components_from_rules(ctx, &rmlvo, &kccgst));
+        // [FIXME] num_explicit_groups
+        assert(xkb_components_from_rules(ctx, &rmlvo, &kccgst, NULL));
         free(kccgst.keycodes);
         free(kccgst.types);
         free(kccgst.compat);

--- a/src/keymap-priv.c
+++ b/src/keymap-priv.c
@@ -68,6 +68,7 @@ xkb_keymap_new(struct xkb_context *ctx,
 
     keymap->format = format;
     keymap->flags = flags;
+    keymap->num_explicit_groups = 0;
 
     update_builtin_keymap_fields(keymap);
 

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -389,6 +389,8 @@ struct xkb_keymap {
 
     /* Number of groups in the key with the most groups. */
     xkb_layout_index_t num_groups;
+    /* Number of groups that were explicitly declared at section level. */
+    xkb_layout_index_t num_explicit_groups;
     /* Not all groups must have names. */
     xkb_layout_index_t num_group_names;
     xkb_atom_t *group_names;

--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -1104,7 +1104,8 @@ out:
 bool
 xkb_components_from_rules(struct xkb_context *ctx,
                           const struct xkb_rule_names *rmlvo,
-                          struct xkb_component_names *out)
+                          struct xkb_component_names *out,
+                          xkb_layout_index_t *layout_count)
 {
     bool ret = false;
     FILE *file;
@@ -1118,6 +1119,10 @@ xkb_components_from_rules(struct xkb_context *ctx,
         goto err_out;
 
     matcher = matcher_new(ctx, rmlvo);
+    // Set the number of explicit layouts
+    if (layout_count != NULL) {
+        *layout_count = matcher->rmlvo.layouts.size;
+    }
 
     ret = read_rules_file(ctx, matcher, 0, file, path);
     if (!ret ||

--- a/src/xkbcomp/rules.h
+++ b/src/xkbcomp/rules.h
@@ -27,6 +27,7 @@
 bool
 xkb_components_from_rules(struct xkb_context *ctx,
                           const struct xkb_rule_names *rmlvo,
-                          struct xkb_component_names *out);
+                          struct xkb_component_names *out,
+                          xkb_layout_index_t *layout_count);
 
 #endif

--- a/src/xkbcomp/xkbcomp.c
+++ b/src/xkbcomp/xkbcomp.c
@@ -65,7 +65,7 @@ text_v1_keymap_new_from_names(struct xkb_keymap *keymap,
             rmlvo->rules, rmlvo->model, rmlvo->layout, rmlvo->variant,
             rmlvo->options);
 
-    ok = xkb_components_from_rules(keymap->ctx, rmlvo, &kccgst);
+    ok = xkb_components_from_rules(keymap->ctx, rmlvo, &kccgst, &keymap->num_explicit_groups);
     if (!ok) {
         log_err(keymap->ctx,
                 "Couldn't look up rules '%s', model '%s', layout '%s', "

--- a/test/data/rules/modifiers
+++ b/test/data/rules/modifiers
@@ -1,0 +1,19 @@
+! include %S/evdev
+
+! option         = symbols
+  // Override
+  my_option_O0   = +group(alt_space_toggle)
+  my_option_O1   = +group(alt_space_toggle):1
+  my_option_O13  = +group(alt_space_toggle):1+group(alt_space_toggle):3
+  my_option_Ox   = +group(alt_space_toggle):4294967295 // invalid layout index
+  my_option_Oall = +group(alt_space_toggle):all
+  // Augment
+  my_option_A0   = |group(alt_space_toggle)
+  my_option_A1   = |group(alt_space_toggle):1
+  my_option_A13  = |group(alt_space_toggle):1|group(alt_space_toggle):3
+  my_option_Ax   = |group(alt_space_toggle):4294967295 // invalid layout index
+  my_option_Aall = |group(alt_space_toggle):all
+
+! layout option	         = symbols
+*        my_option_LOall = +group(alt_space_toggle):all
+*        my_option_LAall = |group(alt_space_toggle):all

--- a/test/rules-file-includes.c
+++ b/test/rules-file-includes.c
@@ -44,6 +44,7 @@ struct test_data {
     const char *types;
     const char *compat;
     const char *symbols;
+    const xkb_layout_index_t groups;
 
     /* Or set this if xkb_components_from_rules() should fail. */
     bool should_fail;
@@ -57,6 +58,7 @@ test_rules(struct xkb_context *ctx, struct test_data *data)
         data->rules, data->model, data->layout, data->variant, data->options
     };
     struct xkb_component_names kccgst;
+    xkb_layout_index_t groups;
 
     fprintf(stderr, "\n\nChecking : %s\t%s\t%s\t%s\t%s\n", data->rules,
             data->model, data->layout, data->variant, data->options);
@@ -64,21 +66,22 @@ test_rules(struct xkb_context *ctx, struct test_data *data)
     if (data->should_fail)
         fprintf(stderr, "Expecting: FAILURE\n");
     else
-        fprintf(stderr, "Expecting: %s\t%s\t%s\t%s\n",
-                data->keycodes, data->types, data->compat, data->symbols);
+        fprintf(stderr, "Expecting: %s\t%s\t%s\t%s\t%u\n",
+                data->keycodes, data->types, data->compat, data->symbols, data->groups);
 
-    if (!xkb_components_from_rules(ctx, &rmlvo, &kccgst)) {
+    if (!xkb_components_from_rules(ctx, &rmlvo, &kccgst, &groups)) {
         fprintf(stderr, "Received : FAILURE\n");
         return data->should_fail;
     }
 
-    fprintf(stderr, "Received : %s\t%s\t%s\t%s\n",
-            kccgst.keycodes, kccgst.types, kccgst.compat, kccgst.symbols);
+    fprintf(stderr, "Received : %s\t%s\t%s\t%s\t%u\n",
+            kccgst.keycodes, kccgst.types, kccgst.compat, kccgst.symbols, groups);
 
     passed = streq(kccgst.keycodes, data->keycodes) &&
              streq(kccgst.types, data->types) &&
              streq(kccgst.compat, data->compat) &&
-             streq(kccgst.symbols, data->symbols);
+             streq(kccgst.symbols, data->symbols) &&
+             groups == data->groups;
 
     free(kccgst.keycodes);
     free(kccgst.types);
@@ -105,6 +108,7 @@ main(int argc, char *argv[])
 
         .keycodes = "my_keycodes", .types = "default_types",
         .compat = "default_compat", .symbols = "my_symbols",
+        .groups = 1,
     };
     assert(test_rules(ctx, &test1));
 
@@ -115,6 +119,7 @@ main(int argc, char *argv[])
 
         .keycodes = "my_keycodes", .types = "default_types",
         .compat = "default_compat", .symbols = "my_symbols",
+        .groups = 1,
     };
     assert(test_rules(ctx, &test2));
 
@@ -134,6 +139,7 @@ main(int argc, char *argv[])
 
         .keycodes = "my_keycodes", .types = "default_types",
         .compat = "default_compat", .symbols = "default_symbols",
+        .groups = 1,
     };
     assert(test_rules(ctx, &test4));
 
@@ -146,6 +152,7 @@ main(int argc, char *argv[])
         .keycodes = "my_keycodes", .types = "default_types",
         .compat = "default_compat+substring+group(bla)|some:compat",
         .symbols = "my_symbols+extra_variant+altwin(menu)",
+        .groups = 1,
     };
     assert(test_rules(ctx, &test5));
 
@@ -156,6 +163,7 @@ main(int argc, char *argv[])
 
         .keycodes = "my_keycodes", .types = "default_types",
         .compat = "default_compat", .symbols = "my_symbols",
+        .groups = 1,
     };
     assert(test_rules(ctx, &test6));
 

--- a/test/rules-file.c
+++ b/test/rules-file.c
@@ -42,6 +42,7 @@ struct test_data {
     const char *types;
     const char *compat;
     const char *symbols;
+    const xkb_layout_index_t groups;
 
     /* Or set this if xkb_components_from_rules() should fail. */
     bool should_fail;
@@ -55,6 +56,7 @@ test_rules(struct xkb_context *ctx, struct test_data *data)
         data->rules, data->model, data->layout, data->variant, data->options
     };
     struct xkb_component_names kccgst;
+    xkb_layout_index_t groups;
 
     fprintf(stderr, "\n\nChecking : %s\t%s\t%s\t%s\t%s\n", data->rules,
             data->model, data->layout, data->variant, data->options);
@@ -62,21 +64,22 @@ test_rules(struct xkb_context *ctx, struct test_data *data)
     if (data->should_fail)
         fprintf(stderr, "Expecting: FAILURE\n");
     else
-        fprintf(stderr, "Expecting: %s\t%s\t%s\t%s\n",
-                data->keycodes, data->types, data->compat, data->symbols);
+        fprintf(stderr, "Expecting: %s\t%s\t%s\t%s\t%u\n",
+                data->keycodes, data->types, data->compat, data->symbols, data->groups);
 
-    if (!xkb_components_from_rules(ctx, &rmlvo, &kccgst)) {
+    if (!xkb_components_from_rules(ctx, &rmlvo, &kccgst, &groups)) {
         fprintf(stderr, "Received : FAILURE\n");
         return data->should_fail;
     }
 
-    fprintf(stderr, "Received : %s\t%s\t%s\t%s\n",
-            kccgst.keycodes, kccgst.types, kccgst.compat, kccgst.symbols);
+    fprintf(stderr, "Received : %s\t%s\t%s\t%s\t%u\n",
+            kccgst.keycodes, kccgst.types, kccgst.compat, kccgst.symbols, groups);
 
     passed = streq(kccgst.keycodes, data->keycodes) &&
              streq(kccgst.types, data->types) &&
              streq(kccgst.compat, data->compat) &&
-             streq(kccgst.symbols, data->symbols);
+             streq(kccgst.symbols, data->symbols) &&
+             groups == data->groups;
 
     free(kccgst.keycodes);
     free(kccgst.types);
@@ -103,6 +106,7 @@ main(int argc, char *argv[])
         .keycodes = "my_keycodes", .types = "my_types",
         .compat = "my_compat|some:compat",
         .symbols = "my_symbols+extra_variant",
+        .groups = 1,
     };
     assert(test_rules(ctx, &test1));
 
@@ -113,6 +117,7 @@ main(int argc, char *argv[])
 
         .keycodes = "default_keycodes", .types = "default_types",
         .compat = "default_compat", .symbols = "default_symbols",
+        .groups = 1,
     };
     assert(test_rules(ctx, &test2));
 
@@ -123,6 +128,7 @@ main(int argc, char *argv[])
 
         .keycodes = "something(pc104)", .types = "default_types",
         .compat = "default_compat", .symbols = "default_symbols",
+        .groups = 1,
     };
     assert(test_rules(ctx, &test3));
 
@@ -133,6 +139,7 @@ main(int argc, char *argv[])
 
         .keycodes = "default_keycodes", .types = "default_types",
         .compat = "default_compat", .symbols = "my_symbols+(bar)",
+        .groups = 1,
     };
     assert(test_rules(ctx, &test4));
 
@@ -155,6 +162,7 @@ main(int argc, char *argv[])
         .keycodes = "default_keycodes", .types = "default_types",
         .compat = "default_compat",
         .symbols = "default_symbols+extra:1+extra:2+extra:3+extra:4",
+        .groups = 4,
     };
     assert(test_rules(ctx, &test6));
 
@@ -167,6 +175,7 @@ main(int argc, char *argv[])
         .keycodes = "my_keycodes", .types = "my_types",
         .compat = "my_compat+some:compat+group(bla)",
         .symbols = "my_symbols+extra_variant+compose(foo)+keypad(bar)+altwin(menu)",
+        .groups = 1,
     };
     assert(test_rules(ctx, &test7));
 

--- a/tools/compile-keymap.c
+++ b/tools/compile-keymap.c
@@ -212,7 +212,7 @@ print_kccgst(struct xkb_context *ctx, const struct xkb_rule_names *rmlvo)
 #if ENABLE_PRIVATE_APIS
         struct xkb_component_names kccgst;
 
-        if (!xkb_components_from_rules(ctx, rmlvo, &kccgst))
+        if (!xkb_components_from_rules(ctx, rmlvo, &kccgst, NULL))
             return false;
 
         printf("xkb_keymap {\n"


### PR DESCRIPTION
This PR adds support for the [`:all`][xkbcomp issue] modifier in rules & include statements.

For example, the `xkeyboard-config` issue “[rules: add custom per-group mapping for level3(ralt_alt)](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/merge_requests/253)” could be solved easier with this feature:

```
! layout        option	        = symbols
*               lv3:ralt_alt    = +level3(ralt_alt):all
```

`xkbcomp` would require a patch too, though (see the corresponding [xkbcomp issue]).

This feature works by detecting the number of layouts in the RMLVO configuration. Example: it will replace the include statement `xx:all` by `xx:1+xx:2+xx:3` if there are 3 layouts and the merge mode is “override”.

__Caveat:__ it only works when a keymap is created from RMLVO configuration; i.e. it will not work when creating  a keymap e.g. from a string. But I guess this case is not so important, because as I understand querying the keymap to the windows system will return a complete & resolved  keymap without include statements.

Note: this could the first step to remove the limit of layout number (see #311, @bam80). 

[xkbcomp issue]: https://gitlab.freedesktop.org/xorg/app/xkbcomp/-/issues/23
