### PR TITLE
Do not interpret nor emit invalid Unicode encoding forms

### DIFF
--- a/test/keysym.c
+++ b/test/keysym.c
@@ -222,6 +222,8 @@ main(void)
 
     assert(test_utf8(0x10005d0, "א"));
     assert(test_utf8(0x110ffff, "\xf4\x8f\xbf\xbf"));
+    assert(test_utf8(0x0100d800, NULL) == 0); // Unicode surrogates
+    assert(test_utf8(0x0100dfff, NULL) == 0); // Unicode surrogates
     assert(test_utf8(0x1110000, NULL) == 0);
 
     assert(test_utf32_to_keysym('y', XKB_KEY_y));
@@ -255,6 +257,8 @@ main(void)
     assert(test_utf32_to_keysym(0x20ac, XKB_KEY_EuroSign));
 
     // Unicode non-characters
+    assert(test_utf32_to_keysym(0xd800, XKB_KEY_NoSymbol)); // Unicode surrogates
+    assert(test_utf32_to_keysym(0xdfff, XKB_KEY_NoSymbol)); // Unicode surrogates
     assert(test_utf32_to_keysym(0xfdd0, XKB_KEY_NoSymbol));
     assert(test_utf32_to_keysym(0xfdef, XKB_KEY_NoSymbol));
     assert(test_utf32_to_keysym(0xfffe, XKB_KEY_NoSymbol));

--- a/test/utf8.c
+++ b/test/utf8.c
@@ -170,6 +170,8 @@ test_utf32_to_utf8(void)
     check_utf32_to_utf8(0x40, 2, "\x40");
     check_utf32_to_utf8(0xA1, 3, "\xc2\xa1");
     check_utf32_to_utf8(0x2701, 4, "\xe2\x9c\x81");
+    check_utf32_to_utf8(0xd800, 0, ""); // Unicode surrogates
+    check_utf32_to_utf8(0xdfff, 0, ""); // Unicode surrogates
     check_utf32_to_utf8(0x1f004, 5, "\xf0\x9f\x80\x84");
     check_utf32_to_utf8(0x110000, 0, "");
     check_utf32_to_utf8(0xffffffff, 0, "");


### PR DESCRIPTION
Surrogates are invalid in both [UTF-32](https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf#G28875) and [UTF-8](https://www.unicode.org/versions/Unicode15.0.0/ch03.pdf#G31703).

Fixes #60 