### PR TITLE
Keysyms: Fix case mapping

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt update
           sudo apt install -y \
             doxygen libxcb-xkb-dev valgrind ninja-build \
-            libwayland-dev wayland-protocols bison graphviz
+            libwayland-dev wayland-protocols bison graphviz libicu-dev
       - name: Install xkeyboard-config
         run: |
           # Install master version of xkeyboard-config, in order to ensure

--- a/meson.build
+++ b/meson.build
@@ -651,10 +651,18 @@ if get_option('enable-x11')
         ],
     )
 endif
+# TODO: version range?
+keysyms_test_dep = [test_dep]
+keysyms_test_c_args = ['-DENABLE_PRIVATE_APIS']
+icu_dep = dependency('icu-uc', required: false)
+if icu_dep.found()
+    keysyms_test_dep += [icu_dep]
+    configh_data.set10('HAVE_ICU', true)
+endif
 test(
     'keysym',
-    executable('test-keysym', 'test/keysym.c', dependencies: test_dep,
-               c_args: ['-DENABLE_PRIVATE_APIS']),
+    executable('test-keysym', 'test/keysym.c', dependencies: keysyms_test_dep,
+               c_args: keysyms_test_c_args),
     env: test_env,
 )
 test(

--- a/src/keysym.c
+++ b/src/keysym.c
@@ -618,8 +618,6 @@ UCSConvertCase(uint32_t code, xkb_keysym_t *lower, xkb_keysym_t *upper)
             *upper = 0x0178;
         else if (code == 0x00b5)      /* micro sign */
             *upper = 0x039c;
-        else if (code == 0x00df)      /* ssharp */
-            *upper = 0x1e9e;
 	return;
     }
 
@@ -796,8 +794,8 @@ UCSConvertCase(uint32_t code, xkb_keysym_t *lower, xkb_keysym_t *upper)
 static void
 XConvertCase(xkb_keysym_t sym, xkb_keysym_t *lower, xkb_keysym_t *upper)
 {
-    /* Latin 1 keysym */
-    if (sym < 0x100) {
+    /* Latin 1 keysym (first part: fast path) */
+    if (sym < 0xb5) {
         UCSConvertCase(sym, lower, upper);
 	return;
     }
@@ -816,6 +814,14 @@ XConvertCase(xkb_keysym_t sym, xkb_keysym_t *lower, xkb_keysym_t *upper)
     *upper = sym;
 
     switch(sym >> 8) {
+    case 0: /* Latin 1 (second part) */
+    if (sym == XKB_KEY_mu)
+        *upper = XKB_KEY_Greek_MU;
+    else if (sym == XKB_KEY_ydiaeresis)
+        *upper = XKB_KEY_Ydiaeresis;
+    else
+        UCSConvertCase(sym, lower, upper);
+    break;
     case 1: /* Latin 2 */
 	/* Assume the KeySym is a legal value (ignore discontinuities) */
 	if (sym == XKB_KEY_Aogonek)


### PR DESCRIPTION
There are a few mistakes in the function `XConvertCase`.

Fixed the upper case mappings for:
- `XKB_KEY_ydiaeresis`
- `XKB_KEY_mu`
- `XKB_KEY_ssharp`

Also added ICU optional test.

Notes:
- `xkb_keysym_is_upper` is interpreted as matching the disjunction of the Unicode character properties “Uppercase” or “Titlecase”.
- In Unicode, the upper case of “ß” (`U+00DF`) is *not* “ẞ” (`U+1E9E`) but “SS”. “ẞ” is reserved for text in capitals.

This MR depends on #414 and should be rebased on it.