### PR TITLE
Compose: add support to all interactive tools

### DIFF
--- a/tools/interactive-evdev.c
+++ b/tools/interactive-evdev.c
@@ -280,7 +280,7 @@ process_event(struct keyboard *kbd, uint16_t type, uint16_t code, int32_t value)
 
     if (value != KEY_STATE_RELEASE) {
         tools_print_keycode_state(
-            kbd->state, kbd->compose_state, keycode,
+            NULL, kbd->state, kbd->compose_state, keycode,
             consumed_mode, print_fields
         );
     }

--- a/tools/interactive-x11.c
+++ b/tools/interactive-x11.c
@@ -242,7 +242,7 @@ process_event(xcb_generic_event_t *gevent, struct keyboard *kbd)
         xcb_key_press_event_t *event = (xcb_key_press_event_t *) gevent;
         xkb_keycode_t keycode = event->detail;
 
-        tools_print_keycode_state(kbd->state, NULL, keycode,
+        tools_print_keycode_state(NULL, kbd->state, NULL, keycode,
                                   XKB_CONSUMED_MODE_XKB,
                                   PRINT_ALL_FIELDS);
 

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -143,7 +143,8 @@ print_keys_modmaps(struct xkb_keymap *keymap) {
 #endif
 
 void
-tools_print_keycode_state(struct xkb_state *state,
+tools_print_keycode_state(char *prefix,
+                          struct xkb_state *state,
                           struct xkb_compose_state *compose_state,
                           xkb_keycode_t keycode,
                           enum xkb_consumed_mode consumed_mode,
@@ -181,6 +182,9 @@ tools_print_keycode_state(struct xkb_state *state,
         sym = xkb_state_key_get_one_sym(state, keycode);
         syms = &sym;
     }
+
+    if (prefix)
+        printf("%s", prefix);
 
     print_keycode(keymap, "keycode [ ", keycode, " ] ");
 

--- a/tools/tools-common.h
+++ b/tools/tools-common.h
@@ -61,7 +61,8 @@ print_keys_modmaps(struct xkb_keymap *keymap);
 #endif
 
 void
-tools_print_keycode_state(struct xkb_state *state,
+tools_print_keycode_state(char *prefix,
+                          struct xkb_state *state,
                           struct xkb_compose_state *compose_state,
                           xkb_keycode_t keycode,
                           enum xkb_consumed_mode consumed_mode,

--- a/tools/xkbcli-interactive-wayland.1
+++ b/tools/xkbcli-interactive-wayland.1
@@ -28,6 +28,9 @@ This is a debugging tool, its behavior or output is not guaranteed to be stable.
 .Bl -tag -width Ds
 .It Fl \-help
 Print help and exit
+.
+.It Fl \-enable\-compose
+Enable Compose functionality
 .El
 .
 .Sh SEE ALSO

--- a/tools/xkbcli-interactive-x11.1
+++ b/tools/xkbcli-interactive-x11.1
@@ -28,6 +28,9 @@ This is a debugging tool, its behavior or output is not guaranteed to be stable.
 .Bl -tag -width Ds
 .It Fl \-help
 Print help and exit
+.
+.It Fl \-enable\-compose
+Enable Compose functionality
 .El
 .
 .Sh SEE ALSO


### PR DESCRIPTION
Currently only `interactive-evdev` has support for compose. Let’s add X11 and Wayland.