### PR TITLE
Improve interactive tools

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -416,10 +416,13 @@ man_pages = []
 # Tools
 build_tools = get_option('enable-tools') and cc.has_header_symbol('getopt.h', 'getopt_long', prefix: '#define _GNU_SOURCE')
 if build_tools
-    libxkbcommon_tools_internal = static_library(
-        'tools-internal',
+    libxkbcommon_tools_internal_sources = [
         'tools/tools-common.h',
         'tools/tools-common.c',
+    ]
+    libxkbcommon_tools_internal = static_library(
+        'tools-internal',
+        libxkbcommon_tools_internal_sources,
         dependencies: dep_libxkbcommon,
     )
     tools_dep = declare_dependency(
@@ -467,6 +470,15 @@ if build_tools
                    install_dir: dir_libexec)
         configh_data.set10('HAVE_XKBCLI_INTERACTIVE_EVDEV', true)
         install_man('tools/xkbcli-interactive-evdev.1')
+        # The same tool again, but with access to some private APIs.
+        executable('interactive-evdev',
+                'tools/interactive-evdev.c',
+                libxkbcommon_sources,
+                libxkbcommon_tools_internal_sources,
+                dependencies: [tools_dep],
+                c_args: ['-DENABLE_PRIVATE_APIS'],
+                include_directories: [include_directories('src', 'include')],
+                install: false)
     endif
     if get_option('enable-x11')
         x11_tools_dep = declare_dependency(

--- a/tools/interactive-wayland.c
+++ b/tools/interactive-wayland.c
@@ -400,7 +400,8 @@ kbd_key(void *data, struct wl_keyboard *wl_kbd, uint32_t serial, uint32_t time,
 
     printf("%s: ", seat->name_str);
     tools_print_keycode_state(seat->state, NULL, key + EVDEV_OFFSET,
-                              XKB_CONSUMED_MODE_XKB);
+                              XKB_CONSUMED_MODE_XKB,
+                              PRINT_ALL_FIELDS);
 
     /* Exit on ESC. */
     if (xkb_state_key_get_one_sym(seat->state, key + EVDEV_OFFSET) == XKB_KEY_Escape)

--- a/tools/interactive-x11.c
+++ b/tools/interactive-x11.c
@@ -243,7 +243,8 @@ process_event(xcb_generic_event_t *gevent, struct keyboard *kbd)
         xkb_keycode_t keycode = event->detail;
 
         tools_print_keycode_state(kbd->state, NULL, keycode,
-                                  XKB_CONSUMED_MODE_XKB);
+                                  XKB_CONSUMED_MODE_XKB,
+                                  PRINT_ALL_FIELDS);
 
         /* Exit on ESC. */
         if (xkb_state_key_get_one_sym(kbd->state, keycode) == XKB_KEY_Escape)

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -32,6 +32,7 @@
 
 #include "config.h"
 
+#include <ctype.h>
 #include <errno.h>
 #include <limits.h>
 #include <fcntl.h>
@@ -99,7 +100,17 @@ tools_print_keycode_state(struct xkb_state *state,
         xkb_compose_state_get_utf8(compose_state, s, sizeof(s));
     else
         xkb_state_key_get_utf8(state, keycode, s, sizeof(s));
-    printf("unicode [ %s ] ", s);
+    /* HACK: escape single control characters from C0 set using the
+    * Unicode codepoint convention. Ideally we would like to escape
+    * any non-printable character in the string.
+    */
+    if (!*s) {
+        printf("unicode [   ] ");
+    } else if (strlen(s) == 1 && (*s <= 0x1F || *s == 0x7F)) {
+        printf("unicode [ U+%04hX ] ", *s);
+    } else {
+        printf("unicode [ %s ] ", s);
+    }
 
     layout = xkb_state_key_get_layout(state, keycode);
     printf("layout [ %s (%d) ] ",

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -50,6 +50,17 @@
 
 #include "tools-common.h"
 
+static void
+print_keycode(struct xkb_keymap *keymap, const char* prefix,
+              xkb_keycode_t keycode, const char *suffix) {
+    const char *keyname = xkb_keymap_key_get_name(keymap, keycode);
+    if (keyname) {
+        printf("%s%-4s%s", prefix, keyname, suffix);
+    } else {
+        printf("%s%-4d%s", prefix, keycode, suffix);
+    }
+}
+
 void
 tools_print_keycode_state(struct xkb_state *state,
                           struct xkb_compose_state *compose_state,
@@ -88,6 +99,8 @@ tools_print_keycode_state(struct xkb_state *state,
         sym = xkb_state_key_get_one_sym(state, keycode);
         syms = &sym;
     }
+
+    print_keycode(keymap, "keycode [ ", keycode, " ] ");
 
     printf("keysyms [ ");
     for (int i = 0; i < nsyms; i++) {

--- a/tools/tools-common.h
+++ b/tools/tools-common.h
@@ -38,6 +38,9 @@
 
 /* Fields that are printed in the interactive tools. */
 enum print_state_fields {
+#ifdef ENABLE_PRIVATE_APIS
+    PRINT_MODMAPS = (1u << 1),
+#endif
     PRINT_LAYOUT = (1u << 2),
     PRINT_UNICODE = (1u << 3),
     PRINT_ALL_FIELDS = ((PRINT_UNICODE << 1) - 1),
@@ -49,6 +52,13 @@ enum print_state_fields {
     PRINT_VERBOSE_FIELDS = (PRINT_LAYOUT | PRINT_UNICODE)
 };
 typedef uint32_t print_state_fields_mask_t;
+
+#ifdef ENABLE_PRIVATE_APIS
+void
+print_keymap_modmaps(struct xkb_keymap *keymap);
+void
+print_keys_modmaps(struct xkb_keymap *keymap);
+#endif
 
 void
 tools_print_keycode_state(struct xkb_state *state,

--- a/tools/tools-common.h
+++ b/tools/tools-common.h
@@ -36,11 +36,26 @@
 
 #define ARRAY_SIZE(arr) ((sizeof(arr) / sizeof(*(arr))))
 
+/* Fields that are printed in the interactive tools. */
+enum print_state_fields {
+    PRINT_LAYOUT = (1u << 2),
+    PRINT_UNICODE = (1u << 3),
+    PRINT_ALL_FIELDS = ((PRINT_UNICODE << 1) - 1),
+    /*
+     * Fields that can be hidden with the option --short.
+     * NOTE: If this value is modified, remember to update the documentation of
+     *       the --short option in the corresponding tools.
+     */
+    PRINT_VERBOSE_FIELDS = (PRINT_LAYOUT | PRINT_UNICODE)
+};
+typedef uint32_t print_state_fields_mask_t;
+
 void
 tools_print_keycode_state(struct xkb_state *state,
                           struct xkb_compose_state *compose_state,
                           xkb_keycode_t keycode,
-                          enum xkb_consumed_mode consumed_mode);
+                          enum xkb_consumed_mode consumed_mode,
+                          print_state_fields_mask_t fields);
 
 void
 tools_print_state_changes(enum xkb_state_component changed);


### PR DESCRIPTION
I would like to revive #36 but I realize that I use a bunch of `printf` for debugging modifiers.

This MR add new options to `interactive-evdev` for debugging (see commits). Some options use the private API, so I added a non-installable version of the tool with this API.

I did not modify the other tools ATM, because `interactive-evdev` seem the most flexible one, being able to load whatever configuration without depending nor impacting the environment.

There is one commit that improve the display of control characters from key strokes translation.