### PR TITLE
Fix compilation error with clang when using the "-Wl,--gc-sections" linker optimization

### DIFF
--- a/test/xvfb-wrapper.h
+++ b/test/xvfb-wrapper.h
@@ -31,7 +31,7 @@ struct test_function {
 #define X11_TEST(_func) \
 static int _func(char* display); \
 static const struct test_function _test_##_func \
-__attribute__((used)) \
+__attribute__((retain,used)) \
 __attribute__((section("test_functions_section"))) = { \
     .name = #_func, \
     .func = _func, \


### PR DESCRIPTION
Hi,

when trying to build libxkbcommon with clang+lld on Gentoo and with the `--gc-sections` linker optimization switch, the following errors are produced:
```
[134/150] clang  -o test-x11 test-x11.p/test_x11.c.o -Wl,--as-needed -Wl,--no-undefined -O2 -march=native -pipe -flto -Werror=odr -Werror=strict-aliasing -ffunction-sections -fdata-sections -Wl,-O2 -Wl,--gc-sections -Wl,--icf=all -Wl,--as-needed -fuse-ld=lld -Wl,--start-group libxkbcommon-x11-internal.a libxkbcommon-test-internal.a /usr/lib64/libxcb.so /usr/lib64/libxcb-xkb.so -Wl,--end-group
FAILED: test-x11 
clang  -o test-x11 test-x11.p/test_x11.c.o -Wl,--as-needed -Wl,--no-undefined -O2 -march=native -pipe -flto -Werror=odr -Werror=strict-aliasing -ffunction-sections -fdata-sections -Wl,-O2 -Wl,--gc-sections -Wl,--icf=all -Wl,--as-needed -fuse-ld=lld -Wl,--start-group libxkbcommon-x11-internal.a libxkbcommon-test-internal.a /usr/lib64/libxcb.so /usr/lib64/libxcb-xkb.so -Wl,--end-group
ld.lld: error: undefined symbol: __start_test_functions_section
>>> referenced by ld-temp.o
>>>               lto.tmp:(main)
>>> the encapsulation symbol needs to be retained under --gc-sections properly; consider -z nostart-stop-gc (see https://lld.llvm.org/ELF/start-stop-gc)

ld.lld: error: undefined symbol: __stop_test_functions_section
>>> referenced by ld-temp.o
>>>               lto.tmp:(main)
>>> referenced by ld-temp.o
>>>               lto.tmp:(main)
clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
[135/150] clang  -o test-x11comp test-x11comp.p/test_x11comp.c.o -Wl,--as-needed -Wl,--no-undefined -O2 -march=native -pipe -flto -Werror=odr -Werror=strict-aliasing -ffunction-sections -fdata-sections -Wl,-O2 -Wl,--gc-sections -Wl,--icf=all -Wl,--as-needed -fuse-ld=lld -Wl,--start-group libxkbcommon-x11-internal.a libxkbcommon-test-internal.a /usr/lib64/libxcb.so /usr/lib64/libxcb-xkb.so -Wl,--end-group
FAILED: test-x11comp 
clang  -o test-x11comp test-x11comp.p/test_x11comp.c.o -Wl,--as-needed -Wl,--no-undefined -O2 -march=native -pipe -flto -Werror=odr -Werror=strict-aliasing -ffunction-sections -fdata-sections -Wl,-O2 -Wl,--gc-sections -Wl,--icf=all -Wl,--as-needed -fuse-ld=lld -Wl,--start-group libxkbcommon-x11-internal.a libxkbcommon-test-internal.a /usr/lib64/libxcb.so /usr/lib64/libxcb-xkb.so -Wl,--end-group
ld.lld: error: undefined symbol: __start_test_functions_section
>>> referenced by ld-temp.o
>>>               lto.tmp:(main)
>>> the encapsulation symbol needs to be retained under --gc-sections properly; consider -z nostart-stop-gc (see https://lld.llvm.org/ELF/start-stop-gc)

ld.lld: error: undefined symbol: __stop_test_functions_section
>>> referenced by ld-temp.o
>>>               lto.tmp:(main)
>>> referenced by ld-temp.o
>>>               lto.tmp:(main)
clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
[136/150] clang  -o bench-rules bench-rules.p/bench_rules.c.o -Wl,--as-needed -Wl,--no-undefined -O2 -march=native -pipe -flto -Werror=odr -Werror=strict-aliasing -ffunction-sections -fdata-sections -Wl,-O2 -Wl,--gc-sections -Wl,--icf=all -Wl,--as-needed -fuse-ld=lld -Wl,--start-group libxkbcommon-test-internal.a -Wl,--end-group
[137/150] clang  -o test-rulescomp test-rulescomp.p/test_rulescomp.c.o -Wl,--as-needed -Wl,--no-undefined -O2 -march=native -pipe -flto -Werror=odr -Werror=strict-aliasing -ffunction-sections -fdata-sections -Wl,-O2 -Wl,--gc-sections -Wl,--icf=all -Wl,--as-needed -fuse-ld=lld -Wl,--start-group libxkbcommon-test-internal.a -Wl,--end-group
[138/150] clang  -o test-modifiers test-modifiers.p/test_modifiers.c.o -Wl,--as-needed -Wl,--no-undefined -O2 -march=native -pipe -flto -Werror=odr -Werror=strict-aliasing -ffunction-sections -fdata-sections -Wl,-O2 -Wl,--gc-sections -Wl,--icf=all -Wl,--as-needed -fuse-ld=lld -Wl,--start-group libxkbcommon-test-internal.a -Wl,--end-group
[139/150] clang  -o fuzz-keymap fuzz-keymap.p/fuzz_keymap_target.c.o -Wl,--as-needed -Wl,--no-undefined -O2 -march=native -pipe -flto -Werror=odr -Werror=strict-aliasing -ffunction-sections -fdata-sections -Wl,-O2 -Wl,--gc-sections -Wl,--icf=all -Wl,--as-needed -fuse-ld=lld -Wl,--start-group libxkbcommon-test-internal.a -Wl,--end-group
[140/150] clang  -o bench-key-proc bench-key-proc.p/bench_key-proc.c.o -Wl,--as-needed -Wl,--no-undefined -O2 -march=native -pipe -flto -Werror=odr -Werror=strict-aliasing -ffunction-sections -fdata-sections -Wl,-O2 -Wl,--gc-sections -Wl,--icf=all -Wl,--as-needed -fuse-ld=lld -Wl,--start-group libxkbcommon-test-internal.a -Wl,--end-group
ninja: build stopped: subcommand failed.
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /usr/bin/ninja -j 7 -v
 * ERROR: x11-libs/libxkbcommon-1.6.0::gentoo failed (compile phase):
 *   compile failed
 * 
 * Call stack:
 *     ebuild.sh, line  136:  Called src_compile
 *   environment, line 2982:  Called meson-multilib_src_compile
 *   environment, line 1777:  Called multilib-minimal_src_compile
 *   environment, line 1996:  Called multilib_foreach_abi 'multilib-minimal_abi_src_compile'
 *   environment, line 2263:  Called multibuild_foreach_variant '_multilib_multibuild_wrapper' 'multilib-minimal_abi_src_compile'
 *   environment, line 1956:  Called _multibuild_run '_multilib_multibuild_wrapper' 'multilib-minimal_abi_src_compile'
 *   environment, line 1954:  Called _multilib_multibuild_wrapper 'multilib-minimal_abi_src_compile'
 *   environment, line  616:  Called multilib-minimal_abi_src_compile
 *   environment, line 1990:  Called multilib_src_compile
 *   environment, line 2483:  Called meson_src_compile
 *   environment, line 1845:  Called die
 * The specific snippet of code:
 *       "$@" || die "compile failed"
 * 
 * If you need support, post the output of `emerge --info '=x11-libs/libxkbcommon-1.6.0::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=x11-libs/libxkbcommon-1.6.0::gentoo'`.
 * The complete build log is located at '/var/log/portage/x11-libs:libxkbcommon-1.6.0:20231126-094931.log'.
 * For convenience, a symlink to the build log is located at '/var/tmp/portage/x11-libs/libxkbcommon-1.6.0/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/x11-libs/libxkbcommon-1.6.0/temp/environment'.
 * Working directory: '/var/tmp/portage/x11-libs/libxkbcommon-1.6.0/work/libxkbcommon-1.6.0-abi_x86_64.amd64'
 * S: '/var/tmp/portage/x11-libs/libxkbcommon-1.6.0/work/libxkbcommon-1.6.0'
 ```

This patch addresses that issue, notifying the linker not to garbage collect these sections. (My checks show it builds with gcc, too.)