### PR TITLE
Provide ssize_t for Windows

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -43,9 +43,11 @@
 #ifdef _WIN32
 # include <direct.h>
 # include <io.h>
+# include <BaseTsd.h>
 # ifndef S_ISDIR
 #  define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
 # endif
+typedef SSIZE_T ssize_t;
 #endif
 
 #include "darray.h"


### PR DESCRIPTION
`ssize_t` is not part of standard C but is specific to POSIX.