### PR TITLE
doc: fix some Doxygen warnings

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -40,6 +40,7 @@ IGNORE_PREFIX          = xkb_ \
 
 HTML_EXTRA_STYLESHEET  = doc/doxygen-extra.css
 
+TIMESTAMP              = NO
 HTML_TIMESTAMP         = NO
 
 ENUM_VALUES_PER_LINE   = 1

--- a/doc/introduction-to-xkb.md
+++ b/doc/introduction-to-xkb.md
@@ -64,7 +64,7 @@ implementation.
       The rules _component_ is the file containing the set of rules to use.
       It is usually implicit and set by the system.
 
-      See the [rules file format](@ref rule-file-format) for further details.
+      See the [rules file format](doc/rules-format.md) for further details.
       </dd>
       <dt>Model</dt>
       <dd>
@@ -178,7 +178,7 @@ is very close to XKB 1.0, with some removals and additions. See the
 [compatibility] page for further details.
 
 The format supported by _xkbcommon_ is documented at the page
-“[The XKB keymap text format, V1][keymap-text-format-v1]”.
+“[The XKB keymap text format, V1][keymap-format-text-v1]”.
 
 The documentation of the _original_ XKB 1.0 format is much more scarce than
 for the protocol. Some priceless resources are:
@@ -193,7 +193,7 @@ for the protocol. Some priceless resources are:
 [xkbcommon-x11]: @ref x11-overview
 [Wayland]: https://wayland.freedesktop.org/docs/html/apa.html#protocol-spec-wl_keyboard
 [compatibility]: @ref xkb-v1-compatibility
-[keymap-text-format-v1]: @ref keymap-text-format-v1
+[keymap-format-text-v1]: doc/keymap-format-text-v1.md
 [ivan-pascal]: https://web.archive.org/web/20190724015820/http://pascal.tsu.ru/en/xkb/
 [unreliable-guide]: https://www.charvolant.org/doug/xkb/html/index.html
 [arch-wiki]: https://wiki.archlinux.org/index.php/X_keyboard_extension

--- a/doc/rules-format.md
+++ b/doc/rules-format.md
@@ -7,7 +7,8 @@ configuration values xkbcomp uses and understands.
 
 xkbcomp uses the `xkb_component_names` struct, which maps directly to
 include statements of the appropriate sections, called for short
-[KcCGST](@ref KcCGST-intro) (see the [XKB introduction](@ref xkb-intro);
+[KcCGST](@ref KcCGST-intro) (see the [XKB
+introduction](doc/introduction-to-xkb.md);
 'G' stands for "geometry", which is not supported). These are not
 really intuitive or straight-forward for the uninitiated.
 


### PR DESCRIPTION
```
libxkbcommon/doc/introduction-to-xkb.md:67: warning: unable to resolve reference to 'rule-file-format' for \ref command
libxkbcommon/doc/introduction-to-xkb.md:181: warning: unable to resolve reference to 'keymap-text-format-v1' for \ref command
libxkbcommon/doc/rules-format.md:10: warning: unable to resolve reference to 'xkb-intro' for \ref command
```