### PR TITLE
doc: remove obsolete HTML_TIMESTAMP

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -41,7 +41,6 @@ IGNORE_PREFIX          = xkb_ \
 HTML_EXTRA_STYLESHEET  = doc/doxygen-extra.css
 
 TIMESTAMP              = NO
-HTML_TIMESTAMP         = NO
 
 ENUM_VALUES_PER_LINE   = 1
 


### PR DESCRIPTION
warning: Tag 'HTML_TIMESTAMP' at line 44 of file '/home/whot/xorg/lib/libxkbcommon/build/Doxyfile' has become obsolete.