### PR TITLE
Add a meson flag to make cool URIs optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -833,20 +833,22 @@ You can disable the documentation with -Denable-docs=false.''')
         install_dir: docdir,
         build_by_default: true,
     )
-    ensure_stable_urls = find_program('scripts'/'ensure-stable-doc-urls.py')
-    custom_target(
-        'doc-cool-uris',
-        input: [doc_gen, 'doc'/'cool-uris.yaml'],
-        output: 'html-xtra',
-        command: [
-            ensure_stable_urls,
-            'generate-redirections',
-            meson.current_source_dir()/'doc'/'cool-uris.yaml',
-            meson.current_build_dir()/'html'
-        ],
-        install: false,
-        build_by_default: true,
-    )
+    if get_option('enable-cool-uris')
+        ensure_stable_urls = find_program('scripts'/'ensure-stable-doc-urls.py')
+        custom_target(
+            'doc-cool-uris',
+            input: [doc_gen, 'doc'/'cool-uris.yaml'],
+            output: 'html-xtra',
+            command: [
+                ensure_stable_urls,
+                'generate-redirections',
+                meson.current_source_dir()/'doc'/'cool-uris.yaml',
+                meson.current_build_dir()/'html'
+            ],
+            install: false,
+            build_by_default: true,
+        )
+    endif
 endif
 
 configure_file(output: 'config.h', configuration: configh_data)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -62,6 +62,12 @@ option(
     description: 'Enable building the documentation',
 )
 option(
+    'enable-cool-uris',
+    type: 'boolean',
+    value: false,
+    description: 'Enable creating redirections to maintain stable documentation pages',
+)
+option(
     'enable-wayland',
     type: 'boolean',
     value: true,


### PR DESCRIPTION
The script `ensure-stable-doc-urls.py` relies on the Doxygen output files names. These may change between Doxygen versions, although the Doxygen developers intend stability.

Since the script is useful mainly for the online documentation of xkbcommon, make the target `doc-cool-uris` optional.

See #347 