### PR TITLE
interactive-evdev: align Usage and or in the help output

### DIFF
--- a/tools/interactive-evdev.c
+++ b/tools/interactive-evdev.c
@@ -380,7 +380,7 @@ usage(FILE *fp, char *progname)
                 "[--rules=<rules>] [--model=<model>] [--layout=<layout>] "
                 "[--variant=<variant>] [--options=<options>]\n",
                 progname);
-        fprintf(fp, "      or: %s --keymap <path to keymap file>\n",
+        fprintf(fp, "   or: %s --keymap <path to keymap file>\n",
                 progname);
         fprintf(fp, "For both:\n"
 #ifdef ENABLE_PRIVATE_APIS


### PR DESCRIPTION
```
Usage: /usr/libexec/xkbcommon/xkbcli-interactive-evdev [--include=<path>] [--include-defaults] [--rules=<rules>] [--model=<model>] [--layout=<layout>] [--variant=<variant>] [--options=<options>]
      or: /usr/libexec/xkbcommon/xkbcli-interactive-evdev --keymap <path to keymap file>
```

after:
```
Usage: ./build/xkbcli-interactive-evdev [--include=<path>] [--include-defaults] [--rules=<rules>] [--model=<model>] [--layout=<layout>] [--variant=<variant>] [--options=<options>]
   or: ./build/xkbcli-interactive-evdev --keymap <path to keymap file>
```