### PR TITLE
Test: Use a xvfb wrapper  for x11 test

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,6 +31,19 @@ jobs:
           sudo apt install -y \
             doxygen libxcb-xkb-dev valgrind ninja-build \
             libwayland-dev wayland-protocols bison graphviz
+      - name: Install xkeyboard-config
+        run: |
+          # Install master version of xkeyboard-config, in order to ensure
+          # its latest version works well with xkbcommon.
+          # HACK: We use meson to install, while it would be cleaner
+          #       to create a proper package to install or use some PPA.
+          pushd ~
+          git clone --depth=1 https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config.git
+          cd "xkeyboard-config"
+          BUILDDIR=build
+          meson setup $BUILDDIR -Dprefix=/usr
+          meson install -C $BUILDDIR
+          popd
       - name: Setup
         run: |
           # -gdwarf-4 - see https://github.com/llvm/llvm-project/issues/56550.

--- a/meson.build
+++ b/meson.build
@@ -573,9 +573,11 @@ test_dep = declare_dependency(
     link_with: libxkbcommon_test_internal,
 )
 if get_option('enable-x11')
-    libxkbcommon_x11_internal = static_library(
+    libxkbcommon_x11_test_internal = static_library(
         'xkbcommon-x11-internal',
         libxkbcommon_x11_sources,
+        'test/xvfb-wrapper.c',
+        'test/xvfb-wrapper.h',
         include_directories: include_directories('src', 'include'),
         link_with: libxkbcommon_test_internal,
         dependencies: [
@@ -584,7 +586,7 @@ if get_option('enable-x11')
         ],
     )
     x11_test_dep = declare_dependency(
-        link_with: libxkbcommon_x11_internal,
+        link_with: libxkbcommon_x11_test_internal,
         dependencies: [
             test_dep,
             xcb_dep,

--- a/meson.build
+++ b/meson.build
@@ -691,9 +691,11 @@ if get_option('enable-x11')
         executable('test-x11', 'test/x11.c', dependencies: x11_test_dep),
         env: test_env,
     )
-    # test/x11comp is meant to be run, but it is (temporarily?) disabled.
-    # See: https://github.com/xkbcommon/libxkbcommon/issues/30
-    executable('test-x11comp', 'test/x11comp.c', dependencies: x11_test_dep)
+    test(
+        'x11comp',
+        executable('test-x11comp', 'test/x11comp.c', dependencies: x11_test_dep),
+        env: test_env,
+    )
 endif
 if get_option('enable-xkbregistry')
     test(

--- a/test/x11.c
+++ b/test/x11.c
@@ -24,10 +24,10 @@
 #include "config.h"
 
 #include "test.h"
+#include "xvfb-wrapper.h"
 #include "xkbcommon/xkbcommon-x11.h"
 
-int
-main(void)
+X11_TEST(test_basic)
 {
     struct xkb_context *ctx = test_get_context(0);
     xcb_connection_t *conn;
@@ -43,7 +43,7 @@ main(void)
     * If it fails, it's not necessarily an actual problem with the code.
     * So we don't want a FAIL here.
     */
-    conn = xcb_connect(NULL, NULL);
+    conn = xcb_connect(display, NULL);
     if (!conn || xcb_connection_has_error(conn)) {
         exit_code = SKIP_TEST;
         goto err_conn;
@@ -83,4 +83,8 @@ err_conn:
     xkb_context_unref(ctx);
 
     return exit_code;
+}
+
+int main(void) {
+    return x11_tests_run();
 }

--- a/test/xvfb-wrapper.c
+++ b/test/xvfb-wrapper.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2014 Ran Benita <ran234@gmail.com>
+ * Copyright © 2023 Pierre Le Marre <dev@wismill.eu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "config.h"
+
+#include <stdio.h>
+#include <spawn.h>
+#include <assert.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include "test.h"
+#include "xvfb-wrapper.h"
+#include "xkbcommon/xkbcommon-x11.h"
+
+int
+xvfb_wrapper(int (*test_func)(char* display))
+{
+    int ret = 0;
+    FILE * display_fd;
+    char display_fd_string[32];
+    char *xvfb_argv[] = {
+        (char *) "Xvfb", (char *) "-displayfd", display_fd_string, NULL
+    };
+    char *envp[] = { NULL };
+    pid_t xvfb_pid = 0;
+    char display[32] = ":";
+    size_t length;
+
+    /* File descriptor to retrieve the display number */
+    display_fd = tmpfile();
+    if (display_fd == NULL){
+        fprintf(stderr, "Unable to create temporary file.\n");
+        goto err_display_fd;
+    }
+    snprintf(display_fd_string, sizeof(display_fd_string), "%d", fileno(display_fd));
+
+    /*
+     * Xvfb command: let the server find an available display.
+     *
+     * Note that it may generate multiple times the following output in stderr:
+     *    _XSERVTransSocketUNIXCreateListener: ...SocketCreateListener() failed
+     * It is expected: this is the server trying the ports until it finds one
+     * that works.
+     */
+    ret = posix_spawnp(&xvfb_pid, "Xvfb", NULL, NULL, xvfb_argv, envp);
+    if (ret != 0) {
+        ret = SKIP_TEST;
+        goto err_xvfd;
+    }
+
+    /* Wait for Xvfb fully waking up to accept a connection from a client. */
+    sleep(1);
+
+    /* Retrieve the display number: Xvfd writes the display number as a newline-
+     * terminated string; copy this number to form a proper display string. */
+    rewind(display_fd);
+    length = fread(&display[1], 1, sizeof(display) - 1, display_fd);
+    if (length <= 0) {
+        ret = SKIP_TEST;
+        goto err_xvfd;
+    } else {
+        /* Drop the newline character */
+        display[length] = '\0';
+    }
+
+    /* Run the function requiring a running X server */
+    ret = test_func(display);
+
+err_xvfd:
+    if (xvfb_pid > 0)
+        kill(xvfb_pid, SIGTERM);
+    fclose(display_fd);
+err_display_fd:
+    return ret;
+}
+
+/* All X11_TEST functions are in the test_functions_section ELF section.
+ * __start and __stop point to the start and end of that section. See the
+ * __attribute__(section) documentation.
+ */
+extern const struct test_function __start_test_functions_section, __stop_test_functions_section;
+
+int
+x11_tests_run()
+{
+    size_t count = 1; /* For NULL-terminated entry */
+
+    for (const struct test_function *t = &__start_test_functions_section;
+         t < &__stop_test_functions_section;
+         t++)
+        count++;
+
+    int rc;
+    for (const struct test_function *t = &__start_test_functions_section;
+         t < &__stop_test_functions_section;
+         t++) {
+        fprintf(stderr, "Running test: %s from %s\n", t->name, t->file);
+        rc = xvfb_wrapper(t->func);
+        if (rc != 0) {
+            break;
+        }
+    }
+
+    return rc;
+}

--- a/test/xvfb-wrapper.h
+++ b/test/xvfb-wrapper.h
@@ -1,0 +1,44 @@
+/* This is a wrapper around X11 tests to make it faster to use for the simple
+ * type of test cases.
+ *
+ * Use with the X11_TEST macro like this:
+ *
+ * X11_TEST(some_test) {
+ *  return 0;
+ * }
+ *
+ * int main(void) {
+ *  return x11_tests_run(void);
+ * }
+ *
+ */
+
+#pragma once
+
+typedef int (* x11_test_func_t)(char* display);
+
+struct test_function {
+    const char *name;     /* function name */
+    const char *file;     /* file name */
+    x11_test_func_t func; /* test function */
+} __attribute__((aligned(16)));
+
+/**
+ * Defines a struct test_function in a custom ELF section that we can then
+ * loop over in x11_tests_run() to extract the tests. This removes the
+ * need of manually adding the tests to a suite or listing them somewhere.
+ */
+#define X11_TEST(_func) \
+static int _func(char* display); \
+static const struct test_function _test_##_func \
+__attribute__((used)) \
+__attribute__((section("test_functions_section"))) = { \
+    .name = #_func, \
+    .func = _func, \
+    .file = __FILE__, \
+}; \
+static int _func(char* display)
+
+int xvfb_wrapper(int (*f)(char* display));
+
+int x11_tests_run(void);


### PR DESCRIPTION
The X11 test is currently silently skipped in CI. Use a `xvfb` wrapper to ensure to run it. See #339 for the rationale.

The code is adapted from #339 ~and it is intended to be rebased on it, then refactor the x11comp test as well with the wrapper~, which is closed in favour of this new PR.

Question: should we use an option to disable the wrapper, in order to test with a local X11 server as previously?