### PR TITLE
parser.y update for deprecated %pure-parser

### DIFF
--- a/src/xkbcomp/parser.y
+++ b/src/xkbcomp/parser.y
@@ -85,7 +85,7 @@ resolve_keysym(const char *name, xkb_keysym_t *sym_rtrn)
 #define param_scanner param->scanner
 %}
 
-%pure-parser
+%define api.pure
 %lex-param      { struct scanner *param_scanner }
 %parse-param    { struct parser_param *param }
 


### PR DESCRIPTION
Hi,
Thank you for libxkbcommon.
I get this when building -
../src/xkbcomp/parser.y:88.1-12: warning: deprecated directive: ‘%pure-parser’, use ‘%define api.pure’ [-Wdeprecated]
and changed parser.y to use newer method.
Not sure if changing causes more harm than good or if we can version this somehow.
I am using bison 3.5.1
thx