### PR TITLE
Configure github pages

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -53,6 +53,14 @@ jobs:
           name: test logs
           path: |
             build/meson-logs/
+      - name: Ensure doxygen version is correct
+        run: |
+            doxygen --version > version.txt
+            echo "1.9.6" >> version.txt
+            if [ $(sort -V version.txt | tail -n1) != "1.9.6" ]; then
+                echo "Doxygen version 1.9.6 or earlier expected, see #347"
+                exit 1
+            fi
       - name: Store doxygen docs for use by the pages workflow
         uses: actions/upload-artifact@v3
         if: success()

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup
         run: |
           # -gdwarf-4 - see https://github.com/llvm/llvm-project/issues/56550.
-          CFLAGS='-gdwarf-4' meson setup build
+          CFLAGS='-gdwarf-4' meson setup build -Denable-cool-uris=true
         env:
           CC: ${{ matrix.compiler }}
       - name: Build
@@ -53,3 +53,10 @@ jobs:
           name: test logs
           path: |
             build/meson-logs/
+      - name: Store doxygen docs for use by the pages workflow
+        uses: actions/upload-artifact@v3
+        if: success()
+        with:
+          name: doxygen-docs
+          path: |
+            build/html/

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,55 @@
+name: Deploy to GitHub pages
+
+on:
+  push:
+    branches: ["master"]
+
+  # Allow running this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Set up directory tree
+        run: mkdir -p public_html/doc/
+      - name: Download doxygen from Linux build
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: linux.yml
+          workflow_conclusion: success
+          name: doxygen-docs
+          path: doxygen/
+      - name: Move doxygen to target directory
+        run: mv doxygen/ public_html/doc/current/
+      - name: Check out the static website
+        uses: actions/checkout@v3
+        with:
+          repository: xkbcommon/website
+          persist-credentials: false
+          path: website
+      - name: Move static website to target directory
+        run: mv website/* public_html/
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: public_html/
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
Upload the doxygen output as artifact from the linux build and use that from the pages job where we combine the static website with our newly build HTML docs. The GitHub actions/download-artefact doesn't work across workflows so we use the other popular one that can do this. The rest of the job is basically copy/paste from the "Static HTML" example GitHub provides.

To make this useful as drop-in replacement, replace the one fixed link to the API docs a relative one.

Refs #326

---

- Result rendered into my checkout: https://whot.github.io/libxkbcommon/
- In the [libxkbcommon project settings](https://github.com/xkbcommon/libxkbcommon/settings/pages), `Build and deployment` select the `Github Actions` option (not `Deploy from branch`).