### PR TITLE
Fix numeric keysym parsing

### DIFF
--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -304,6 +304,15 @@ typedef uint32_t xkb_led_mask_t;
 #define XKB_KEYCODE_MAX     (0xffffffff - 1)
 
 /**
+ * Maximum keysym value
+ *
+ * @since 1.6.0
+ * @sa xkb_keysym_t
+ * @ingroup keysyms
+ */
+#define XKB_KEYSYM_MAX      0x1fffffff
+
+/**
  * Test whether a value is a valid extended keycode.
  * @sa xkb_keycode_t
  **/

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -169,28 +169,37 @@ typedef uint32_t xkb_keycode_t;
  *
  * A key, represented by a keycode, may generate different symbols according
  * to keyboard state.  For example, on a QWERTY keyboard, pressing the key
- * labled \<A\> generates the symbol 'a'.  If the Shift key is held, it
- * generates the symbol 'A'.  If a different layout is used, say Greek,
- * it generates the symbol 'α'.  And so on.
+ * labled \<A\> generates the symbol ‘a’.  If the Shift key is held, it
+ * generates the symbol ‘A’.  If a different layout is used, say Greek,
+ * it generates the symbol ‘α’.  And so on.
  *
- * Each such symbol is represented by a keysym.  Note that keysyms are
- * somewhat more general, in that they can also represent some "function",
- * such as "Left" or "Right" for the arrow keys.  For more information,
- * see:
- * https://www.x.org/releases/current/doc/xproto/x11protocol.html#keysym_encoding
+ * Each such symbol is represented by a *keysym* (short for “key symbol”).
+ * Note that keysyms are somewhat more general, in that they can also represent
+ * some “function”, such as “Left” or “Right” for the arrow keys.  For more
+ * information, see: Appendix A [“KEYSYM Encoding”][encoding] of the X Window
+ * System Protocol.
  *
  * Specifically named keysyms can be found in the
  * xkbcommon/xkbcommon-keysyms.h header file.  Their name does not include
- * the XKB_KEY_ prefix.
+ * the `XKB_KEY_` prefix.
  *
- * Besides those, any Unicode/ISO 10646 character in the range U0100 to
- * U10FFFF can be represented by a keysym value in the range 0x01000100 to
- * 0x0110FFFF.  The name of Unicode keysyms is "U<codepoint>", e.g. "UA1B2".
+ * Besides those, any Unicode/ISO&nbsp;10646 character in the range U+0100 to
+ * U+10FFFF can be represented by a keysym value in the range 0x01000100 to
+ * 0x0110FFFF.  The name of Unicode keysyms is `U<codepoint>`, e.g. `UA1B2`.
  *
  * The name of other unnamed keysyms is the hexadecimal representation of
- * their value, e.g. "0xabcd1234".
+ * their value, e.g. `0xabcd1234`.
  *
  * Keysym names are case-sensitive.
+ *
+ * @note **Encoding:** Keysyms are 32-bit integers with the 3 most significant
+ * bits always set to zero.  See: Appendix A [“KEYSYM Encoding”][encoding] of
+ * the X Window System Protocol.
+ *
+ * [encoding]: https://www.x.org/releases/current/doc/xproto/x11protocol.html#keysym_encoding
+ *
+ * @ingroup keysyms
+ * @sa XKB_KEYSYM_MAX
  */
 typedef uint32_t xkb_keysym_t;
 
@@ -389,7 +398,7 @@ struct xkb_rule_names {
 
 /**
  * @defgroup keysyms Keysyms
- * Utility functions related to keysyms.
+ * Utility functions related to *keysyms* (short for “key symbols”).
  *
  * @{
  */

--- a/src/keysym.c
+++ b/src/keysym.c
@@ -208,6 +208,8 @@ xkb_keysym_from_name(const char *name, enum xkb_keysym_flags flags)
     else if (name[0] == '0' && (name[1] == 'x' || (icase && name[1] == 'X'))) {
         if (!parse_keysym_hex(&name[2], &val))
             return XKB_KEY_NoSymbol;
+        if (val > XKB_KEYSYM_MAX)
+            return XKB_KEY_NoSymbol;
         return (xkb_keysym_t) val;
     }
 

--- a/src/keysym.c
+++ b/src/keysym.c
@@ -64,7 +64,7 @@ get_name(const struct name_keysym *entry)
 XKB_EXPORT int
 xkb_keysym_get_name(xkb_keysym_t ks, char *buffer, size_t size)
 {
-    if ((ks & ((unsigned long) ~0x1fffffff)) != 0) {
+    if (ks > XKB_KEYSYM_MAX) {
         snprintf(buffer, size, "Invalid");
         return -1;
     }

--- a/src/keysym.h
+++ b/src/keysym.h
@@ -50,6 +50,14 @@
 #ifndef KEYSYM_H
 #define KEYSYM_H
 
+/*
+ * NOTE: this is not defined in xkbcommon.h, because if we did, it may add
+ * overhead for library user: when handling keysyms they would also need to
+ * check min keysym when previously there was no reason to.
+ */
+/** Minimum keysym value */
+#define XKB_KEYSYM_MIN      0x00000000
+
 bool
 xkb_keysym_is_lower(xkb_keysym_t keysym);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -62,6 +62,9 @@
 /* Round up @a so it's divisible by @b. */
 #define ROUNDUP(a, b) (((a) + (b) - 1) / (b) * (b))
 
+#define STRINGIFY(x) #x
+#define STRINGIFY2(x) STRINGIFY(x)
+
 char
 to_lower(char c);
 

--- a/src/x11/keymap.c
+++ b/src/x11/keymap.c
@@ -61,7 +61,6 @@
  * We try not to trust the server too much and be paranoid. If we get
  * something which we definitely shouldn't, we fail.
  */
-#define STRINGIFY(expr) #expr
 #define FAIL_UNLESS(expr) do {                                          \
     if (!(expr)) {                                                      \
         log_err(keymap->ctx,                                            \

--- a/test/data/symbols/numeric_keysyms
+++ b/test/data/symbols/numeric_keysyms
@@ -1,0 +1,13 @@
+default alphanumeric_keys
+xkb_symbols "numeric keysyms" {
+    name[Group1]= "My Awesome Layout";
+
+    key <AD01> { [ 536870909 ] };
+    key <AD02> { [ 0x1ffffffe ] };
+    key <AD03> { [ 0x1fffffff, 0xffffffff ] };
+
+    modMap Mod1 { 536870909 };
+    modMap Mod2 { 0x1ffffffe };
+    modMap Mod3 { 0x1fffffff };
+    modMap Mod4 { 0xffffffff };
+};


### PR DESCRIPTION
While working on #332, I realized that numeric keysyms parsing has some issues. Let’s deal with it in this separate PR.

This PR fixes some edges cases and improve tests.