### PR TITLE
Keysyms: fix xkb_keysym_is_modifier

### DIFF
--- a/src/keysym.c
+++ b/src/keysym.c
@@ -370,8 +370,7 @@ xkb_keysym_is_modifier(xkb_keysym_t keysym)
 {
     return
         (keysym >= XKB_KEY_Shift_L && keysym <= XKB_KEY_Hyper_R) ||
-        /* libX11 only goes upto XKB_KEY_ISO_Level5_Lock. */
-        (keysym >= XKB_KEY_ISO_Lock && keysym <= XKB_KEY_ISO_Last_Group_Lock) ||
+        (keysym >= XKB_KEY_ISO_Lock && keysym <= XKB_KEY_ISO_Level5_Lock) ||
         keysym == XKB_KEY_Mode_switch ||
         keysym == XKB_KEY_Num_Lock;
 }

--- a/test/keysym.c
+++ b/test/keysym.c
@@ -103,6 +103,13 @@ test_modifier(xkb_keysym_t ks)
     return false;
 }
 
+static bool
+test_keypad(xkb_keysym_t ks, char *name)
+{
+    const char prefix[] = "KP_";
+    return strncmp(prefix, name, sizeof(prefix) - 1) == 0;
+}
+
 static int
 test_string(const char *string, xkb_keysym_t expected)
 {
@@ -271,6 +278,13 @@ main(void)
         assert_printf(got == expected,
                       "xkb_keysym_is_modifier(0x%04"PRIx32"): expected %d, got: %d\n",
                       ks, expected, got);
+        /* Test keypad keysyms */
+        expected = test_keypad(ks, name);
+        got = xkb_keysym_is_keypad(ks);
+        assert_printf(got == expected,
+                      "xkb_keysym_is_keypad(0x%04"PRIx32") \"%s\": "
+                      "expected %d, got: %d\n",
+                      ks, name, expected, got);
     }
     iter = xkb_keysym_iterator_unref(iter);
     assert(ks_prev == XKB_KEYSYM_MAX_ASSIGNED);


### PR DESCRIPTION
Fixes #413 and add corresponding tests. Also add some tests for keypad keysyms.

This is based on #414; we should wait for it to be merged.