### PR TITLE
Keysyms: explicit bounds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -623,6 +623,7 @@ libxkbcommon_test_internal = static_library(
     'bench/bench.h',
     libxkbcommon_sources,
     include_directories: include_directories('src', 'include'),
+    c_args: ['-DENABLE_PRIVATE_APIS'],
 )
 test_dep = declare_dependency(
     include_directories: include_directories('src', 'include'),
@@ -652,7 +653,8 @@ if get_option('enable-x11')
 endif
 test(
     'keysym',
-    executable('test-keysym', 'test/keysym.c', dependencies: test_dep),
+    executable('test-keysym', 'test/keysym.c', dependencies: test_dep,
+               c_args: ['-DENABLE_PRIVATE_APIS']),
     env: test_env,
 )
 test(

--- a/scripts/update-headers.py
+++ b/scripts/update-headers.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+import argparse
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+import jinja2
+
+KEYSYM_PATTERN = re.compile(
+    r"^#define\s+XKB_KEY_(?P<name>\w+)\s+(?P<value>0x[0-9a-fA-F]+)\s"
+)
+
+
+def load_keysyms(path: Path) -> dict[str, int]:
+    # Load the keysyms header
+    keysym_min = sys.maxsize
+    keysym_max = 0
+    min_unicode_keysym = 0x01000100
+    max_unicode_keysym = 0x0110FFFF
+    keysyms = set()
+    with path.open("rt", encoding="utf-8") as fd:
+        for line in fd:
+            if m := KEYSYM_PATTERN.match(line):
+                value = int(m.group("value"), 16)
+                keysyms.add(value)
+                keysym_min = min(keysym_min, value)
+                keysym_max = max(keysym_max, value)
+    return {
+        "XKB_KEYSYM_MIN_ASSIGNED": min(keysym_min, min_unicode_keysym),
+        "XKB_KEYSYM_MAX_ASSIGNED": max(keysym_max, max_unicode_keysym),
+        "XKB_KEYSYM_MIN_EXPLICIT": keysym_min,
+        "XKB_KEYSYM_MAX_EXPLICIT": keysym_max,
+        "XKB_KEYSYM_COUNT_EXPLICIT": len(keysyms),
+    }
+
+
+def generate(
+    env: jinja2.Environment,
+    data: dict[str, Any],
+    root: Path,
+    file: Path,
+):
+    """Generate a file from its Jinja2 template"""
+    template_path = file.with_suffix(f"{file.suffix}.jinja")
+    template = env.get_template(str(template_path))
+    path = root / file
+    with path.open("wt", encoding="utf-8") as fd:
+        fd.writelines(template.generate(**data))
+
+
+# Root of the project
+ROOT = Path(__file__).parent.parent
+
+# Parse commands
+parser = argparse.ArgumentParser(
+    description="Generate C header files related to keysyms bounds"
+)
+parser.add_argument(
+    "--root",
+    type=Path,
+    default=ROOT,
+    help="Path to the root of the project (default: %(default)s)",
+)
+
+args = parser.parse_args()
+
+# Configure Jinja
+template_loader = jinja2.FileSystemLoader(args.root, encoding="utf-8")
+jinja_env = jinja2.Environment(
+    loader=template_loader,
+    keep_trailing_newline=True,
+    trim_blocks=True,
+    lstrip_blocks=True,
+)
+
+jinja_env.filters["keysym"] = lambda ks: f"0x{ks:0>8x}"
+
+# Load keysyms
+keysyms_data = load_keysyms(args.root / "include/xkbcommon/xkbcommon-keysyms.h")
+
+# Generate the files
+generate(
+    jinja_env,
+    keysyms_data,
+    args.root,
+    Path("src/keysym.h"),
+)

--- a/scripts/update-headers.py
+++ b/scripts/update-headers.py
@@ -19,20 +19,28 @@ def load_keysyms(path: Path) -> dict[str, int]:
     keysym_max = 0
     min_unicode_keysym = 0x01000100
     max_unicode_keysym = 0x0110FFFF
-    keysyms = set()
+    canonical_names: dict[int, str] = {}
+    max_unicode_name = "U10FFFF"
+    max_keysym_name = "0x1fffffff"  # XKB_KEYSYM_MAX
     with path.open("rt", encoding="utf-8") as fd:
         for line in fd:
             if m := KEYSYM_PATTERN.match(line):
                 value = int(m.group("value"), 16)
-                keysyms.add(value)
                 keysym_min = min(keysym_min, value)
                 keysym_max = max(keysym_max, value)
+                if value not in canonical_names:
+                    canonical_names[value] = m.group("name")
     return {
         "XKB_KEYSYM_MIN_ASSIGNED": min(keysym_min, min_unicode_keysym),
         "XKB_KEYSYM_MAX_ASSIGNED": max(keysym_max, max_unicode_keysym),
         "XKB_KEYSYM_MIN_EXPLICIT": keysym_min,
         "XKB_KEYSYM_MAX_EXPLICIT": keysym_max,
-        "XKB_KEYSYM_COUNT_EXPLICIT": len(keysyms),
+        "XKB_KEYSYM_COUNT_EXPLICIT": len(canonical_names),
+        "XKB_KEYSYM_NAME_MAX_SIZE": max(
+            max(len(name) for name in canonical_names.values()),
+            len(max_unicode_name),
+            len(max_keysym_name),
+        ),
     }
 
 

--- a/scripts/update-keysyms
+++ b/scripts/update-keysyms
@@ -4,3 +4,4 @@
 export LC_CTYPE=C
 scripts/makeheader > include/xkbcommon/xkbcommon-keysyms.h
 scripts/makekeys include/xkbcommon/xkbcommon-keysyms.h > src/ks_tables.h
+scripts/update-headers

--- a/src/keysym-utf.c
+++ b/src/keysym-utf.c
@@ -40,6 +40,7 @@
 #include "xkbcommon/xkbcommon.h"
 #include "utils.h"
 #include "utf8.h"
+#include "keysym.h"
 
 #define NO_KEYSYM_UNICODE_CONVERSION 0
 
@@ -886,8 +887,8 @@ xkb_keysym_to_utf32(xkb_keysym_t keysym)
      * ways. However, changing this after a couple of decades probably won't
      * go well, so it stays as it is.
      */
-    if (0x01000000 <= keysym && keysym <= 0x0110ffff)
-        return keysym - 0x01000000;
+    if (XKB_KEYSYM_UNICODE_OFFSET <= keysym && keysym <= XKB_KEYSYM_UNICODE_MAX)
+        return keysym - XKB_KEYSYM_UNICODE_OFFSET;
 
     /* search main table */
     return bin_search(keysymtab, ARRAY_SIZE(keysymtab) - 1, keysym);
@@ -920,7 +921,7 @@ xkb_utf32_to_keysym(uint32_t ucs)
             return keysymtab[i].keysym;
 
     /* Use direct encoding if everything else fails */
-    return ucs | 0x01000000;
+    return ucs | XKB_KEYSYM_UNICODE_OFFSET;
 }
 
 /*

--- a/src/keysym.c
+++ b/src/keysym.c
@@ -82,7 +82,7 @@ xkb_keysym_get_name(xkb_keysym_t ks, char *buffer, size_t size)
     }
 
     /* Unnamed Unicode codepoint. */
-    if (ks >= 0x01000100 && ks <= 0x0110ffff) {
+    if (ks >= XKB_KEYSYM_UNICODE_MIN && ks <= XKB_KEYSYM_UNICODE_MAX) {
         const int width = (ks & 0xff0000UL) ? 8 : 4;
         return snprintf(buffer, size, "U%0*lX", width, ks & 0xffffffUL);
     }
@@ -203,7 +203,7 @@ xkb_keysym_from_name(const char *name, enum xkb_keysym_flags flags)
             return (xkb_keysym_t) val;
         if (val > 0x10ffff)
             return XKB_KEY_NoSymbol;
-        return (xkb_keysym_t) val | 0x01000000;
+        return (xkb_keysym_t) val | XKB_KEYSYM_UNICODE_OFFSET;
     }
     else if (name[0] == '0' && (name[1] == 'x' || (icase && name[1] == 'X'))) {
         if (!parse_keysym_hex(&name[2], &val))
@@ -677,10 +677,10 @@ XConvertCase(xkb_keysym_t sym, xkb_keysym_t *lower, xkb_keysym_t *upper)
     }
 
     /* Unicode keysym */
-    if ((sym & 0xff000000) == 0x01000000) {
+    if ((sym & 0xff000000) == XKB_KEYSYM_UNICODE_OFFSET) {
         UCSConvertCase((sym & 0x00ffffff), lower, upper);
-        *upper |= 0x01000000;
-        *lower |= 0x01000000;
+        *upper |= XKB_KEYSYM_UNICODE_OFFSET;
+        *lower |= XKB_KEYSYM_UNICODE_OFFSET;
         return;
     }
 

--- a/src/keysym.h
+++ b/src/keysym.h
@@ -56,7 +56,13 @@
  * check min keysym when previously there was no reason to.
  */
 /** Minimum keysym value */
-#define XKB_KEYSYM_MIN      0x00000000
+#define XKB_KEYSYM_MIN            0x00000000
+/** Offset to use when converting a Unicode code point to a keysym */
+#define XKB_KEYSYM_UNICODE_OFFSET 0x01000000
+/** Minimum Unicode keysym. NOTE: code points in 0..0xff cannot be converted. */
+#define XKB_KEYSYM_UNICODE_MIN    0x01000100
+/** Maximum Unicode keysym, correspoding to the maximum Unicode code point */
+#define XKB_KEYSYM_UNICODE_MAX    0x0110ffff
 
 bool
 xkb_keysym_is_lower(xkb_keysym_t keysym);

--- a/src/keysym.h
+++ b/src/keysym.h
@@ -76,6 +76,8 @@
 #define XKB_KEYSYM_UNICODE_MIN    0x01000100
 /** Maximum Unicode keysym, correspoding to the maximum Unicode code point */
 #define XKB_KEYSYM_UNICODE_MAX    0x0110ffff
+/** Maximum keysym name length */
+#define XKB_KEYSYM_NAME_MAX_SIZE  27
 
 bool
 xkb_keysym_is_assigned(xkb_keysym_t ks);

--- a/src/keysym.h
+++ b/src/keysym.h
@@ -80,6 +80,27 @@
 bool
 xkb_keysym_is_assigned(xkb_keysym_t ks);
 
+struct xkb_keysym_iterator;
+
+struct xkb_keysym_iterator*
+xkb_keysym_iterator_new(bool explicit);
+
+struct xkb_keysym_iterator*
+xkb_keysym_iterator_unref(struct xkb_keysym_iterator *iter);
+
+bool
+xkb_keysym_iterator_next(struct xkb_keysym_iterator *iter);
+
+xkb_keysym_t
+xkb_keysym_iterator_get_keysym(struct xkb_keysym_iterator *iter);
+
+int
+xkb_keysym_iterator_get_name(struct xkb_keysym_iterator *iter,
+                             char *buffer, size_t size);
+
+bool
+xkb_keysym_iterator_is_explicitly_named(struct xkb_keysym_iterator *iter);
+
 bool
 xkb_keysym_is_lower(xkb_keysym_t keysym);
 

--- a/src/keysym.h
+++ b/src/keysym.h
@@ -50,6 +50,9 @@
 #ifndef KEYSYM_H
 #define KEYSYM_H
 
+#include <stdbool.h>
+#include "xkbcommon/xkbcommon.h"
+
 /*
  * NOTE: this is not defined in xkbcommon.h, because if we did, it may add
  * overhead for library user: when handling keysyms they would also need to
@@ -73,6 +76,9 @@
 #define XKB_KEYSYM_UNICODE_MIN    0x01000100
 /** Maximum Unicode keysym, correspoding to the maximum Unicode code point */
 #define XKB_KEYSYM_UNICODE_MAX    0x0110ffff
+
+bool
+xkb_keysym_is_assigned(xkb_keysym_t ks);
 
 bool
 xkb_keysym_is_lower(xkb_keysym_t keysym);

--- a/src/keysym.h.jinja
+++ b/src/keysym.h.jinja
@@ -76,6 +76,8 @@
 #define XKB_KEYSYM_UNICODE_MIN    0x01000100
 /** Maximum Unicode keysym, correspoding to the maximum Unicode code point */
 #define XKB_KEYSYM_UNICODE_MAX    0x0110ffff
+/** Maximum keysym name length */
+#define XKB_KEYSYM_NAME_MAX_SIZE  {{ XKB_KEYSYM_NAME_MAX_SIZE }}
 
 bool
 xkb_keysym_is_assigned(xkb_keysym_t ks);

--- a/src/keysym.h.jinja
+++ b/src/keysym.h.jinja
@@ -58,15 +58,15 @@
 /** Minimum keysym value */
 #define XKB_KEYSYM_MIN            0x00000000
 /** Minimum keysym value assigned */
-#define XKB_KEYSYM_MIN_ASSIGNED   ((xkb_keysym_t)0x00000000)
+#define XKB_KEYSYM_MIN_ASSIGNED   ((xkb_keysym_t){{ XKB_KEYSYM_MIN_ASSIGNED | keysym }})
 /** Maximum keysym value assigned */
-#define XKB_KEYSYM_MAX_ASSIGNED   0x1008ffb8
+#define XKB_KEYSYM_MAX_ASSIGNED   {{ XKB_KEYSYM_MAX_ASSIGNED | keysym }}
 /** Minimum keysym value with explicit name */
-#define XKB_KEYSYM_MIN_EXPLICIT   0x00000000
+#define XKB_KEYSYM_MIN_EXPLICIT   {{ XKB_KEYSYM_MIN_EXPLICIT | keysym }}
 /** Maximum keysym value with explicit name */
-#define XKB_KEYSYM_MAX_EXPLICIT   0x1008ffb8
+#define XKB_KEYSYM_MAX_EXPLICIT   {{ XKB_KEYSYM_MAX_EXPLICIT | keysym }}
 /** Count of keysym value with explicit name */
-#define XKB_KEYSYM_COUNT_EXPLICIT 2442
+#define XKB_KEYSYM_COUNT_EXPLICIT {{ XKB_KEYSYM_COUNT_EXPLICIT }}
 /** Offset to use when converting a Unicode code point to a keysym */
 #define XKB_KEYSYM_UNICODE_OFFSET 0x01000000
 /** Minimum Unicode keysym. NOTE: code points in 0..0xff cannot be converted. */

--- a/src/keysym.h.jinja
+++ b/src/keysym.h.jinja
@@ -80,6 +80,27 @@
 bool
 xkb_keysym_is_assigned(xkb_keysym_t ks);
 
+struct xkb_keysym_iterator;
+
+struct xkb_keysym_iterator*
+xkb_keysym_iterator_new(bool explicit);
+
+struct xkb_keysym_iterator*
+xkb_keysym_iterator_unref(struct xkb_keysym_iterator *iter);
+
+bool
+xkb_keysym_iterator_next(struct xkb_keysym_iterator *iter);
+
+xkb_keysym_t
+xkb_keysym_iterator_get_keysym(struct xkb_keysym_iterator *iter);
+
+int
+xkb_keysym_iterator_get_name(struct xkb_keysym_iterator *iter,
+                             char *buffer, size_t size);
+
+bool
+xkb_keysym_iterator_is_explicitly_named(struct xkb_keysym_iterator *iter);
+
 bool
 xkb_keysym_is_lower(xkb_keysym_t keysym);
 

--- a/src/keysym.h.jinja
+++ b/src/keysym.h.jinja
@@ -50,6 +50,9 @@
 #ifndef KEYSYM_H
 #define KEYSYM_H
 
+#include <stdbool.h>
+#include "xkbcommon/xkbcommon.h"
+
 /*
  * NOTE: this is not defined in xkbcommon.h, because if we did, it may add
  * overhead for library user: when handling keysyms they would also need to
@@ -73,6 +76,9 @@
 #define XKB_KEYSYM_UNICODE_MIN    0x01000100
 /** Maximum Unicode keysym, correspoding to the maximum Unicode code point */
 #define XKB_KEYSYM_UNICODE_MAX    0x0110ffff
+
+bool
+xkb_keysym_is_assigned(xkb_keysym_t ks);
 
 bool
 xkb_keysym_is_lower(xkb_keysym_t keysym);

--- a/src/text.c
+++ b/src/text.c
@@ -27,6 +27,7 @@
 #include "config.h"
 
 #include "keymap.h"
+#include "keysym.h"
 #include "text.h"
 
 bool
@@ -235,8 +236,8 @@ ActionTypeText(enum xkb_action_type type)
 const char *
 KeysymText(struct xkb_context *ctx, xkb_keysym_t sym)
 {
-    char *buffer = xkb_context_get_buffer(ctx, 64);
-    xkb_keysym_get_name(sym, buffer, 64);
+    char *buffer = xkb_context_get_buffer(ctx, XKB_KEYSYM_NAME_MAX_SIZE);
+    xkb_keysym_get_name(sym, buffer, XKB_KEYSYM_NAME_MAX_SIZE);
     return buffer;
 }
 

--- a/test/common.c
+++ b/test/common.c
@@ -47,6 +47,7 @@
 
 #include "test.h"
 #include "utils.h"
+#include "src/keysym.h"
 
 /*
  * Test a sequence of keysyms, resulting from a sequence of key presses,
@@ -76,7 +77,7 @@ test_key_seq_va(struct xkb_keymap *keymap, va_list ap)
     const xkb_keysym_t *syms;
     xkb_keysym_t sym;
     unsigned int nsyms, i;
-    char ksbuf[64];
+    char ksbuf[XKB_KEYSYM_NAME_MAX_SIZE];
 
     fprintf(stderr, "----\n");
 

--- a/test/compose.c
+++ b/test/compose.c
@@ -28,6 +28,7 @@
 
 #include "test.h"
 #include "src/utf8.h"
+#include "src/keysym.h"
 #include "src/compose/parser.h"
 #include "src/compose/dump.h"
 
@@ -73,7 +74,7 @@ test_compose_seq_va(struct xkb_compose_table *table, va_list ap)
 {
     int ret;
     struct xkb_compose_state *state;
-    char buffer[64];
+    char buffer[XKB_KEYSYM_NAME_MAX_SIZE];
 
     state = xkb_compose_state_new(table, XKB_COMPOSE_STATE_NO_FLAGS);
     assert(state);

--- a/test/keysym.c
+++ b/test/keysym.c
@@ -147,6 +147,32 @@ main(void)
     assert(XKB_KEYSYM_UNICODE_MIN < XKB_KEYSYM_UNICODE_MAX);
     assert(XKB_KEYSYM_UNICODE_MAX <= XKB_KEYSYM_MAX_EXPLICIT);
 
+    /* Assigned keysyms */
+    assert(xkb_keysym_is_assigned(XKB_KEYSYM_MIN));
+    assert(xkb_keysym_is_assigned(XKB_KEYSYM_MIN_ASSIGNED));
+    assert(xkb_keysym_is_assigned(XKB_KEY_space));
+    assert(xkb_keysym_is_assigned(XKB_KEY_nobreakspace));
+    assert(xkb_keysym_is_assigned(XKB_KEY_Aogonek));
+    assert(xkb_keysym_is_assigned(XKB_KEY_Hstroke));
+    assert(xkb_keysym_is_assigned(XKB_KEY_kra));
+    assert(xkb_keysym_is_assigned(XKB_KEY_braille_dot_1));
+    assert(xkb_keysym_is_assigned(XKB_KEY_XF86KbdLcdMenu5));
+    assert(xkb_keysym_is_assigned(XKB_KEY_Shift_L));
+    assert(xkb_keysym_is_assigned(XKB_KEY_XF86MonBrightnessUp));
+    assert(xkb_keysym_is_assigned(XKB_KEY_VoidSymbol));
+    assert(xkb_keysym_is_assigned(XKB_KEYSYM_UNICODE_MIN));
+    assert(xkb_keysym_is_assigned((XKB_KEYSYM_UNICODE_MIN + XKB_KEYSYM_UNICODE_MAX) / 2));
+    assert(xkb_keysym_is_assigned(XKB_KEYSYM_UNICODE_MAX));
+    assert(xkb_keysym_is_assigned(XKB_KEYSYM_MAX_ASSIGNED));
+    assert(!xkb_keysym_is_assigned(XKB_KEYSYM_MAX));
+
+    for (xkb_keysym_t ks = XKB_KEYSYM_MIN; ks <= XKB_KEYSYM_MAX; ks++) {
+        if (!xkb_keysym_is_assigned(ks))
+            continue;
+        /* Check assigned keysyms bounds */
+        assert(XKB_KEYSYM_MIN_ASSIGNED <= (int32_t)ks && ks <= XKB_KEYSYM_MAX_ASSIGNED);
+    }
+
     /* Named keysyms */
     assert(test_string("NoSymbol", XKB_KEY_NoSymbol));
     assert(test_string("Undo", 0xFF65));

--- a/test/keysym.c
+++ b/test/keysym.c
@@ -131,6 +131,22 @@ test_utf32_to_keysym(uint32_t ucs, xkb_keysym_t expected)
 int
 main(void)
 {
+    /* Bounds */
+    assert(XKB_KEYSYM_MIN == 0);
+    assert(XKB_KEYSYM_MIN < XKB_KEYSYM_MAX);
+    assert(XKB_KEYSYM_MAX <= UINT32_MAX); /* Ensure it fits in xkb_keysym_t */
+    assert(XKB_KEYSYM_MAX <= INT32_MAX); /* Ensure correct cast to int32_t */
+    assert(XKB_KEYSYM_MIN_ASSIGNED == XKB_KEYSYM_MIN);
+    assert(XKB_KEYSYM_MIN_ASSIGNED < XKB_KEYSYM_MAX_ASSIGNED);
+    assert(XKB_KEYSYM_MAX_ASSIGNED <= XKB_KEYSYM_MAX);
+    assert(XKB_KEYSYM_MIN_EXPLICIT == XKB_KEYSYM_MIN_ASSIGNED);
+    assert(XKB_KEYSYM_MIN_EXPLICIT < XKB_KEYSYM_MAX_EXPLICIT);
+    assert(XKB_KEYSYM_MAX_EXPLICIT <= XKB_KEYSYM_MAX_ASSIGNED);
+    assert(XKB_KEYSYM_COUNT_EXPLICIT <= XKB_KEYSYM_MAX_EXPLICIT - XKB_KEYSYM_MIN_EXPLICIT + 1);
+    assert(XKB_KEYSYM_UNICODE_MIN >= XKB_KEYSYM_MIN_EXPLICIT);
+    assert(XKB_KEYSYM_UNICODE_MIN < XKB_KEYSYM_UNICODE_MAX);
+    assert(XKB_KEYSYM_UNICODE_MAX <= XKB_KEYSYM_MAX_EXPLICIT);
+
     /* Named keysyms */
     assert(test_string("NoSymbol", XKB_KEY_NoSymbol));
     assert(test_string("Undo", 0xFF65));

--- a/test/keysym.c
+++ b/test/keysym.c
@@ -179,6 +179,10 @@ main(void)
         ks_prev = ks;
         /* Check assigned keysyms bounds */
         assert((int32_t)XKB_KEYSYM_MIN_ASSIGNED <= (int32_t)ks && ks <= XKB_KEYSYM_MAX_ASSIGNED);
+        /* Check utf8 */
+        char utf8[7];
+        int needed = xkb_keysym_to_utf8(ks, utf8, sizeof(utf8));
+        assert(0 <= needed && needed <= 5);
     }
     iter = xkb_keysym_iterator_unref(iter);
     assert(ks_prev == XKB_KEYSYM_MAX_ASSIGNED);

--- a/test/keysym.c
+++ b/test/keysym.c
@@ -166,9 +166,10 @@ main(void)
     assert(test_string("U009f", XKB_KEY_NoSymbol));
     assert(test_string("U00a0", 0x00000a0));
     assert(test_string("U00ff", 0x00000ff));
+    assert(test_string("U0100", XKB_KEYSYM_UNICODE_MIN));
     assert(test_string("U4567", 0x1004567));
     assert(test_string("U1F4A9", 0x0101F4A9));
-    assert(test_string("U10FFFF", 0x110ffff)); /* Max Unicode */
+    assert(test_string("U10FFFF", XKB_KEYSYM_UNICODE_MAX)); /* Max Unicode */
     assert(test_string("U110000", XKB_KEY_NoSymbol));
     /* Unicode: test syntax */
     assert(test_string("U00004567", 0x1004567));         /* OK:  8 digits */
@@ -189,8 +190,8 @@ main(void)
     assert(test_string("0x1", 0x00000001));
     assert(test_string("0x01234567", 0x01234567));
     assert(test_string("0x09abcdef", 0x09abcdef));
-    assert(test_string("0x01000100", 0x01000100)); /* Min Unicode. */
-    assert(test_string("0x0110ffff", 0x0110ffff)); /* Max Unicode. */
+    assert(test_string("0x01000100", XKB_KEYSYM_UNICODE_MIN)); /* Min Unicode. */
+    assert(test_string("0x0110ffff", XKB_KEYSYM_UNICODE_MAX)); /* Max Unicode. */
     assert(test_string(STRINGIFY2(XKB_KEYSYM_MAX), XKB_KEYSYM_MAX));   /* Max keysym. */
     assert(test_string("0x20000000", XKB_KEY_NoSymbol));
     assert(test_string("0xffffffff", XKB_KEY_NoSymbol));
@@ -215,16 +216,16 @@ main(void)
     assert(test_keysym(0x1008FF56, "XF86Close"));
     assert(test_keysym(0x0, "NoSymbol"));
     assert(test_keysym(0x1008FE20, "XF86Ungrab"));
-    assert(test_keysym(0x01000000, "0x01000000"));
+    assert(test_keysym(XKB_KEYSYM_UNICODE_OFFSET, "0x01000000"));
     /* Min Unicode */
-    assert(test_keysym(0x01000100, "U0100"));
+    assert(test_keysym(XKB_KEYSYM_UNICODE_MIN, "U0100"));
     assert(test_keysym(0x01001234, "U1234"));
     /* 16-bit unicode padded to width 4. */
     assert(test_keysym(0x010002DE, "U02DE"));
     /* 32-bit unicode padded to width 8. */
     assert(test_keysym(0x0101F4A9, "U0001F4A9"));
     /* Max Unicode */
-    assert(test_keysym(0x0110ffff, "U0010FFFF"));
+    assert(test_keysym(XKB_KEYSYM_UNICODE_MAX, "U0010FFFF"));
     /* Max Unicode + 1 */
     assert(test_keysym(0x01110000, "0x01110000"));
     /* Min keysym. */
@@ -293,14 +294,14 @@ main(void)
     assert(test_utf8(XKB_KEY_KP_Subtract, "-"));
 
     /* Unicode keysyms */
-    assert(test_utf8(0x1000000, NULL) == 0); /* Min Unicode codepoint */
+    assert(test_utf8(XKB_KEYSYM_UNICODE_OFFSET, NULL) == 0); /* Min Unicode codepoint */
     assert(test_utf8(0x1000001, "\x01"));     /* Currently accepted, but not intended (< 0x100100) */
     assert(test_utf8(0x1000020, " "));        /* Currently accepted, but not intended (< 0x100100) */
     assert(test_utf8(0x100007f, "\x7f"));     /* Currently accepted, but not intended (< 0x100100) */
     assert(test_utf8(0x10000a0, "\xc2\xa0")); /* Currently accepted, but not intended (< 0x100100) */
-    assert(test_utf8(0x1000100, "Ā")); /* Min Unicode keysym */
+    assert(test_utf8(XKB_KEYSYM_UNICODE_MIN, "Ā")); /* Min Unicode keysym */
     assert(test_utf8(0x10005d0, "א"));
-    assert(test_utf8(0x110ffff, "\xf4\x8f\xbf\xbf")); /* Max Unicode */
+    assert(test_utf8(XKB_KEYSYM_UNICODE_MAX, "\xf4\x8f\xbf\xbf")); /* Max Unicode */
     assert(test_utf8(0x0100d800, NULL) == 0); // Unicode surrogates
     assert(test_utf8(0x0100dfff, NULL) == 0); // Unicode surrogates
     assert(test_utf8(0x1110000, NULL) == 0);

--- a/test/keysym.c
+++ b/test/keysym.c
@@ -166,12 +166,23 @@ main(void)
     assert(xkb_keysym_is_assigned(XKB_KEYSYM_MAX_ASSIGNED));
     assert(!xkb_keysym_is_assigned(XKB_KEYSYM_MAX));
 
-    for (xkb_keysym_t ks = XKB_KEYSYM_MIN; ks <= XKB_KEYSYM_MAX; ks++) {
-        if (!xkb_keysym_is_assigned(ks))
-            continue;
+    struct xkb_keysym_iterator *iter = xkb_keysym_iterator_new(false);
+    xkb_keysym_t ks_prev = XKB_KEYSYM_MIN;
+    uint32_t count = 0;
+    uint32_t count_non_unicode = 0;
+    while (xkb_keysym_iterator_next(iter)) {
+        count++;
+        xkb_keysym_t ks = xkb_keysym_iterator_get_keysym(iter);
+        if (ks < XKB_KEYSYM_UNICODE_MIN || ks > XKB_KEYSYM_UNICODE_MAX)
+            count_non_unicode++;
+        assert(ks > ks_prev || count == 1);
+        ks_prev = ks;
         /* Check assigned keysyms bounds */
-        assert(XKB_KEYSYM_MIN_ASSIGNED <= (int32_t)ks && ks <= XKB_KEYSYM_MAX_ASSIGNED);
+        assert((int32_t)XKB_KEYSYM_MIN_ASSIGNED <= (int32_t)ks && ks <= XKB_KEYSYM_MAX_ASSIGNED);
     }
+    iter = xkb_keysym_iterator_unref(iter);
+    assert(ks_prev == XKB_KEYSYM_MAX_ASSIGNED);
+    assert(count == XKB_KEYSYM_UNICODE_MAX - XKB_KEYSYM_UNICODE_MIN + 1 + count_non_unicode);
 
     /* Named keysyms */
     assert(test_string("NoSymbol", XKB_KEY_NoSymbol));

--- a/test/keysym.c
+++ b/test/keysym.c
@@ -56,7 +56,7 @@ test_casestring(const char *string, xkb_keysym_t expected)
 static int
 test_keysym(xkb_keysym_t keysym, const char *expected)
 {
-    char s[16];
+    char s[XKB_KEYSYM_NAME_MAX_SIZE];
 
     xkb_keysym_get_name(keysym, s, sizeof(s));
 
@@ -117,11 +117,11 @@ get_keysym_name(xkb_keysym_t keysym, char *buffer, size_t size)
 static int
 test_utf32_to_keysym(uint32_t ucs, xkb_keysym_t expected)
 {
-    char expected_name[64];
-    char actual_name[64];
+    char expected_name[XKB_KEYSYM_NAME_MAX_SIZE];
+    char actual_name[XKB_KEYSYM_NAME_MAX_SIZE];
     xkb_keysym_t actual = xkb_utf32_to_keysym(ucs);
-    get_keysym_name(expected, expected_name, 64);
-    get_keysym_name(actual, actual_name, 64);
+    get_keysym_name(expected, expected_name, XKB_KEYSYM_NAME_MAX_SIZE);
+    get_keysym_name(actual, actual_name, XKB_KEYSYM_NAME_MAX_SIZE);
 
     fprintf(stderr, "Code point 0x%lx: expected keysym: %s, actual: %s\n\n",
             (unsigned long)ucs, expected_name, actual_name);
@@ -183,6 +183,10 @@ main(void)
         char utf8[7];
         int needed = xkb_keysym_to_utf8(ks, utf8, sizeof(utf8));
         assert(0 <= needed && needed <= 5);
+        /* Check maximum name length */
+        char name[XKB_KEYSYM_NAME_MAX_SIZE];
+        needed = xkb_keysym_iterator_get_name(iter, name, sizeof(name));
+        assert(0 < needed && (size_t)needed <= sizeof(name));
     }
     iter = xkb_keysym_iterator_unref(iter);
     assert(ks_prev == XKB_KEYSYM_MAX_ASSIGNED);

--- a/tools/compile-compose.c
+++ b/tools/compile-compose.c
@@ -31,6 +31,7 @@
 #include "xkbcommon/xkbcommon-keysyms.h"
 #include "xkbcommon/xkbcommon-compose.h"
 #include "src/compose/dump.h"
+#include "src/keysym.h"
 
 static void
 usage(FILE *fp, char *progname)
@@ -57,7 +58,7 @@ print_compose_table_entry(struct xkb_compose_table_entry *entry)
 {
     size_t nsyms;
     const xkb_keysym_t *syms = xkb_compose_table_entry_sequence(entry, &nsyms);
-    char buf[128];
+    char buf[XKB_KEYSYM_NAME_MAX_SIZE];
     for (size_t i = 0; i < nsyms; i++) {
         xkb_keysym_get_name(syms[i], buf, sizeof(buf));
         printf("<%s>", buf);

--- a/tools/how-to-type.c
+++ b/tools/how-to-type.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 
 #include "xkbcommon/xkbcommon.h"
+#include "src/keysym.h"
 
 #define ARRAY_SIZE(arr) ((sizeof(arr) / sizeof(*(arr))))
 
@@ -57,7 +58,7 @@ main(int argc, char *argv[])
     uint32_t codepoint;
     xkb_keysym_t keysym;
     int ret;
-    char name[200];
+    char name[XKB_KEYSYM_NAME_MAX_SIZE];
     struct xkb_keymap *keymap = NULL;
     xkb_keycode_t min_keycode, max_keycode;
     xkb_mod_index_t num_mods;

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -49,6 +49,8 @@
 #endif
 
 #include "tools-common.h"
+#include "src/utils.h"
+#include "src/keysym.h"
 
 static void
 print_keycode(struct xkb_keymap *keymap, const char* prefix,
@@ -155,7 +157,9 @@ tools_print_keycode_state(char *prefix,
     xkb_keysym_t sym;
     const xkb_keysym_t *syms;
     int nsyms;
-    char s[16];
+    // FIXME: this buffer is used for xkb_compose_state_get_utf8,
+    // which can have a length up to 256. Need to import this constant from compose.
+    char s[MAX(16, XKB_KEYSYM_NAME_MAX_SIZE)];
     xkb_layout_index_t layout;
     enum xkb_compose_status status;
 


### PR DESCRIPTION
Working on a fix of #413, I realize that some bounds related should be made explicit. 

I added `XKB_KEYSYM_NAME_MAX_SIZE` to the public API and a keysym iterator API for internal use.