### PR TITLE
Test (compose): fix assumption on environment variables

### DIFF
--- a/test/compose.c
+++ b/test/compose.c
@@ -588,6 +588,22 @@ main(int argc, char *argv[])
     ctx = test_get_context(CONTEXT_NO_FLAG);
     assert(ctx);
 
+    /*
+     * Ensure no environment variables but “top_srcdir” is set. This ensures
+     * that user Compose file paths are unset before the tests and set
+     * explicitely when necessary.
+     */
+#ifdef __linux__
+    const char *srcdir = getenv("top_srcdir");
+    clearenv();
+    setenv("top_srcdir", srcdir, 1);
+#else
+    unsetenv("XCOMPOSEFILE");
+    unsetenv("XDG_CONFIG_HOME");
+    unsetenv("HOME");
+    unsetenv("XLOCALEDIR");
+#endif
+
     test_seqs(ctx);
     test_conflicting(ctx);
     test_XCOMPOSEFILE(ctx);


### PR DESCRIPTION
The test `test_from_locale` fails when there is a user-defined compose file, e.g. ~/.XCompose.

Indeed, the function `xkb_compose_table_new_from_locale` use various environment variables to determine the location of the compose file.

Ensure these environment variables are initially explicitly unset, in order to have robust tests.

Fixes #349