### PR TITLE
interactive-evdev: reduce the space allocated for keysyms

### DIFF
--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -200,7 +200,7 @@ tools_print_keycode_state(char *prefix,
     printf("keysyms [ ");
     for (int i = 0; i < nsyms; i++) {
         xkb_keysym_get_name(syms[i], s, sizeof(s));
-        printf("%-*s ", (int) sizeof(s), s);
+        printf("%-*s ", (int)MAX(strlen(s), XKB_KEYSYM_NAME_MAX_SIZE), s);
     }
     printf("] ");
 

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -200,7 +200,7 @@ tools_print_keycode_state(char *prefix,
     printf("keysyms [ ");
     for (int i = 0; i < nsyms; i++) {
         xkb_keysym_get_name(syms[i], s, sizeof(s));
-        printf("%-*s ", (int)MAX(strlen(s), XKB_KEYSYM_NAME_MAX_SIZE), s);
+        printf("%-*s ", XKB_KEYSYM_NAME_MAX_SIZE, s);
     }
     printf("] ");
 


### PR DESCRIPTION
In commit 8cca3a7bfb185876994d6ec3d25cda88e5640a4d the buffer for the keysym was extended to accommodate for up to XKB_COMPOSE_MAX_STRING_SIZE bytes. This caused the printf to expand to the same width for the keysym alone, making the output less useful. Drop this back down to the same width it was before.

cc @wismill 