### PR TITLE
Prevent recursive includes of keymap components

### DIFF
--- a/src/xkbcomp/ast-build.c
+++ b/src/xkbcomp/ast-build.c
@@ -534,8 +534,8 @@ err:
 }
 
 XkbFile *
-XkbFileCreate(enum xkb_file_type type, char *name, ParseCommon *defs,
-              enum xkb_map_flags flags)
+XkbFileCreate(enum xkb_file_type type, const char *file_name, char *name,
+              ParseCommon *defs, enum xkb_map_flags flags)
 {
     XkbFile *file;
 
@@ -545,6 +545,7 @@ XkbFileCreate(enum xkb_file_type type, char *name, ParseCommon *defs,
 
     XkbEscapeMapName(name);
     file->file_type = type;
+    file->file_name = file_name;
     file->name = name ? name : strdup("(unnamed)");
     file->defs = defs;
     file->flags = flags;
@@ -570,7 +571,7 @@ XkbFileFromComponents(struct xkb_context *ctx,
         if (!include)
             goto err;
 
-        file = XkbFileCreate(type, NULL, (ParseCommon *) include, 0);
+        file = XkbFileCreate(type, NULL, NULL, (ParseCommon *) include, 0);
         if (!file) {
             FreeInclude(include);
             goto err;
@@ -582,7 +583,7 @@ XkbFileFromComponents(struct xkb_context *ctx,
             defsLast = defsLast->next = &file->common;
     }
 
-    file = XkbFileCreate(FILE_TYPE_KEYMAP, NULL, defs, 0);
+    file = XkbFileCreate(FILE_TYPE_KEYMAP, NULL, NULL, defs, 0);
     if (!file)
         goto err;
 

--- a/src/xkbcomp/ast-build.h
+++ b/src/xkbcomp/ast-build.h
@@ -116,8 +116,8 @@ IncludeStmt *
 IncludeCreate(struct xkb_context *ctx, char *str, enum merge_mode merge);
 
 XkbFile *
-XkbFileCreate(enum xkb_file_type type, char *name, ParseCommon *defs,
-              enum xkb_map_flags flags);
+XkbFileCreate(enum xkb_file_type type, const char *file_name, char *name,
+              ParseCommon *defs, enum xkb_map_flags flags);
 
 void
 FreeStmt(ParseCommon *stmt);

--- a/src/xkbcomp/ast.h
+++ b/src/xkbcomp/ast.h
@@ -352,6 +352,7 @@ enum xkb_map_flags {
 typedef struct {
     ParseCommon common;
     enum xkb_file_type file_type;
+    const char *file_name;
     char *name;
     ParseCommon *defs;
     enum xkb_map_flags flags;

--- a/src/xkbcomp/include.h
+++ b/src/xkbcomp/include.h
@@ -27,6 +27,21 @@
 #ifndef XKBCOMP_INCLUDE_H
 #define XKBCOMP_INCLUDE_H
 
+#include "context.h"
+#include "atom.h"
+
+struct include_atom {
+    xkb_atom_t file;
+    xkb_atom_t map;
+    bool is_map_default;
+};
+
+typedef darray(struct include_atom) include_parents;
+
+void
+include_parents_append(struct xkb_context *ctx, include_parents *parents,
+                       const char *file, char *map, bool is_map_default);
+
 bool
 ParseIncludeMap(char **str_inout, char **file_rtrn, char **map_rtrn,
                 char *nextop_rtrn, char **extra_data);
@@ -37,7 +52,8 @@ FindFileInXkbPath(struct xkb_context *ctx, const char *name,
                   unsigned int *offset);
 
 XkbFile *
-ProcessIncludeFile(struct xkb_context *ctx, IncludeStmt *stmt,
+ProcessIncludeFile(struct xkb_context *ctx,
+                   include_parents *parents, IncludeStmt *stmt,
                    enum xkb_file_type file_type);
 
 #endif

--- a/src/xkbcomp/parser.y
+++ b/src/xkbcomp/parser.y
@@ -263,7 +263,7 @@ XkbFile         :       XkbCompositeMap
 XkbCompositeMap :       OptFlags XkbCompositeType OptMapName OBRACE
                             XkbMapConfigList
                         CBRACE SEMI
-                        { $$ = XkbFileCreate($2, $3, (ParseCommon *) $5.head, $1); }
+                        { $$ = XkbFileCreate($2, param->scanner->file_name, $3, (ParseCommon *) $5.head, $1); }
                 ;
 
 XkbCompositeType:       XKB_KEYMAP      { $$ = FILE_TYPE_KEYMAP; }
@@ -281,7 +281,7 @@ XkbMapConfig    :       OptFlags FileType OptMapName OBRACE
                             DeclList
                         CBRACE SEMI
                         {
-                            $$ = XkbFileCreate($2, $3, $5.head, $1);
+                            $$ = XkbFileCreate($2, param->scanner->file_name, $3, $5.head, $1);
                         }
                 ;
 

--- a/src/xkbcomp/types.c
+++ b/src/xkbcomp/types.c
@@ -180,6 +180,11 @@ MergeIncludedKeyTypes(KeyTypesInfo *into, KeyTypesInfo *from,
 {
     if (from->errorCount > 0) {
         into->errorCount += from->errorCount;
+        // Free unused types
+        KeyTypeInfo *type;
+        darray_foreach(type, from->types) {
+            ClearKeyTypeInfo(type);
+        }
         return;
     }
 

--- a/test/buffercomp.c
+++ b/test/buffercomp.c
@@ -31,6 +31,88 @@
 
 #define DATA_PATH "keymaps/stringcomp.data"
 
+static void
+test_recursive(void)
+{
+    struct xkb_context *ctx = test_get_context(0);
+    struct xkb_keymap *keymap;
+
+    assert(ctx);
+
+    const char* const keymaps[] = {
+        /* Recursive keycodes */
+        "Keycodes: recursive",
+        "xkb_keymap {"
+        "  xkb_keycodes { include \"evdev+recursive\" };"
+        "  xkb_types { include \"complete\" };"
+        "  xkb_compat { include \"complete\" };"
+        "  xkb_symbols { include \"pc\" };"
+        "};",
+        "Keycodes: recursive(bar)",
+        "xkb_keymap {"
+        "  xkb_keycodes { include \"evdev+recursive(bar)\" };"
+        "  xkb_types { include \"complete\" };"
+        "  xkb_compat { include \"complete\" };"
+        "  xkb_symbols { include \"pc\" };"
+        "};",
+        /* Recursive key types */
+        "Key types: recursive",
+        "xkb_keymap {"
+        "  xkb_keycodes { include \"evdev\" };"
+        "  xkb_types { include \"recursive\" };"
+        "  xkb_compat { include \"complete\" };"
+        "  xkb_symbols { include \"pc\" };"
+        "};",
+        "Key types: recursive(bar)",
+        "xkb_keymap {"
+        "  xkb_keycodes { include \"evdev\" };"
+        "  xkb_types { include \"recursive(bar)\" };"
+        "  xkb_compat { include \"complete\" };"
+        "  xkb_symbols { include \"pc\" };"
+        "};",
+        /* Recursive compat */
+        "Compat: recursive",
+        "xkb_keymap {"
+        "  xkb_keycodes { include \"evdev\" };"
+        "  xkb_types { include \"recursive\" };"
+        "  xkb_compat { include \"complete\" };"
+        "  xkb_symbols { include \"pc\" };"
+        "};",
+        "Compat: recursive(bar)",
+        "xkb_keymap {"
+        "  xkb_keycodes { include \"evdev\" };"
+        "  xkb_types { include \"complete\" };"
+        "  xkb_compat { include \"recursive(bar)\" };"
+        "  xkb_symbols { include \"pc\" };"
+        "};",
+        /* Recursive symbols */
+        "Symbols: recursive",
+        "xkb_keymap {"
+        "  xkb_keycodes { include \"evdev\" };"
+        "  xkb_types { include \"complete\" };"
+        "  xkb_compat { include \"complete\" };"
+        "  xkb_symbols { include \"recursive\" };"
+        "};",
+        "Symbols: recursive(bar)",
+        "xkb_keymap {"
+        "  xkb_keycodes { include \"evdev\" };"
+        "  xkb_types { include \"complete\" };"
+        "  xkb_compat { include \"complete\" };"
+        "  xkb_symbols { include \"recursive(bar)\" };"
+        // "};"
+    };
+
+    int len = sizeof(keymaps) / sizeof(keymaps[0]);
+
+    for (int k = 0; k < len; k++) {
+        fprintf(stderr, "*** Recursive test: %s ***\n", keymaps[k++]);
+        keymap = test_compile_buffer(ctx, keymaps[k], strlen(keymaps[k]));
+        assert(!keymap);
+    }
+
+    xkb_context_unref(ctx);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -91,6 +173,8 @@ main(int argc, char *argv[])
     free(dump);
 
     xkb_context_unref(ctx);
+
+    test_recursive();
 
     return 0;
 }

--- a/test/data/compat/recursive
+++ b/test/data/compat/recursive
@@ -1,0 +1,12 @@
+default
+xkb_compatibility "foo" {
+    include "recursive"
+};
+
+xkb_compatibility "bar" {
+    include "recursive(baz)"
+};
+
+xkb_compatibility "baz" {
+    include "recursive(bar)"
+};

--- a/test/data/keycodes/recursive
+++ b/test/data/keycodes/recursive
@@ -1,0 +1,15 @@
+default
+xkb_keycodes "foo" {
+    include "recursive"
+    <FOO> = 0x100000;
+};
+
+xkb_keycodes "bar" {
+    include "recursive(baz)"
+    <BAR> = 0x100001;
+};
+
+xkb_keycodes "baz" {
+    include "recursive(bar)"
+    <BAZ> = 0x100002;
+};

--- a/test/data/symbols/recursive
+++ b/test/data/symbols/recursive
@@ -1,0 +1,12 @@
+default
+xkb_symbols "foo" {
+    include "recursive"
+};
+
+xkb_symbols "bar" {
+    include "recursive(baz)"
+};
+
+xkb_symbols "baz" {
+    include "recursive(bar)"
+};

--- a/test/data/types/recursive
+++ b/test/data/types/recursive
@@ -1,0 +1,27 @@
+default
+xkb_types "foo" {
+    type "FOO" {
+        modifiers = None;
+        map[None] = Level1;
+        level_name[Level1]= "Any";
+    };
+    include "recursive"
+};
+
+xkb_types "bar" {
+    type "BAR" {
+        modifiers = None;
+        map[None] = Level1;
+        level_name[Level1]= "Any";
+    };
+    include "recursive(baz)"
+};
+
+xkb_types "baz" {
+    type "BAZ" {
+        modifiers = None;
+        map[None] = Level1;
+        level_name[Level1]= "Any";
+    };
+    include "recursive(bar)"
+};


### PR DESCRIPTION
Prevent recursive includes of keymap components:

- Add file name property to `XkbFile`. This allow better identification of the file being processed.
- Add check for recursive includes of keycodes, key types, compat and symbols keymap components.
- Add tests for recursive includes.

I would like to get the design right wrt further work on #390.