### PR TITLE
state: fix -Walloc-size

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -586,7 +586,7 @@ xkb_state_new(struct xkb_keymap *keymap)
 {
     struct xkb_state *ret;
 
-    ret = calloc(sizeof(*ret), 1);
+    ret = calloc(1, sizeof(*ret));
     if (!ret)
         return NULL;
 


### PR DESCRIPTION
GCC 14 introduces a new -Walloc-size included in -Wextra which gives:
```
src/state.c:589:9: warning: allocation of insufficient size ‘1’ for type ‘struct xkb_state’ with size ‘128’ [-Walloc-size]
```

The calloc prototype is:
```
void *calloc(size_t nmemb, size_t size);
```

So, just swap the number of members and size arguments to match the prototype, as we're initialising 1 struct of size `sizeof(struct xkb_state)`. GCC then sees we're not doing anything wrong.