### PR TITLE
Improve compose traverse perf

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -503,6 +503,9 @@ if build_tools
     # Tool: compose
     executable('xkbcli-compile-compose',
                'tools/compile-compose.c',
+               'src/compose/dump.c',
+               'src/compose/dump.h',
+               'src/compose/escape.h',
                dependencies: tools_dep,
                install: true,
                install_dir: dir_libexec)
@@ -765,7 +768,14 @@ test(
 )
 test(
     'compose',
-    executable('test-compose', 'test/compose.c', dependencies: test_dep),
+    executable(
+        'test-compose',
+        'test/compose.c',
+        'src/compose/dump.c',
+        'src/compose/dump.h',
+        'src/compose/escape.h',
+        dependencies: test_dep
+    ),
     env: test_env,
 )
 test(

--- a/meson.build
+++ b/meson.build
@@ -917,7 +917,15 @@ benchmark(
 )
 benchmark(
     'compose-traversal',
-    executable('bench-compose-traversal', 'bench/compose-traversal.c', dependencies: test_dep),
+    executable(
+        'bench-compose-traversal',
+        'bench/compose-traversal.c',
+        'bench/bench.h',
+        'test/compose-iter.c',
+        'test/compose-iter.h',
+        'test/test.h',
+        dependencies: test_dep
+    ),
     env: bench_env,
 )
 benchmark(

--- a/meson.build
+++ b/meson.build
@@ -133,6 +133,9 @@ if cc.has_header_symbol('stdio.h', 'asprintf', prefix: system_ext_define)
 elif cc.has_header_symbol('stdio.h', 'vasprintf', prefix: system_ext_define)
     configh_data.set('HAVE_VASPRINTF', 1)
 endif
+if cc.has_header_symbol('stdio.h', 'open_memstream', prefix: system_ext_define)
+    configh_data.set('HAVE_OPEN_MEMSTREAM', 1)
+endif
 if cc.has_header_symbol('stdlib.h', 'secure_getenv', prefix: system_ext_define)
     configh_data.set('HAVE_SECURE_GETENV', 1)
 elif cc.has_header_symbol('stdlib.h', '__secure_getenv', prefix: system_ext_define)

--- a/meson.build
+++ b/meson.build
@@ -771,6 +771,10 @@ test(
     executable(
         'test-compose',
         'test/compose.c',
+        'test/shuffle-lines.c',
+        'test/shuffle-lines.h',
+        'test/compose-iter.c',
+        'test/compose-iter.h',
         'src/compose/dump.c',
         'src/compose/dump.h',
         'src/compose/escape.h',
@@ -863,6 +867,8 @@ if valgrind.found()
                        '--track-origins=yes',
                        '--gen-suppressions=all',
                        '--error-exitcode=99'],
+        # This is used in some tests, to avoid excessive run time.
+        env: {'RUNNING_VALGRIND': '1'},
         timeout_multiplier : 10)
 else
     message('valgrind not found, disabling valgrind test setup')

--- a/src/compose/dump.c
+++ b/src/compose/dump.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2021 Ran Benita <ran@unusedvar.com>
+ * Copyright © 2023 Pierre Le Marre <dev@wismill.eu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "config.h"
+
+#include "src/darray.h"
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "xkbcommon/xkbcommon-compose.h"
+#include "parser.h"
+#include "escape.h"
+#include "dump.h"
+#include "src/keysym.h"
+#include "src/utils.h"
+
+bool
+print_compose_table_entry(FILE *file, struct xkb_compose_table_entry *entry)
+{
+    size_t nsyms;
+    const xkb_keysym_t *syms = xkb_compose_table_entry_sequence(entry, &nsyms);
+    char buf[XKB_KEYSYM_NAME_MAX_SIZE];
+    for (size_t i = 0; i < nsyms; i++) {
+        xkb_keysym_get_name(syms[i], buf, sizeof(buf));
+        fprintf(file, "<%s>", buf);
+        if (i + 1 < nsyms) {
+            fprintf(file, " ");
+        }
+    }
+    fprintf(file, " : ");
+    const char *utf8 = xkb_compose_table_entry_utf8(entry);
+    if (*utf8 != '\0') {
+        char *escaped = escape_utf8_string_literal(utf8);
+        if (!escaped) {
+            fprintf(stderr, "ERROR: Cannot escape the string: allocation error\n");
+            return false;
+        } else {
+            fprintf(file, " \"%s\"", escaped);
+            free(escaped);
+        }
+    }
+    const xkb_keysym_t keysym = xkb_compose_table_entry_keysym(entry);
+    if (keysym != XKB_KEY_NoSymbol) {
+        xkb_keysym_get_name(keysym, buf, sizeof(buf));
+        fprintf(file, " %s", buf);
+    }
+    fprintf(file, "\n");
+    return true;
+}
+
+bool
+xkb_compose_table_dump(FILE *file, struct xkb_compose_table *table)
+{
+    struct xkb_compose_table_entry *entry;
+    struct xkb_compose_table_iterator *iter = xkb_compose_table_iterator_new(table);
+
+    if (!iter)
+        return false;
+
+    bool ok = true;
+    while ((entry = xkb_compose_table_iterator_next(iter))) {
+        if (!print_compose_table_entry(file, entry)) {
+            ok = false;
+            break;
+        }
+    }
+
+    xkb_compose_table_iterator_free(iter);
+    return ok;
+}

--- a/src/compose/dump.h
+++ b/src/compose/dump.h
@@ -1,95 +1,14 @@
-/*
- * Copyright © 2023 Pierre Le Marre <dev@wismill.eu>
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice (including the next
- * paragraph) shall be included in all copies or substantial portions of the
- * Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
- */
-
-
 #ifndef COMPOSE_DUMP_H
 #define COMPOSE_DUMP_H
 
 #include "config.h"
 
-#include <stdlib.h>
+#include "table.h"
 
-#include "src/utils.h"
+bool
+print_compose_table_entry(FILE *file, struct xkb_compose_table_entry *entry);
 
-/* Ad-hoc escaping for UTF-8 string
- *
- * Note that it only escapes the strict minimum to get a valid Compose file.
- * It also escapes hexadecimal digits after an hexadecimal escape. This is not
- * strictly needed by the current implementation: "\x0abcg" parses as "␊bcg",
- * but better be cautious than sorry and produce "\x0a\x62\x63g" instead.
- * In the latter string there is no ambiguity and no need to know the maximum
- * number of digits supported by the escape sequence.
- */
-static inline char*
-escape_utf8_string_literal(const char *from)
-{
-    const size_t length = strlen(from);
-    /* Longest escape is converting ASCII character to "\xNN" */
-    char* to = calloc(4 * length + 1, sizeof(*to));
-    if (!to)
-        return NULL;
-
-    size_t t = 0;
-    bool previous_is_hex_escape = false;
-    uint8_t nbytes = 0;
-    for (size_t f = 0; f < length;) {
-        if ((unsigned char) from[f] < 0x80) {
-            /* ASCII */
-            if (from[f] <= 0x10 || from[f] == 0x7f ||
-                (is_xdigit(from[f]) && previous_is_hex_escape))
-            {
-                /* Control character or
-                   hexadecimal digit following an hexadecimal escape */
-                snprintf_safe(&to[t], 5, "\\x%02x", from[f]);
-                t += 4;
-                previous_is_hex_escape = true;
-            } else if (from[f] == '"' || from[f] == '\\') {
-                /* Quote and backslash */
-                snprintf_safe(&to[t], 3, "\\%c", from[f]);
-                t += 2;
-                previous_is_hex_escape = false;
-            } else {
-                /* Other characters */
-                to[t++] = from[f];
-                previous_is_hex_escape = false;
-            }
-            f++;
-            continue;
-        }
-        /* Test next byte for the next Unicode codepoint’s bytes count */
-        else if ((unsigned char) from[f] < 0xe0)
-            nbytes = 2;
-        else if ((unsigned char) from[f] < 0xf0)
-            nbytes = 3;
-        else
-            nbytes = 4;
-        memcpy(&to[t], &from[f], nbytes);
-        t += nbytes;
-        f += nbytes;
-        previous_is_hex_escape = false;
-    }
-    to[t++] = '\0';
-    return realloc(to, t);
-}
+bool
+xkb_compose_table_dump(FILE *file, struct xkb_compose_table *table);
 
 #endif

--- a/src/compose/escape.h
+++ b/src/compose/escape.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2023 Pierre Le Marre <dev@wismill.eu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+
+#ifndef COMPOSE_ESCAPE_H
+#define COMPOSE_ESCAPE_H
+
+#include "config.h"
+
+#include <stdlib.h>
+
+#include "src/utils.h"
+
+/* Ad-hoc escaping for UTF-8 string
+ *
+ * Note that it only escapes the strict minimum to get a valid Compose file.
+ * It also escapes hexadecimal digits after an hexadecimal escape. This is not
+ * strictly needed by the current implementation: "\x0abcg" parses as "␊bcg",
+ * but better be cautious than sorry and produce "\x0a\x62\x63g" instead.
+ * In the latter string there is no ambiguity and no need to know the maximum
+ * number of digits supported by the escape sequence.
+ */
+static inline char*
+escape_utf8_string_literal(const char *from)
+{
+    const size_t length = strlen(from);
+    /* Longest escape is converting ASCII character to "\xNN" */
+    char* to = calloc(4 * length + 1, sizeof(*to));
+    if (!to)
+        return NULL;
+
+    size_t t = 0;
+    bool previous_is_hex_escape = false;
+    uint8_t nbytes = 0;
+    for (size_t f = 0; f < length;) {
+        if ((unsigned char) from[f] < 0x80) {
+            /* ASCII */
+            if (from[f] <= 0x10 || from[f] == 0x7f ||
+                (is_xdigit(from[f]) && previous_is_hex_escape))
+            {
+                /* Control character or
+                   hexadecimal digit following an hexadecimal escape */
+                snprintf_safe(&to[t], 5, "\\x%02x", from[f]);
+                t += 4;
+                previous_is_hex_escape = true;
+            } else if (from[f] == '"' || from[f] == '\\') {
+                /* Quote and backslash */
+                snprintf_safe(&to[t], 3, "\\%c", from[f]);
+                t += 2;
+                previous_is_hex_escape = false;
+            } else {
+                /* Other characters */
+                to[t++] = from[f];
+                previous_is_hex_escape = false;
+            }
+            f++;
+            continue;
+        }
+        /* Test next byte for the next Unicode codepoint’s bytes count */
+        else if ((unsigned char) from[f] < 0xe0)
+            nbytes = 2;
+        else if ((unsigned char) from[f] < 0xf0)
+            nbytes = 3;
+        else
+            nbytes = 4;
+        memcpy(&to[t], &from[f], nbytes);
+        t += nbytes;
+        f += nbytes;
+        previous_is_hex_escape = false;
+    }
+    to[t++] = '\0';
+    return realloc(to, t);
+}
+
+#endif

--- a/src/compose/table.h
+++ b/src/compose/table.h
@@ -25,8 +25,8 @@
 #define COMPOSE_COMPOSE_H
 
 #include "xkbcommon/xkbcommon-compose.h"
-#include "utils.h"
-#include "context.h"
+#include "src/utils.h"
+#include "src/context.h"
 
 /*
  * The compose table data structure is a ternary search tree.

--- a/src/compose/table.h
+++ b/src/compose/table.h
@@ -77,7 +77,8 @@
 
 /* 7 nodes for every potential Unicode character and then some should be
  * enough for all purposes. */
-#define MAX_COMPOSE_NODES (1 << 23)
+#define MAX_COMPOSE_NODES_LOG2 23
+#define MAX_COMPOSE_NODES (1 << MAX_COMPOSE_NODES_LOG2)
 
 struct compose_node {
     xkb_keysym_t keysym;

--- a/test/compose-iter.c
+++ b/test/compose-iter.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2022 Ran Benita <ran@unusedvar.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "config.h"
+
+#include "src/darray.h"
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "xkbcommon/xkbcommon-compose.h"
+#include "src/compose/escape.h"
+#include "src/compose/parser.h"
+#include "src/keysym.h"
+#include "src/utils.h"
+#include "test/compose-iter.h"
+
+/* Reference implentation of Compose table traversal */
+static void
+for_each_helper(struct xkb_compose_table *table,
+                xkb_compose_table_iter_t iter,
+                void *data,
+                xkb_keysym_t *syms,
+                size_t nsyms,
+                uint16_t p)
+{
+    if (!p) {
+        return;
+    }
+    const struct compose_node *node = &darray_item(table->nodes, p);
+    for_each_helper(table, iter, data, syms, nsyms, node->lokid);
+    syms[nsyms++] = node->keysym;
+    if (node->is_leaf) {
+        struct xkb_compose_table_entry entry = {
+            .sequence = syms,
+            .sequence_length = nsyms,
+            .keysym = node->leaf.keysym,
+            .utf8 = &darray_item(table->utf8, node->leaf.utf8),
+        };
+        iter(&entry, data);
+    } else {
+        for_each_helper(table, iter, data, syms, nsyms, node->internal.eqkid);
+    }
+    nsyms--;
+    for_each_helper(table, iter, data, syms, nsyms, node->hikid);
+}
+
+XKB_EXPORT void
+xkb_compose_table_for_each(struct xkb_compose_table *table,
+                           xkb_compose_table_iter_t iter,
+                           void *data)
+{
+    if (darray_size(table->nodes) <= 1) {
+        return;
+    }
+    xkb_keysym_t syms[MAX_LHS_LEN];
+    for_each_helper(table, iter, data, syms, 0, 1);
+}

--- a/test/compose-iter.h
+++ b/test/compose-iter.h
@@ -1,0 +1,26 @@
+#ifndef COMPOSE_LEGACY_ITER_H
+#define COMPOSE_LEGACY_ITER_H
+
+#include "config.h"
+#include "src/compose/table.h"
+
+/**
+ * The iterator function type used by xkb_compose_table_for_each().
+ */
+typedef void
+(*xkb_compose_table_iter_t)(struct xkb_compose_table_entry *entry,
+                            void *data);
+
+/**
+ * Run a specified function for every valid entry in the table.
+ *
+ * The entries are returned in lexicographic order of the left-hand
+ * side of entries. This does not correspond to the order in which
+ * the entries appear in the Compose file.
+ */
+void
+xkb_compose_table_for_each(struct xkb_compose_table *table,
+                           xkb_compose_table_iter_t iter,
+                           void *data);
+
+#endif

--- a/test/compose.c
+++ b/test/compose.c
@@ -32,6 +32,9 @@
 #include "src/keysym.h"
 #include "src/compose/parser.h"
 #include "src/compose/escape.h"
+#include "src/compose/dump.h"
+#include "test/shuffle-lines.h"
+#include "test/compose-iter.h"
 
 static const char *
 compose_status_string(enum xkb_compose_status status)
@@ -717,8 +720,45 @@ test_eq_entry(struct xkb_compose_table_entry *entry, xkb_keysym_t keysym, const 
     return ok;
 }
 
+static bool
+test_eq_entries(struct xkb_compose_table_entry *entry1, struct xkb_compose_table_entry *entry2)
+{
+    if (!entry1 || !entry2)
+        goto error;
+    bool ok = true;
+    if (entry1->keysym != entry2->keysym ||
+        !streq_null(entry1->utf8, entry2->utf8) ||
+        entry1->sequence_length != entry2->sequence_length)
+        ok = false;
+    for (size_t k = 0; k < entry1->sequence_length; k++) {
+        if (entry1->sequence[k] != entry2->sequence[k])
+            ok = false;
+    }
+    if (ok)
+        return true;
+error:
+#define print_entry(msg, entry)                   \
+    fprintf(stderr, msg);                         \
+    if (entry)                                    \
+        print_compose_table_entry(stderr, entry); \
+    else                                          \
+        fprintf(stderr, "\n");
+    print_entry("Expected: ", entry1);
+    print_entry("Got:      ", entry2);
+#undef print_entry
+    return false;
+}
+
 static void
-test_traverse(struct xkb_context *ctx)
+compose_traverse_fn(struct xkb_compose_table_entry *entry_ref, void *data)
+{
+    struct xkb_compose_table_iterator *iter = (struct xkb_compose_table_iterator *)data;
+    struct xkb_compose_table_entry *entry = xkb_compose_table_iterator_next(iter);
+    assert(test_eq_entries(entry_ref, entry));
+}
+
+static void
+test_traverse(struct xkb_context *ctx, size_t quickcheck_loops)
 {
     struct xkb_compose_table *table;
     struct xkb_compose_table_iterator *iter;
@@ -796,6 +836,34 @@ test_traverse(struct xkb_context *ctx)
 
     xkb_compose_table_iterator_free(iter);
     xkb_compose_table_unref(table);
+
+    /* QuickCheck: shuffle compose file lines and compare against
+     * reference implementation */
+    char *input = test_read_file("locale/en_US.UTF-8/Compose");
+    assert(input);
+    struct text_line lines[6000];
+    size_t input_length = strlen(input);
+    size_t lines_count = split_lines(input, input_length, lines, ARRAY_SIZE(lines));
+    /* Note: we may add additional new line char */
+    char *shuffled = calloc(input_length + 1, sizeof(char));
+    assert(shuffled);
+    for (size_t k = 0; k < quickcheck_loops; k++) {
+        size_t shuffled_length = shuffle_lines(lines, lines_count, shuffled);
+        table = xkb_compose_table_new_from_buffer(ctx, shuffled, shuffled_length, "",
+                                                  XKB_COMPOSE_FORMAT_TEXT_V1,
+                                                  XKB_COMPOSE_COMPILE_NO_FLAGS);
+        assert(table);
+
+        iter = xkb_compose_table_iterator_new(table);
+        assert(iter);
+        xkb_compose_table_for_each(table, compose_traverse_fn, iter);
+        assert(xkb_compose_table_iterator_next(iter) == NULL);
+        xkb_compose_table_iterator_free(iter);
+
+        xkb_compose_table_unref(table);
+    }
+    free(shuffled);
+    free(input);
 }
 
 static void
@@ -938,6 +1006,15 @@ test_encode_escape_sequences(struct xkb_context *ctx)
 #   undef MAX_CODE_POINTS_COUNT
 }
 
+/* CLI positional arguments:
+ * 1. Seed for the pseudo-random generator:
+ *    - Leave it unset or set it to “-” to use current time.
+ *    - Use an integer to set it explicitly.
+ * 2. Number of quickcheck loops:
+ *    - Leave it unset to use the default. It depends if the `RUNNING_VALGRIND`
+ *      environment variable is set.
+ *    - Use an integer to set it explicitly.
+ */
 int
 main(int argc, char *argv[])
 {
@@ -950,13 +1027,23 @@ main(int argc, char *argv[])
 
     /* Initialize pseudo-random generator with program arg or current time */
     int seed;
-    if (argc == 2) {
+    if (argc >= 2 && !streq(argv[1], "-")) {
         seed = atoi(argv[1]);
     } else {
         seed = (int)time(NULL);
     }
     fprintf(stderr, "Seed for the pseudo-random generator: %d\n", seed);
     srand(seed);
+
+    /* Determine number of loops for quickchecks */
+    size_t quickcheck_loops = 100; /* Default */
+    if (argc > 2) {
+        /* From command-line */
+        quickcheck_loops = (size_t)atoi(argv[2]);
+    } else if (getenv("RUNNING_VALGRIND") != NULL) {
+        /* Reduce if running Valgrind */
+        quickcheck_loops = quickcheck_loops / 20;
+    }
 
     /*
      * Ensure no environment variables but “top_srcdir” is set. This ensures
@@ -985,7 +1072,7 @@ main(int argc, char *argv[])
     test_modifier_syntax(ctx);
     test_include(ctx);
     test_override(ctx);
-    test_traverse(ctx);
+    test_traverse(ctx, quickcheck_loops);
     test_string_length(ctx);
     test_decode_escape_sequences(ctx);
     test_encode_escape_sequences(ctx);

--- a/test/compose.c
+++ b/test/compose.c
@@ -31,7 +31,7 @@
 #include "src/utf8.h"
 #include "src/keysym.h"
 #include "src/compose/parser.h"
-#include "src/compose/dump.h"
+#include "src/compose/escape.h"
 
 static const char *
 compose_status_string(enum xkb_compose_status status)

--- a/test/shuffle-lines.c
+++ b/test/shuffle-lines.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2024 Pierre Le Marre <dev@wismill.eu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "config.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include "src/utils.h"
+#include "test/shuffle-lines.h"
+
+/* Split string into lines */
+size_t
+split_lines(const char *input, size_t input_length,
+            struct text_line *output, size_t output_length)
+{
+    const char *start = input;
+    char *next;
+    size_t l;
+    size_t i = 0;
+
+    for (l = 0; i < input_length && l < output_length && *start != '\0'; l++) {
+        /* Look for newline character */
+        next = strchr(start, 0x0a);
+        output[l].start = start;
+        if (next == NULL) {
+            /* Not found: add the rest of the string */
+            output[l++].length = strlen(start);
+            break;
+        }
+        output[l].length = (size_t)(next - start) + 1;
+        start = next + 1;
+        i += output[l].length;
+    }
+    return l;
+}
+
+size_t
+shuffle_lines(struct text_line *lines, size_t length, char *output)
+{
+    /* Shuffle lines in-place using Fisher–Yates algorithm.
+     * See: https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle */
+
+    assert(length < RAND_MAX);
+    char *out = output;
+    if (length > 1) {
+        /* 1. Set the current i to the last line.
+         * 2. Take a random line j before the current line i.
+         * 3. Swap the lines i and j.
+         * 4. Append line i to the output.
+         * 5. If i is the first line, stop. Else decrease i and go to 2).
+         */
+        for (size_t i = length - 1; i > 0; i--) {
+            /* Swap current line with random line before it */
+            size_t j = (size_t)(rand() % (i+1));
+            struct text_line tmp = lines[j];
+            lines[j] = lines[i];
+            lines[i] = tmp;
+            /* Append current line */
+            memcpy(out, lines[i].start, lines[i].length);
+            out += lines[i].length;
+            /* Ensure line ends with newline */
+            if (out[-1] != '\n') {
+                out[0] = '\n';
+                out++;
+            }
+        }
+    }
+    return (size_t)(out - output);
+}

--- a/test/shuffle-lines.h
+++ b/test/shuffle-lines.h
@@ -1,0 +1,13 @@
+#include <stdint.h>
+
+struct text_line {
+    const char *start;
+    size_t length;
+};
+
+size_t
+split_lines(const char *input, size_t input_length,
+            struct text_line *output, size_t output_length);
+
+size_t
+shuffle_lines(struct text_line *lines, size_t length, char *output);


### PR DESCRIPTION
This is a follow-up of #367 (see the [motivation](https://github.com/xkbcommon/libxkbcommon/pull/367#issuecomment-1732521452)). The aim is to explore better implementations of the compose traversal API, in particular `xkb_compose_table_iterator_next`.

~Currently it is in the state of #367 before removing alternative implementation and squashing. It will need to be rebased once #367 is merged.~ Done

I kept the 2 implementations (see the [benchmarks](https://github.com/xkbcommon/libxkbcommon/pull/367#issuecomment-1722517850)) in an intermediate commit for testing.

TODO:
- [x] Squash commit marked as “SQUASH ME”