### PR TITLE
Prevent recursive includes of keymap components (using include depth)

### DIFF
--- a/doc/message-registry.md
+++ b/doc/message-registry.md
@@ -39,6 +39,7 @@ There are currently 54 entries.
 | [XKB-338] | `included-file-not-found` | Could not find a file used in an include statement | Error |
 | [XKB-345] | `unknown-operator` | Use of an operator that is unknown and thus unsupported | Error |
 | [XKB-378] | `duplicate-entry` | An entry is duplicated and will be ignored | Warning |
+| [XKB-386] | `recursive-include` | Included files form cycle | Error |
 | [XKB-407] | `conflicting-key-type-definitions` | Conflicting definitions of a key type | Warning |
 | [XKB-428] | `wrong-scope` | A statement is in a wrong scope and should be moved | Error |
 | [XKB-433] | `missing-default-section` | Missing default section in included file | Warning |
@@ -325,6 +326,14 @@ as numbers and as identifiers `LevelN`, where `N` is in the range (1..8).
   <dt>Since</dt><dd>1.0.0</dd>
   <dt>Type</dt><dd>Warning</dd>
   <dt>Summary</dt><dd>An entry is duplicated and will be ignored</dd>
+</dl>
+
+### XKB-386 – Recursive include {#XKB-386}
+
+<dl>
+  <dt>Since</dt><dd>1.7.0</dd>
+  <dt>Type</dt><dd>Error</dd>
+  <dt>Summary</dt><dd>Included files form cycle</dd>
 </dl>
 
 ### XKB-407 – Conflicting key type definitions {#XKB-407}
@@ -657,6 +666,7 @@ The modifiers used in `map` or `preserve` entries should be declared using the e
 [XKB-338]: @ref XKB-338
 [XKB-345]: @ref XKB-345
 [XKB-378]: @ref XKB-378
+[XKB-386]: @ref XKB-386
 [XKB-407]: @ref XKB-407
 [XKB-428]: @ref XKB-428
 [XKB-433]: @ref XKB-433

--- a/doc/message-registry.yaml
+++ b/doc/message-registry.yaml
@@ -180,6 +180,11 @@
   added: ALWAYS
   type: warning
   description: "An entry is duplicated and will be ignored"
+- id: "recursive-include"
+  code: 386
+  added: 1.7.0
+  type: error
+  description: "Included files form cycle"
 - id: "conflicting-key-type-definitions"
   code: 407
   added: ALWAYS

--- a/src/messages-codes.h
+++ b/src/messages-codes.h
@@ -66,6 +66,8 @@ enum xkb_message_code {
     XKB_ERROR_UNKNOWN_OPERATOR = 345,
     /** An entry is duplicated and will be ignored */
     XKB_WARNING_DUPLICATE_ENTRY = 378,
+    /** Included files form cycle */
+    XKB_ERROR_RECURSIVE_INCLUDE = 386,
     /** Conflicting definitions of a key type */
     XKB_WARNING_CONFLICTING_KEY_TYPE_DEFINITIONS = 407,
     /** A statement is in a wrong scope and should be moved */

--- a/src/xkbcomp/include.c
+++ b/src/xkbcomp/include.c
@@ -286,6 +286,20 @@ out:
     return file;
 }
 
+bool
+ExceedsIncludeMaxDepth(struct xkb_context *ctx, unsigned int include_depth)
+{
+    if (include_depth >= INCLUDE_MAX_DEPTH) {
+        log_err(ctx,
+                XKB_ERROR_RECURSIVE_INCLUDE,
+                "Exceeded include depth threshold (%d)",
+                INCLUDE_MAX_DEPTH);
+        return true;
+    } else {
+        return false;
+    }
+}
+
 XkbFile *
 ProcessIncludeFile(struct xkb_context *ctx, IncludeStmt *stmt,
                    enum xkb_file_type file_type)
@@ -333,8 +347,6 @@ ProcessIncludeFile(struct xkb_context *ctx, IncludeStmt *stmt,
                     "Couldn't process include statement for '%s'\n",
                     stmt->file);
     }
-
-    /* FIXME: we have to check recursive includes here (or somewhere) */
 
     return xkb_file;
 }

--- a/src/xkbcomp/include.h
+++ b/src/xkbcomp/include.h
@@ -27,6 +27,9 @@
 #ifndef XKBCOMP_INCLUDE_H
 #define XKBCOMP_INCLUDE_H
 
+/* Reasonable threshold, with plenty of margin for keymaps in the wild */
+#define INCLUDE_MAX_DEPTH 15
+
 bool
 ParseIncludeMap(char **str_inout, char **file_rtrn, char **map_rtrn,
                 char *nextop_rtrn, char **extra_data);
@@ -35,6 +38,9 @@ FILE *
 FindFileInXkbPath(struct xkb_context *ctx, const char *name,
                   enum xkb_file_type type, char **pathRtrn,
                   unsigned int *offset);
+
+bool
+ExceedsIncludeMaxDepth(struct xkb_context *ctx, unsigned int include_depth);
 
 XkbFile *
 ProcessIncludeFile(struct xkb_context *ctx, IncludeStmt *stmt,

--- a/test/buffercomp.c
+++ b/test/buffercomp.c
@@ -84,6 +84,88 @@ test_encodings(struct xkb_context *ctx)
     return true;
 }
 
+static void
+test_recursive(void)
+{
+    struct xkb_context *ctx = test_get_context(0);
+    struct xkb_keymap *keymap;
+
+    assert(ctx);
+
+    const char* const keymaps[] = {
+        /* Recursive keycodes */
+        "Keycodes: recursive",
+        "xkb_keymap {"
+        "  xkb_keycodes { include \"evdev+recursive\" };"
+        "  xkb_types { include \"complete\" };"
+        "  xkb_compat { include \"complete\" };"
+        "  xkb_symbols { include \"pc\" };"
+        "};",
+        "Keycodes: recursive(bar)",
+        "xkb_keymap {"
+        "  xkb_keycodes { include \"evdev+recursive(bar)\" };"
+        "  xkb_types { include \"complete\" };"
+        "  xkb_compat { include \"complete\" };"
+        "  xkb_symbols { include \"pc\" };"
+        "};",
+        /* Recursive key types */
+        "Key types: recursive",
+        "xkb_keymap {"
+        "  xkb_keycodes { include \"evdev\" };"
+        "  xkb_types { include \"recursive\" };"
+        "  xkb_compat { include \"complete\" };"
+        "  xkb_symbols { include \"pc\" };"
+        "};",
+        "Key types: recursive(bar)",
+        "xkb_keymap {"
+        "  xkb_keycodes { include \"evdev\" };"
+        "  xkb_types { include \"recursive(bar)\" };"
+        "  xkb_compat { include \"complete\" };"
+        "  xkb_symbols { include \"pc\" };"
+        "};",
+        /* Recursive compat */
+        "Compat: recursive",
+        "xkb_keymap {"
+        "  xkb_keycodes { include \"evdev\" };"
+        "  xkb_types { include \"recursive\" };"
+        "  xkb_compat { include \"complete\" };"
+        "  xkb_symbols { include \"pc\" };"
+        "};",
+        "Compat: recursive(bar)",
+        "xkb_keymap {"
+        "  xkb_keycodes { include \"evdev\" };"
+        "  xkb_types { include \"complete\" };"
+        "  xkb_compat { include \"recursive(bar)\" };"
+        "  xkb_symbols { include \"pc\" };"
+        "};",
+        /* Recursive symbols */
+        "Symbols: recursive",
+        "xkb_keymap {"
+        "  xkb_keycodes { include \"evdev\" };"
+        "  xkb_types { include \"complete\" };"
+        "  xkb_compat { include \"complete\" };"
+        "  xkb_symbols { include \"recursive\" };"
+        "};",
+        "Symbols: recursive(bar)",
+        "xkb_keymap {"
+        "  xkb_keycodes { include \"evdev\" };"
+        "  xkb_types { include \"complete\" };"
+        "  xkb_compat { include \"complete\" };"
+        "  xkb_symbols { include \"recursive(bar)\" };"
+        // "};"
+    };
+
+    int len = sizeof(keymaps) / sizeof(keymaps[0]);
+
+    for (int k = 0; k < len; k++) {
+        fprintf(stderr, "*** Recursive test: %s ***\n", keymaps[k++]);
+        keymap = test_compile_buffer(ctx, keymaps[k], strlen(keymaps[k]));
+        assert(!keymap);
+    }
+
+    xkb_context_unref(ctx);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -146,6 +228,8 @@ main(int argc, char *argv[])
     free(dump);
 
     xkb_context_unref(ctx);
+
+    test_recursive();
 
     return 0;
 }

--- a/test/data/compat/recursive
+++ b/test/data/compat/recursive
@@ -1,0 +1,12 @@
+default
+xkb_compatibility "foo" {
+    include "recursive"
+};
+
+xkb_compatibility "bar" {
+    include "recursive(baz)"
+};
+
+xkb_compatibility "baz" {
+    include "recursive(bar)"
+};

--- a/test/data/keycodes/recursive
+++ b/test/data/keycodes/recursive
@@ -1,0 +1,15 @@
+default
+xkb_keycodes "foo" {
+    include "recursive"
+    <FOO> = 0x100000;
+};
+
+xkb_keycodes "bar" {
+    include "recursive(baz)"
+    <BAR> = 0x100001;
+};
+
+xkb_keycodes "baz" {
+    include "recursive(bar)"
+    <BAZ> = 0x100002;
+};

--- a/test/data/symbols/recursive
+++ b/test/data/symbols/recursive
@@ -1,0 +1,12 @@
+default
+xkb_symbols "foo" {
+    include "recursive"
+};
+
+xkb_symbols "bar" {
+    include "recursive(baz)"
+};
+
+xkb_symbols "baz" {
+    include "recursive(bar)"
+};

--- a/test/data/types/recursive
+++ b/test/data/types/recursive
@@ -1,0 +1,27 @@
+default
+xkb_types "foo" {
+    type "FOO" {
+        modifiers = None;
+        map[None] = Level1;
+        level_name[Level1]= "Any";
+    };
+    include "recursive"
+};
+
+xkb_types "bar" {
+    type "BAR" {
+        modifiers = None;
+        map[None] = Level1;
+        level_name[Level1]= "Any";
+    };
+    include "recursive(baz)"
+};
+
+xkb_types "baz" {
+    type "BAZ" {
+        modifiers = None;
+        map[None] = Level1;
+        level_name[Level1]= "Any";
+    };
+    include "recursive(bar)"
+};

--- a/tools/messages.c
+++ b/tools/messages.c
@@ -63,6 +63,7 @@ static const struct xkb_message_entry xkb_messages[] = {
     {XKB_ERROR_INCLUDED_FILE_NOT_FOUND, "Included file not found"},
     {XKB_ERROR_UNKNOWN_OPERATOR, "Unknown operator"},
     {XKB_WARNING_DUPLICATE_ENTRY, "Duplicate entry"},
+    {XKB_ERROR_RECURSIVE_INCLUDE, "Recursive include"},
     {XKB_WARNING_CONFLICTING_KEY_TYPE_DEFINITIONS, "Conflicting key type definitions"},
     {XKB_ERROR_WRONG_SCOPE, "Wrong scope"},
     {XKB_WARNING_MISSING_DEFAULT_SECTION, "Missing default section"},


### PR DESCRIPTION
Prevent recursive includes of keymap components by limiting the include depth. This is an alternative design of #389.

This PR has a commit that fixes a memory leak, but should be rebased once #391 is merged.