### PR TITLE
Compose: explicit result string size

### DIFF
--- a/src/compose/parser.c
+++ b/src/compose/parser.c
@@ -328,7 +328,7 @@ struct production {
     xkb_keysym_t lhs[MAX_LHS_LEN];
     unsigned int len;
     xkb_keysym_t keysym;
-    char string[256];
+    char string[XKB_COMPOSE_MAX_STRING_SIZE];
     /* At least one of these is true. */
     bool has_keysym;
     bool has_string;
@@ -687,8 +687,10 @@ rhs:
             scanner_warn(s, "right-hand side string must not be empty; skipping line");
             goto skip;
         }
-        if (val.string.len >= sizeof(production.string)) {
-            scanner_warn(s, "right-hand side string is too long; skipping line");
+        if (val.string.len > sizeof(production.string)) {
+            scanner_warn(s,
+                         "right-hand side string is too long: expected max: %d, got: %d; "
+                         "skipping line", (int)sizeof(production.string) - 1, (int)val.string.len);
             goto skip;
         }
         strcpy(production.string, val.string.str);

--- a/src/compose/parser.h
+++ b/src/compose/parser.h
@@ -26,6 +26,8 @@
 
 #define MAX_LHS_LEN 10
 #define MAX_INCLUDE_DEPTH 5
+/** Maximum size of the string returned by xkb_compose_state_get_utf8() */
+#define XKB_COMPOSE_MAX_STRING_SIZE 256
 
 char *
 parse_string_literal(struct xkb_context *ctx, const char *string);

--- a/src/compose/state.c
+++ b/src/compose/state.c
@@ -168,17 +168,17 @@ xkb_compose_state_get_utf8(struct xkb_compose_state *state,
     /* If there's no string specified, but only a keysym, try to do the
      * most helpful thing. */
     if (node->leaf.utf8 == 0 && node->leaf.keysym != XKB_KEY_NoSymbol) {
-        char name[64];
+        char utf8[7];
         int ret;
 
-        ret = xkb_keysym_to_utf8(node->leaf.keysym, name, sizeof(name));
+        ret = xkb_keysym_to_utf8(node->leaf.keysym, utf8, sizeof(utf8));
         if (ret < 0 || ret == 0) {
             /* ret < 0 is impossible.
              * ret == 0 means the keysym has no string representation. */
             goto fail;
         }
 
-        return snprintf(buffer, size, "%s", name);
+        return snprintf(buffer, size, "%s", utf8);
     }
 
     return snprintf(buffer, size, "%s",

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -51,6 +51,7 @@
 #include "tools-common.h"
 #include "src/utils.h"
 #include "src/keysym.h"
+#include "src/compose/parser.h"
 
 static void
 print_keycode(struct xkb_keymap *keymap, const char* prefix,
@@ -157,9 +158,7 @@ tools_print_keycode_state(char *prefix,
     xkb_keysym_t sym;
     const xkb_keysym_t *syms;
     int nsyms;
-    // FIXME: this buffer is used for xkb_compose_state_get_utf8,
-    // which can have a length up to 256. Need to import this constant from compose.
-    char s[MAX(16, XKB_KEYSYM_NAME_MAX_SIZE)];
+    char s[MAX(XKB_COMPOSE_MAX_STRING_SIZE, XKB_KEYSYM_NAME_MAX_SIZE)];
     xkb_layout_index_t layout;
     enum xkb_compose_status status;
 


### PR DESCRIPTION
In the spirit than #414, add explicit bound for compose result string.

This is based on #414; we should wait for it to be merged.