### PR TITLE
Fix crash when an element of SymbolsBody is empty

### DIFF
--- a/src/xkbcomp/parser.y
+++ b/src/xkbcomp/parser.y
@@ -465,7 +465,6 @@ SymbolsBody     :       SymbolsBody COMMA SymbolsVarDecl
                         { $$.head = $1.head; $$.last->common.next = &$3->common; $$.last = $3; }
                 |       SymbolsVarDecl
                         { $$.head = $$.last = $1; }
-                |       { $$.head = $$.last = NULL; }
                 ;
 
 SymbolsVarDecl  :       Lhs EQUALS Expr         { $$ = VarCreate($1, $3); }

--- a/test/data/keymaps/empty-symbol-decl.xkb
+++ b/test/data/keymaps/empty-symbol-decl.xkb
@@ -1,0 +1,10 @@
+xkb_keymap {
+    xkb_keycodes  { include "evdev+aliases(qwerty)" };
+    xkb_types     { include "complete" };
+    xkb_compat    { include "complete" };
+    xkb_symbols "sym" {
+        // This syntax caused the crash in parser before, and is not accepted
+        // anymore.
+        key <SPC> { , [Space] };
+    };
+};

--- a/test/filecomp.c
+++ b/test/filecomp.c
@@ -54,6 +54,7 @@ main(void)
     assert(!test_file(ctx, "keymaps/bad.xkb"));
     assert(!test_file(ctx, "keymaps/syntax-error.xkb"));
     assert(!test_file(ctx, "keymaps/syntax-error2.xkb"));
+    assert(!test_file(ctx, "keymaps/empty-symbol-decl.xkb"));
     assert(!test_file(ctx, "does not exist"));
 
     /* Test response to invalid flags and formats. */


### PR DESCRIPTION
An empty element is allowed in SymbolsBody definition, so the following keymap is gramatically correct.

```
xkb_keymap {
  xkb_symbols "sym" {
    key <SPC> {, [Space] };
  };
};
```

However, the current parser crashes with the keymap due to null pointer access.
This change fixes the crash.