### PR TITLE
Experiment: Add new real modifiers

### DIFF
--- a/src/keymap-priv.c
+++ b/src/keymap-priv.c
@@ -31,8 +31,11 @@
 static void
 update_builtin_keymap_fields(struct xkb_keymap *keymap)
 {
-    /* Predefined (AKA real, core, X11) modifiers. The order is important! */
+    /* Predefined (AKA real) modifiers. The order is important!
+     * Indeed, the modifier position defines the bit used to encode it.
+     * We use explicit indexes here to facilitate debugging. */
     static const char *const builtin_mods[] = {
+        /* Core/X11 modifiers */
         [0] = "Shift",
         [1] = "Lock",
         [2] = "Control",
@@ -40,8 +43,16 @@ update_builtin_keymap_fields(struct xkb_keymap *keymap)
         [4] = "Mod2",
         [5] = "Mod3",
         [6] = "Mod4",
-        [7] = "Mod5"
+        [7] = "Mod5",
+        /* xkbcommon extension */
+        [8] = "Mod6",
+        [9] = "Mod7",
+        [10] = "Mod8",
+        [11] = "Mod9",
+        [12] = "Mod10"
     };
+
+    _Static_assert(ARRAY_SIZE(builtin_mods) == MOD_REAL_MAX);
 
     for (unsigned i = 0; i < ARRAY_SIZE(builtin_mods); i++) {
         keymap->mods.mods[i].name = xkb_atom_intern(keymap->ctx,

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -121,12 +121,14 @@ enum mod_type {
 
 /* Count of real modifiers */
 #define MOD_REAL_MAX 13
+#define MOD_REAL_MAX_X11 8
 
 /* Ensure we can encode the modifier mask in xkb_mod_mask_t */
 _Static_assert(MOD_REAL_MAX <= XKB_MAX_MODS);
 
 /* Mask for all real modifiers */
 #define MOD_REAL_MASK_ALL ((xkb_mod_mask_t) ((1u << MOD_REAL_MAX) - 1))
+#define MOD_REAL_MASK_ALL_X11 ((xkb_mod_mask_t) ((1u << MOD_REAL_MAX_X11) - 1))
 
 enum xkb_action_type {
     ACTION_TYPE_NONE = 0,

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -118,7 +118,15 @@ enum mod_type {
     MOD_VIRT = (1 << 1),
     MOD_BOTH = (MOD_REAL | MOD_VIRT),
 };
-#define MOD_REAL_MASK_ALL ((xkb_mod_mask_t) 0x000000ff)
+
+/* Count of real modifiers */
+#define MOD_REAL_MAX 13
+
+/* Ensure we can encode the modifier mask in xkb_mod_mask_t */
+_Static_assert(MOD_REAL_MAX <= XKB_MAX_MODS);
+
+/* Mask for all real modifiers */
+#define MOD_REAL_MASK_ALL ((xkb_mod_mask_t) ((1u << MOD_REAL_MAX) - 1))
 
 enum xkb_action_type {
     ACTION_TYPE_NONE = 0,

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -104,10 +104,10 @@
 #define XKB_MAX_GROUPS 4
 
 /* Don't allow more modifiers than we can hold in xkb_mod_mask_t. */
-#define XKB_MAX_MODS ((xkb_mod_index_t) (sizeof(xkb_mod_mask_t) * 8))
+#define XKB_MAX_MODS ((xkb_mod_index_t) (sizeof(xkb_mod_mask_t) * CHAR_BIT))
 
 /* Don't allow more leds than we can hold in xkb_led_mask_t. */
-#define XKB_MAX_LEDS ((xkb_led_index_t) (sizeof(xkb_led_mask_t) * 8))
+#define XKB_MAX_LEDS ((xkb_led_index_t) (sizeof(xkb_led_mask_t) * CHAR_BIT))
 
 /* Special value to handle modMap None {…} */
 #define XKB_MOD_NONE 0xffffffffU

--- a/src/text.c
+++ b/src/text.c
@@ -269,7 +269,8 @@ ModMaskText(struct xkb_context *ctx, const struct xkb_mod_set *mods,
     if (mask == 0)
         return "none";
 
-    if (mask == MOD_REAL_MASK_ALL)
+    if (mask == MOD_REAL_MASK_ALL ||
+        mask == MOD_REAL_MASK_ALL_X11 /* hack for X11 compatibility */)
         return "all";
 
     xkb_mods_enumerate(i, mod, mods) {

--- a/test/data/keymaps/real-modifiers.xkb
+++ b/test/data/keymaps/real-modifiers.xkb
@@ -26,8 +26,8 @@ xkb_keycodes "test" {
 
 xkb_types "complete" {
     // Define a buch of virtual modifier to test mappings to Mod5-Mod10 real
-    // modifiers. WonderMod will be mapped to Mod5+Mod6.
-    virtual_modifiers MyMod5,MyMod6,MyMod6,MyMod7,MyMod8,MyMod9,MyMod10,WonderMod;
+    // modifiers. VMod11 will be mapped to Mod5+Mod6.
+    virtual_modifiers VMod5,VMod6,VMod6,VMod7,VMod8,VMod9,VMod10,VMod11;
 
     type "ONE_LEVEL" {
         modifiers= none;
@@ -40,16 +40,16 @@ xkb_types "complete" {
 		level_name[2]= "Shift";
 	};
     type "SOOO_MANY_LEVELS" {
-        modifiers = Shift+MyMod5+MyMod6+MyMod6+MyMod7+MyMod8+MyMod9+MyMod10+WonderMod;
+        modifiers = Shift+VMod5+VMod6+VMod6+VMod7+VMod8+VMod9+VMod10+VMod11;
         map[Shift] = 2;
-        map[MyMod5] = 3;
-        map[MyMod6] = 4;
-        map[MyMod6+Shift] = 5;
-        map[MyMod7] = 6;
-        map[MyMod8] = 7;
-        map[MyMod9] = 8;
-        map[MyMod10] = 9;
-        map[WonderMod] = 10;
+        map[VMod5] = 3;
+        map[VMod6] = 4;
+        map[VMod6+Shift] = 5;
+        map[VMod7] = 6;
+        map[VMod8] = 7;
+        map[VMod9] = 8;
+        map[VMod10] = 9;
+        map[VMod11] = 10;
         level_name[1] = "1";
         level_name[2] = "2";
         level_name[3] = "3";
@@ -67,7 +67,7 @@ xkb_compatibility "complete" {
     interpret.repeat= False;
     interpret.locking= False;
 
-    virtual_modifiers MyMod5,MyMod6,MyMod7,MyMod8,MyMod9,MyMod10,WonderMod;
+    virtual_modifiers VMod5,VMod6,VMod7,VMod8,VMod9,VMod10,VMod11;
 
     interpret Any+AnyOf(all) {
         action = SetMods(modifiers=modMapMods,clearLocks);
@@ -76,43 +76,43 @@ xkb_compatibility "complete" {
     // Define some letter keysyms as custom modifiers
     interpret Q {
         useModMapMods = level1;
-        virtualModifier = MyMod5;
-        action = SetMods(modifiers=MyMod5);
+        virtualModifier = VMod5;
+        action = SetMods(modifiers=VMod5);
     };
     interpret W {
         useModMapMods = level1;
-        virtualModifier = MyMod6;
-        action = SetMods(modifiers=MyMod6);
+        virtualModifier = VMod6;
+        action = SetMods(modifiers=VMod6);
     };
     interpret E {
         useModMapMods = level1;
-        virtualModifier = MyMod7;
-        action = SetMods(modifiers=MyMod7);
+        virtualModifier = VMod7;
+        action = SetMods(modifiers=VMod7);
     };
     interpret R {
         useModMapMods = level1;
-        virtualModifier = MyMod8;
-        action = SetMods(modifiers=MyMod8);
+        virtualModifier = VMod8;
+        action = SetMods(modifiers=VMod8);
     };
     interpret T {
         useModMapMods = level1;
-        virtualModifier = MyMod9;
-        action = SetMods(modifiers=MyMod9);
+        virtualModifier = VMod9;
+        action = SetMods(modifiers=VMod9);
     };
     interpret Y {
         useModMapMods = level1;
-        virtualModifier = MyMod10;
-        action = SetMods(modifiers=MyMod10);
+        virtualModifier = VMod10;
+        action = SetMods(modifiers=VMod10);
     };
     interpret U {
         useModMapMods = level1;
-        virtualModifier = WonderMod;
-        action = SetMods(modifiers=WonderMod);
+        virtualModifier = VMod11;
+        action = SetMods(modifiers=VMod11);
     };
     interpret I {
         useModMapMods = level1;
-        virtualModifier = WonderMod;
-        action = SetMods(modifiers=WonderMod);
+        virtualModifier = VMod11;
+        action = SetMods(modifiers=VMod11);
     };
 };
 xkb_symbols {
@@ -124,31 +124,31 @@ xkb_symbols {
     key <LFSH> { [Shift_L] };
     modifier_map Shift { <LFSH> };
 
-    // virtual modifier: MyMod5
+    // virtual modifier: VMod5
     key <AD01> { [Q] };
     modifier_map Mod5 { <AD01> };
 
-    // virtual modifier: MyMod6
+    // virtual modifier: VMod6
     key <AD02> { [W] };
     modifier_map Mod6 { <AD02> }; // real modifier not supported by X11
 
-    // virtual modifier: MyMod7
+    // virtual modifier: VMod7
     key <AD03> { [E] };
     modifier_map Mod7 { <AD03> }; // real modifier not supported by X11
 
-    // virtual modifier: MyMod8
+    // virtual modifier: VMod8
     key <AD04> { [R] };
     modifier_map Mod8 { <AD04> }; // real modifier not supported by X11
 
-    // virtual modifier: MyMod9
+    // virtual modifier: VMod9
     key <AD05> { [T] };
     modifier_map Mod9 { <AD05> }; // real modifier not supported by X11
 
-    // virtual modifier: MyMod10
+    // virtual modifier: VMod10
     key <AD06> { [Y] };
     modifier_map Mod10 { <AD06> }; // real modifier not supported by X11
 
-    // virtual modifier: WonderMod (Mod5+Mod6)
+    // virtual modifier: VMod11 (Mod5+Mod6)
     key <AD07> { [U] };
     modifier_map Mod5 { <AD07> };
     key <AD08> { [I] };

--- a/test/data/keymaps/real-modifiers.xkb
+++ b/test/data/keymaps/real-modifiers.xkb
@@ -1,0 +1,151 @@
+xkb_keymap {
+xkb_keycodes "test" {
+    minimum = 8;
+    maximum = 255;
+	<LVL3>  = 92;
+    <LFSH>  = 50;
+	<RTSH>  = 62;
+	<LALT>  = 64;
+	<RALT>  = 108;
+	<LWIN>  = 133;
+	<RWIN>  = 134;
+	<LCTL>  = 37;
+	<RCTL>  = 105;
+	<CAPS>  = 66;
+
+	<AD01> = 24;
+	<AD02> = 25;
+	<AD03> = 26;
+	<AD04> = 27;
+	<AD05> = 28;
+	<AD06> = 29;
+	<AD07> = 30;
+	<AD08> = 31;
+	<AD09> = 32;
+};
+
+xkb_types "complete" {
+    virtual_modifiers MyMod5,MyMod6,MyMod6,MyMod7,MyMod8,MyMod9,MyMod10,WonderMod;
+
+    type "ONE_LEVEL" {
+        modifiers= none;
+        level_name[Level1]= "Any";
+    };
+	type "TWO_LEVEL" {
+		modifiers= Shift;
+		map[Shift]= 2;
+		level_name[1]= "Base";
+		level_name[2]= "Shift";
+	};
+    type "SO_MANY_LEVELS" {
+        modifiers = Shift+MyMod5+MyMod6+MyMod6+MyMod7+MyMod8+MyMod9+MyMod10+WonderMod;
+        map[Shift] = 2;
+        map[MyMod5] = 3;
+        map[MyMod6] = 4;
+        map[MyMod6+Shift] = 5;
+        map[MyMod7] = 6;
+        map[MyMod8] = 7;
+        map[MyMod9] = 8;
+        map[MyMod10] = 9;
+        map[WonderMod] = 10;
+        level_name[1] = "1";
+        level_name[2] = "2";
+        level_name[3] = "3";
+        level_name[4] = "4";
+        level_name[5] = "5";
+        level_name[6] = "6";
+        level_name[7] = "7";
+        level_name[8] = "8";
+        level_name[9] = "9";
+        level_name[10] = "10";
+    };
+};
+xkb_compatibility "complete" {
+    interpret.useModMapMods= AnyLevel;
+    interpret.repeat= False;
+    interpret.locking= False;
+
+    virtual_modifiers MyMod5,MyMod6,MyMod7,MyMod8,MyMod9,MyMod10,WonderMod;
+
+    interpret Any+AnyOf(all) {
+        action = SetMods(modifiers=modMapMods,clearLocks);
+    };
+
+    interpret q {
+        useModMapMods = level1;
+        virtualModifier = MyMod5;
+        action = SetMods(modifiers=MyMod5);
+    };
+    interpret w {
+        useModMapMods = level1;
+        virtualModifier = MyMod6;
+        action = SetMods(modifiers=MyMod6);
+    };
+    interpret e {
+        useModMapMods = level1;
+        virtualModifier = MyMod7;
+        action = SetMods(modifiers=MyMod7);
+    };
+    interpret r {
+        useModMapMods = level1;
+        virtualModifier = MyMod8;
+        action = SetMods(modifiers=MyMod8);
+    };
+    interpret t {
+        useModMapMods = level1;
+        virtualModifier = MyMod9;
+        action = SetMods(modifiers=MyMod9);
+    };
+    interpret y {
+        useModMapMods = level1;
+        virtualModifier = MyMod10;
+        action = SetMods(modifiers=MyMod10);
+    };
+    interpret u {
+        useModMapMods = level1;
+        virtualModifier = WonderMod;
+        action = SetMods(modifiers=WonderMod);
+    };
+    interpret i {
+        useModMapMods = level1;
+        virtualModifier = WonderMod;
+        action = SetMods(modifiers=WonderMod);
+    };
+};
+xkb_symbols {
+    name[group1]="Test";
+
+    key <LFSH> { [Shift_L] };
+    modmap Shift { <LFSH> };
+
+    key <AD01> { [q] };
+    modMap Mod5 { <AD01> };
+
+    key <AD02> { [w] };
+    modMap Mod6 { <AD02> };
+
+    key <AD03> { [e] };
+    modMap Mod7 { <AD03> };
+
+    key <AD04> { [r] };
+    modMap Mod8 { <AD04> };
+
+    key <AD05> { [t] };
+    modMap Mod9 { <AD05> };
+
+    key <AD06> { [y] };
+    modMap Mod10 { <AD06> };
+
+    key <AD07> { [u] };
+    modMap Mod5 { <AD07> };
+
+    key <AD08> { [i] };
+    modMap Mod6 { <AD08> };
+
+    key <AD09> {
+        type[Group1]="SO_MANY_LEVELS",
+        symbols[Group1]=[a,b,c,d,e,f,g,h,i,j]
+    };
+
+};
+};

--- a/test/data/keymaps/real-modifiers.xkb
+++ b/test/data/keymaps/real-modifiers.xkb
@@ -25,6 +25,8 @@ xkb_keycodes "test" {
 };
 
 xkb_types "complete" {
+    // Define a buch of virtual modifier to test mappings to Mod5-Mod10 real
+    // modifiers. WonderMod will be mapped to Mod5+Mod6.
     virtual_modifiers MyMod5,MyMod6,MyMod6,MyMod7,MyMod8,MyMod9,MyMod10,WonderMod;
 
     type "ONE_LEVEL" {
@@ -37,7 +39,7 @@ xkb_types "complete" {
 		level_name[1]= "Base";
 		level_name[2]= "Shift";
 	};
-    type "SO_MANY_LEVELS" {
+    type "SOOO_MANY_LEVELS" {
         modifiers = Shift+MyMod5+MyMod6+MyMod6+MyMod7+MyMod8+MyMod9+MyMod10+WonderMod;
         map[Shift] = 2;
         map[MyMod5] = 3;
@@ -71,42 +73,43 @@ xkb_compatibility "complete" {
         action = SetMods(modifiers=modMapMods,clearLocks);
     };
 
-    interpret q {
+    // Define some letter keysyms as custom modifiers
+    interpret Q {
         useModMapMods = level1;
         virtualModifier = MyMod5;
         action = SetMods(modifiers=MyMod5);
     };
-    interpret w {
+    interpret W {
         useModMapMods = level1;
         virtualModifier = MyMod6;
         action = SetMods(modifiers=MyMod6);
     };
-    interpret e {
+    interpret E {
         useModMapMods = level1;
         virtualModifier = MyMod7;
         action = SetMods(modifiers=MyMod7);
     };
-    interpret r {
+    interpret R {
         useModMapMods = level1;
         virtualModifier = MyMod8;
         action = SetMods(modifiers=MyMod8);
     };
-    interpret t {
+    interpret T {
         useModMapMods = level1;
         virtualModifier = MyMod9;
         action = SetMods(modifiers=MyMod9);
     };
-    interpret y {
+    interpret Y {
         useModMapMods = level1;
         virtualModifier = MyMod10;
         action = SetMods(modifiers=MyMod10);
     };
-    interpret u {
+    interpret U {
         useModMapMods = level1;
         virtualModifier = WonderMod;
         action = SetMods(modifiers=WonderMod);
     };
-    interpret i {
+    interpret I {
         useModMapMods = level1;
         virtualModifier = WonderMod;
         action = SetMods(modifiers=WonderMod);
@@ -115,36 +118,46 @@ xkb_compatibility "complete" {
 xkb_symbols {
     name[group1]="Test";
 
+    // Map the modifiers. The letter keysyms only serve to map
+    // the modifier actions (see interpret entries above).
+
     key <LFSH> { [Shift_L] };
-    modmap Shift { <LFSH> };
+    modifier_map Shift { <LFSH> };
 
-    key <AD01> { [q] };
-    modMap Mod5 { <AD01> };
+    // virtual modifier: MyMod5
+    key <AD01> { [Q] };
+    modifier_map Mod5 { <AD01> };
 
-    key <AD02> { [w] };
-    modMap Mod6 { <AD02> };
+    // virtual modifier: MyMod6
+    key <AD02> { [W] };
+    modifier_map Mod6 { <AD02> }; // real modifier not supported by X11
 
-    key <AD03> { [e] };
-    modMap Mod7 { <AD03> };
+    // virtual modifier: MyMod7
+    key <AD03> { [E] };
+    modifier_map Mod7 { <AD03> }; // real modifier not supported by X11
 
-    key <AD04> { [r] };
-    modMap Mod8 { <AD04> };
+    // virtual modifier: MyMod8
+    key <AD04> { [R] };
+    modifier_map Mod8 { <AD04> }; // real modifier not supported by X11
 
-    key <AD05> { [t] };
-    modMap Mod9 { <AD05> };
+    // virtual modifier: MyMod9
+    key <AD05> { [T] };
+    modifier_map Mod9 { <AD05> }; // real modifier not supported by X11
 
-    key <AD06> { [y] };
-    modMap Mod10 { <AD06> };
+    // virtual modifier: MyMod10
+    key <AD06> { [Y] };
+    modifier_map Mod10 { <AD06> }; // real modifier not supported by X11
 
-    key <AD07> { [u] };
-    modMap Mod5 { <AD07> };
+    // virtual modifier: WonderMod (Mod5+Mod6)
+    key <AD07> { [U] };
+    modifier_map Mod5 { <AD07> };
+    key <AD08> { [I] };
+    modifier_map Mod6 { <AD08> }; // real modifier not supported by X11
 
-    key <AD08> { [i] };
-    modMap Mod6 { <AD08> };
-
+    // Key to test that all the levels work
     key <AD09> {
-        type[Group1]="SO_MANY_LEVELS",
-        symbols[Group1]=[a,b,c,d,e,f,g,h,i,j]
+        type[Group1]="SOOO_MANY_LEVELS",
+        symbols[Group1]=[1,2,3,4,5,6,7,8,9,A]
     };
 
 };

--- a/test/modifiers.c
+++ b/test/modifiers.c
@@ -45,6 +45,7 @@
 #define Mod8Mask    (1 << 10)
 #define Mod9Mask    (1 << 11)
 #define Mod10Mask   (1 << 12)
+#define HighestRealMask Mod10Mask
 #define NoModifier  0
 
 static void
@@ -172,42 +173,74 @@ test_real_mods(void)
     assert(keycode != XKB_KEYCODE_INVALID);
     key = XkbKey(keymap, keycode);
     assert(key->modmap == Mod5Mask);
-    assert(key->vmodmap == Mod10Mask << 1);
+    /* Test that MyMod5 is the first defined virtual modifier */
+    assert(key->vmodmap == HighestRealMask << 1);
 
     keycode = xkb_keymap_key_by_name(keymap, "AD02");
     assert(keycode != XKB_KEYCODE_INVALID);
     key = XkbKey(keymap, keycode);
     assert(key->modmap == Mod6Mask);
-    assert(key->vmodmap == Mod10Mask << 2);
+    /* Test that MyMod5 is the second defined virtual modifier */
+    assert(key->vmodmap == HighestRealMask << 2);
 
+    /* Test that we get the expected keysym for each level of KEY_O (<AD09>).
+     * Most levels require support of the real modifiers Mod6-Mod10. */
     assert(test_key_seq(keymap,
-                        KEY_O, BOTH, XKB_KEY_a, NEXT,
-                        KEY_Q, DOWN, XKB_KEY_q, NEXT,
-                        KEY_O, BOTH, XKB_KEY_c, NEXT,
-                        KEY_Q, UP,   XKB_KEY_q, NEXT,
-                        KEY_W, DOWN, XKB_KEY_w, NEXT,
-                        KEY_O, BOTH, XKB_KEY_d, NEXT,
-                        KEY_W, UP,   XKB_KEY_w, NEXT,
-                        KEY_E, DOWN, XKB_KEY_e, NEXT,
-                        KEY_O, BOTH, XKB_KEY_f, NEXT,
-                        KEY_E, UP,   XKB_KEY_e, NEXT,
-                        KEY_R, DOWN, XKB_KEY_r, NEXT,
-                        KEY_O, BOTH, XKB_KEY_g, NEXT,
-                        KEY_R, UP,   XKB_KEY_r, NEXT,
-                        KEY_T, DOWN, XKB_KEY_t, NEXT,
-                        KEY_O, BOTH, XKB_KEY_h, NEXT,
-                        KEY_T, UP,   XKB_KEY_t, NEXT,
-                        KEY_Y, DOWN, XKB_KEY_y, NEXT,
-                        KEY_O, BOTH, XKB_KEY_i, NEXT,
-                        KEY_Y, UP,   XKB_KEY_y, NEXT,
-                        KEY_U, DOWN, XKB_KEY_u, NEXT,
-                        KEY_O, BOTH, XKB_KEY_j, NEXT,
-                        KEY_U, UP,   XKB_KEY_u, NEXT,
-                        KEY_Q, DOWN, XKB_KEY_q, NEXT,
-                        KEY_W, DOWN, XKB_KEY_w, NEXT,
-                        KEY_O, BOTH, XKB_KEY_j, NEXT,
-                        KEY_W, UP,   XKB_KEY_w, NEXT,
-                        KEY_Q, UP,   XKB_KEY_q, FINISH));
+                        /* Level 1 */
+                        KEY_O, BOTH, XKB_KEY_1, NEXT,
+                        /* Level 2 */
+                        KEY_LEFTSHIFT, DOWN, XKB_KEY_Shift_L, NEXT,
+                        KEY_O, BOTH, XKB_KEY_2, NEXT,
+                        KEY_LEFTSHIFT, UP, XKB_KEY_Shift_L, NEXT,
+                        /* Level 3 (MyMod5 = Mod5) */
+                        KEY_Q, DOWN, XKB_KEY_Q, NEXT,
+                        KEY_O, BOTH, XKB_KEY_3, NEXT,
+                        KEY_Q, UP,   XKB_KEY_Q, NEXT,
+                        /* Level 4 (MyMod6 = Mod6) */
+                        KEY_W, DOWN, XKB_KEY_W, NEXT,
+                        KEY_O, BOTH, XKB_KEY_4, NEXT,
+                        /* Level 5 (MyMod6 + Shift = Mod6 + Shift) */
+                        KEY_LEFTSHIFT, DOWN, XKB_KEY_Shift_L, NEXT,
+                        KEY_O, BOTH, XKB_KEY_5, NEXT,
+                        KEY_LEFTSHIFT, UP, XKB_KEY_Shift_L, NEXT,
+                        KEY_W, UP,   XKB_KEY_W, NEXT,
+                        /* Level 6 (MyMod7 = Mod7) */
+                        KEY_E, DOWN, XKB_KEY_E, NEXT,
+                        KEY_O, BOTH, XKB_KEY_6, NEXT,
+                        KEY_E, UP,   XKB_KEY_E, NEXT,
+                        /* Level 7 (MyMod8 = Mod8) */
+                        KEY_R, DOWN, XKB_KEY_R, NEXT,
+                        KEY_O, BOTH, XKB_KEY_7, NEXT,
+                        KEY_R, UP,   XKB_KEY_R, NEXT,
+                        /* Level 8 (MyMod9 = Mod9) */
+                        KEY_T, DOWN, XKB_KEY_T, NEXT,
+                        KEY_O, BOTH, XKB_KEY_8, NEXT,
+                        KEY_T, UP,   XKB_KEY_T, NEXT,
+                        /* Level 9 (MyMod10 = Mod10) */
+                        KEY_Y, DOWN, XKB_KEY_Y, NEXT,
+                        KEY_O, BOTH, XKB_KEY_9, NEXT,
+                        KEY_Y, UP,   XKB_KEY_Y, NEXT,
+                        /* Level 10 using KEY_U (WonderMod = Mod5 + Mod6) */
+                        KEY_U, DOWN, XKB_KEY_U, NEXT,
+                        KEY_O, BOTH, XKB_KEY_A, NEXT,
+                        KEY_U, UP,   XKB_KEY_U, NEXT,
+                        /* Level 10 using KEY_I (WonderMod = Mod5 + Mod6) */
+                        KEY_I, DOWN, XKB_KEY_I, NEXT,
+                        KEY_O, BOTH, XKB_KEY_A, NEXT,
+                        KEY_I, UP,   XKB_KEY_I, NEXT,
+                        /* Level 10 using KEY_Q + KEY_W
+                         * MyMod5 + MyMod6 = Mod5 + Mod6 = WonderMod */
+                        KEY_Q, DOWN, XKB_KEY_Q, NEXT,
+                        KEY_W, DOWN, XKB_KEY_W, NEXT,
+                        KEY_O, BOTH, XKB_KEY_A, NEXT,
+                        KEY_W, UP,   XKB_KEY_W, NEXT,
+                        KEY_Q, UP,   XKB_KEY_Q, NEXT,
+                        /* Invalid level, fallback to base level */
+                        KEY_W, DOWN, XKB_KEY_W, NEXT,
+                        KEY_E, DOWN, XKB_KEY_E, NEXT,
+                        KEY_O, BOTH, XKB_KEY_1, NEXT,
+                        KEY_E, UP,   XKB_KEY_E, NEXT,
+                        KEY_W, UP,   XKB_KEY_W, FINISH));
 
     xkb_keymap_unref(keymap);
     xkb_context_unref(context);

--- a/test/modifiers.c
+++ b/test/modifiers.c
@@ -173,14 +173,14 @@ test_real_mods(void)
     assert(keycode != XKB_KEYCODE_INVALID);
     key = XkbKey(keymap, keycode);
     assert(key->modmap == Mod5Mask);
-    /* Test that MyMod5 is the first defined virtual modifier */
+    /* Test that VMod5 is the first defined virtual modifier */
     assert(key->vmodmap == HighestRealMask << 1);
 
     keycode = xkb_keymap_key_by_name(keymap, "AD02");
     assert(keycode != XKB_KEYCODE_INVALID);
     key = XkbKey(keymap, keycode);
     assert(key->modmap == Mod6Mask);
-    /* Test that MyMod5 is the second defined virtual modifier */
+    /* Test that VMod5 is the second defined virtual modifier */
     assert(key->vmodmap == HighestRealMask << 2);
 
     /* Test that we get the expected keysym for each level of KEY_O (<AD09>).
@@ -192,44 +192,44 @@ test_real_mods(void)
                         KEY_LEFTSHIFT, DOWN, XKB_KEY_Shift_L, NEXT,
                         KEY_O, BOTH, XKB_KEY_2, NEXT,
                         KEY_LEFTSHIFT, UP, XKB_KEY_Shift_L, NEXT,
-                        /* Level 3 (MyMod5 = Mod5) */
+                        /* Level 3 (VMod5 = Mod5) */
                         KEY_Q, DOWN, XKB_KEY_Q, NEXT,
                         KEY_O, BOTH, XKB_KEY_3, NEXT,
                         KEY_Q, UP,   XKB_KEY_Q, NEXT,
-                        /* Level 4 (MyMod6 = Mod6) */
+                        /* Level 4 (VMod6 = Mod6) */
                         KEY_W, DOWN, XKB_KEY_W, NEXT,
                         KEY_O, BOTH, XKB_KEY_4, NEXT,
-                        /* Level 5 (MyMod6 + Shift = Mod6 + Shift) */
+                        /* Level 5 (VMod6 + Shift = Mod6 + Shift) */
                         KEY_LEFTSHIFT, DOWN, XKB_KEY_Shift_L, NEXT,
                         KEY_O, BOTH, XKB_KEY_5, NEXT,
                         KEY_LEFTSHIFT, UP, XKB_KEY_Shift_L, NEXT,
                         KEY_W, UP,   XKB_KEY_W, NEXT,
-                        /* Level 6 (MyMod7 = Mod7) */
+                        /* Level 6 (VMod7 = Mod7) */
                         KEY_E, DOWN, XKB_KEY_E, NEXT,
                         KEY_O, BOTH, XKB_KEY_6, NEXT,
                         KEY_E, UP,   XKB_KEY_E, NEXT,
-                        /* Level 7 (MyMod8 = Mod8) */
+                        /* Level 7 (VMod8 = Mod8) */
                         KEY_R, DOWN, XKB_KEY_R, NEXT,
                         KEY_O, BOTH, XKB_KEY_7, NEXT,
                         KEY_R, UP,   XKB_KEY_R, NEXT,
-                        /* Level 8 (MyMod9 = Mod9) */
+                        /* Level 8 (VMod9 = Mod9) */
                         KEY_T, DOWN, XKB_KEY_T, NEXT,
                         KEY_O, BOTH, XKB_KEY_8, NEXT,
                         KEY_T, UP,   XKB_KEY_T, NEXT,
-                        /* Level 9 (MyMod10 = Mod10) */
+                        /* Level 9 (VMod10 = Mod10) */
                         KEY_Y, DOWN, XKB_KEY_Y, NEXT,
                         KEY_O, BOTH, XKB_KEY_9, NEXT,
                         KEY_Y, UP,   XKB_KEY_Y, NEXT,
-                        /* Level 10 using KEY_U (WonderMod = Mod5 + Mod6) */
+                        /* Level 10 using KEY_U (VMod11 = Mod5 + Mod6) */
                         KEY_U, DOWN, XKB_KEY_U, NEXT,
                         KEY_O, BOTH, XKB_KEY_A, NEXT,
                         KEY_U, UP,   XKB_KEY_U, NEXT,
-                        /* Level 10 using KEY_I (WonderMod = Mod5 + Mod6) */
+                        /* Level 10 using KEY_I (VMod11 = Mod5 + Mod6) */
                         KEY_I, DOWN, XKB_KEY_I, NEXT,
                         KEY_O, BOTH, XKB_KEY_A, NEXT,
                         KEY_I, UP,   XKB_KEY_I, NEXT,
                         /* Level 10 using KEY_Q + KEY_W
-                         * MyMod5 + MyMod6 = Mod5 + Mod6 = WonderMod */
+                         * VMod5 + VMod6 = Mod5 + Mod6 = VMod11 */
                         KEY_Q, DOWN, XKB_KEY_Q, NEXT,
                         KEY_W, DOWN, XKB_KEY_W, NEXT,
                         KEY_O, BOTH, XKB_KEY_A, NEXT,

--- a/test/modifiers.c
+++ b/test/modifiers.c
@@ -29,6 +29,7 @@
 
 #include "test.h"
 #include "keymap.h"
+#include "evdev-scancodes.h"
 
 // Standard real modifier masks
 #define ShiftMask   (1 << 0)
@@ -39,6 +40,11 @@
 #define Mod3Mask    (1 << 5)
 #define Mod4Mask    (1 << 6)
 #define Mod5Mask    (1 << 7)
+#define Mod6Mask    (1 << 8)
+#define Mod7Mask    (1 << 9)
+#define Mod8Mask    (1 << 10)
+#define Mod9Mask    (1 << 11)
+#define Mod10Mask   (1 << 12)
 #define NoModifier  0
 
 static void
@@ -151,10 +157,67 @@ test_modmap_none(void)
     xkb_context_unref(context);
 }
 
+static void
+test_real_mods(void)
+{
+    struct xkb_context *context = test_get_context(0);
+    struct xkb_keymap *keymap;
+    const struct xkb_key *key;
+    xkb_keycode_t keycode;
+
+    keymap = test_compile_file(context, "keymaps/real-modifiers.xkb");
+    assert(keymap);
+
+    keycode = xkb_keymap_key_by_name(keymap, "AD01");
+    assert(keycode != XKB_KEYCODE_INVALID);
+    key = XkbKey(keymap, keycode);
+    assert(key->modmap == Mod5Mask);
+    assert(key->vmodmap == Mod10Mask << 1);
+
+    keycode = xkb_keymap_key_by_name(keymap, "AD02");
+    assert(keycode != XKB_KEYCODE_INVALID);
+    key = XkbKey(keymap, keycode);
+    assert(key->modmap == Mod6Mask);
+    assert(key->vmodmap == Mod10Mask << 2);
+
+    assert(test_key_seq(keymap,
+                        KEY_O, BOTH, XKB_KEY_a, NEXT,
+                        KEY_Q, DOWN, XKB_KEY_q, NEXT,
+                        KEY_O, BOTH, XKB_KEY_c, NEXT,
+                        KEY_Q, UP,   XKB_KEY_q, NEXT,
+                        KEY_W, DOWN, XKB_KEY_w, NEXT,
+                        KEY_O, BOTH, XKB_KEY_d, NEXT,
+                        KEY_W, UP,   XKB_KEY_w, NEXT,
+                        KEY_E, DOWN, XKB_KEY_e, NEXT,
+                        KEY_O, BOTH, XKB_KEY_f, NEXT,
+                        KEY_E, UP,   XKB_KEY_e, NEXT,
+                        KEY_R, DOWN, XKB_KEY_r, NEXT,
+                        KEY_O, BOTH, XKB_KEY_g, NEXT,
+                        KEY_R, UP,   XKB_KEY_r, NEXT,
+                        KEY_T, DOWN, XKB_KEY_t, NEXT,
+                        KEY_O, BOTH, XKB_KEY_h, NEXT,
+                        KEY_T, UP,   XKB_KEY_t, NEXT,
+                        KEY_Y, DOWN, XKB_KEY_y, NEXT,
+                        KEY_O, BOTH, XKB_KEY_i, NEXT,
+                        KEY_Y, UP,   XKB_KEY_y, NEXT,
+                        KEY_U, DOWN, XKB_KEY_u, NEXT,
+                        KEY_O, BOTH, XKB_KEY_j, NEXT,
+                        KEY_U, UP,   XKB_KEY_u, NEXT,
+                        KEY_Q, DOWN, XKB_KEY_q, NEXT,
+                        KEY_W, DOWN, XKB_KEY_w, NEXT,
+                        KEY_O, BOTH, XKB_KEY_j, NEXT,
+                        KEY_W, UP,   XKB_KEY_w, NEXT,
+                        KEY_Q, UP,   XKB_KEY_q, FINISH));
+
+    xkb_keymap_unref(keymap);
+    xkb_context_unref(context);
+}
+
 int
 main(void)
 {
     test_modmap_none();
+    test_real_mods();
 
     return 0;
 }


### PR DESCRIPTION
In X11 we are limited to 8 _real_ modifiers and it seems just fine in general. But they are some use cases where it would be useful to have some more:

- Have true separate `Meta` and `Hyper` modifiers;
- Have an `Fn` layer;
- Possibly an accessibility modifier;
- Use latch modifiers rather than dead keys, because then the layout is completely defined in XKB;
- Differentiate right/left modifiers.

It is already possible to do this, but at the cost of other modifiers.

This PR adds 5 new modifiers (`Mod6`..`Mod10`) for a total of **13** (count subject to change). Why not add more? Good question! We encode the mask on 32 bits, but _real_ and _virtual_ modifiers share the same mask. So we cannot have 32 real modifiers because we need to keep some bits (at least 16) to encode the virtual modifiers as well.

This PR is a PoC to open the discussion. 

*Warning:* The current implementation provides no backward-compatibility (X11, older xkbcommon).

@whot @bluetech 