### PR TITLE
xkbcli: allow compile-keymap without args

### DIFF
--- a/tools/compile-keymap.c
+++ b/tools/compile-keymap.c
@@ -322,7 +322,7 @@ main(int argc, char **argv)
     };
     int rc = 1;
 
-    if (argc <= 1) {
+    if (argc < 1) {
         usage(argv);
         return EXIT_INVALID_USAGE;
     }


### PR DESCRIPTION
All of the arguments have defaults, but still an argument is required. Make it work.