### PR TITLE
Some improvements to test debugging

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -434,6 +434,7 @@ if build_tools
         link_with: libxkbcommon_tools_internal,
         dependencies: dep_libxkbcommon,
     )
+    configh_data.set10('HAVE_TOOLS', true)
 
     # Tool: xkbcli
     executable('xkbcli', 'tools/xkbcli.c',
@@ -586,6 +587,8 @@ You can disable the Wayland xkbcli programs with -Denable-wayland=false.''')
                dependencies: [tools_dep],
                include_directories: [include_directories('src', 'include', 'tools')],
                install: false)
+else
+    tools_dep = declare_dependency()
 endif
 
 
@@ -628,6 +631,7 @@ libxkbcommon_test_internal = static_library(
 test_dep = declare_dependency(
     include_directories: include_directories('src', 'include'),
     link_with: libxkbcommon_test_internal,
+    dependencies: [tools_dep],
 )
 if get_option('enable-x11')
     libxkbcommon_x11_test_internal = static_library(

--- a/test/common.c
+++ b/test/common.c
@@ -78,6 +78,7 @@ test_key_seq_va(struct xkb_keymap *keymap, va_list ap)
     xkb_keysym_t sym;
     unsigned int nsyms, i;
     char ksbuf[XKB_KEYSYM_NAME_MAX_SIZE];
+    const char *opstr = NULL;
 
     fprintf(stderr, "----\n");
 
@@ -88,13 +89,22 @@ test_key_seq_va(struct xkb_keymap *keymap, va_list ap)
         kc = va_arg(ap, int) + EVDEV_OFFSET;
         op = va_arg(ap, int);
 
+        switch (op) {
+            case DOWN: opstr = "DOWN"; break;
+            case REPEAT: opstr = "REPEAT"; break;
+            case UP: opstr = "UP"; break;
+            case BOTH: opstr = "BOTH"; break;
+            case NEXT: opstr = "NEXT"; break;
+            case FINISH: opstr = "FINISH"; break;
+        }
+
         nsyms = xkb_state_key_get_syms(state, kc, &syms);
         if (nsyms == 1) {
             sym = xkb_state_key_get_one_sym(state, kc);
             syms = &sym;
         }
 
-        fprintf(stderr, "got %u syms for keycode %u: [", nsyms, kc);
+        fprintf(stderr, "op %-6s got %u syms for keycode %3u: [", opstr, nsyms, kc);
 
         if (op == DOWN || op == BOTH)
             xkb_state_update_key(state, kc, XKB_KEY_DOWN);
@@ -108,15 +118,15 @@ test_key_seq_va(struct xkb_keymap *keymap, va_list ap)
 
             if (keysym == FINISH || keysym == NEXT) {
                 xkb_keysym_get_name(syms[i], ksbuf, sizeof(ksbuf));
-                fprintf(stderr, "Did not expect keysym: %s.\n", ksbuf);
+                fprintf(stderr, " Did not expect keysym: %s.\n", ksbuf);
                 goto fail;
             }
 
             if (keysym != syms[i]) {
                 xkb_keysym_get_name(keysym, ksbuf, sizeof(ksbuf));
-                fprintf(stderr, "Expected keysym: %s. ", ksbuf);;
+                fprintf(stderr, " Expected keysym: %s. ", ksbuf);;
                 xkb_keysym_get_name(syms[i], ksbuf, sizeof(ksbuf));
-                fprintf(stderr, "Got keysym: %s.\n", ksbuf);;
+                fprintf(stderr, " Got keysym: %s.\n", ksbuf);;
                 goto fail;
             }
         }
@@ -125,7 +135,7 @@ test_key_seq_va(struct xkb_keymap *keymap, va_list ap)
             keysym = va_arg(ap, int);
             if (keysym != XKB_KEY_NoSymbol) {
                 xkb_keysym_get_name(keysym, ksbuf, sizeof(ksbuf));
-                fprintf(stderr, "Expected %s, but got no keysyms.\n", ksbuf);
+                fprintf(stderr, " Expected %s, but got no keysyms.\n", ksbuf);
                 goto fail;
             }
         }

--- a/test/common.c
+++ b/test/common.c
@@ -298,6 +298,8 @@ test_get_context(enum test_context_flags test_flags)
     struct xkb_context *ctx;
     char *path;
 
+    setbuf(stdout, NULL);
+
     ctx_flags = XKB_CONTEXT_NO_DEFAULT_INCLUDES;
     if (test_flags & CONTEXT_ALLOW_ENVIRONMENT_NAMES) {
         unsetenv("XKB_DEFAULT_RULES");

--- a/test/common.c
+++ b/test/common.c
@@ -49,6 +49,8 @@
 #include "utils.h"
 #include "src/keysym.h"
 
+#include "tools/tools-common.h"
+
 /*
  * Test a sequence of keysyms, resulting from a sequence of key presses,
  * against the keysyms they're supposed to generate.
@@ -104,12 +106,15 @@ test_key_seq_va(struct xkb_keymap *keymap, va_list ap)
             syms = &sym;
         }
 
-        fprintf(stderr, "op %-6s got %u syms for keycode %3u: [", opstr, nsyms, kc);
-
         if (op == DOWN || op == BOTH)
             xkb_state_update_key(state, kc, XKB_KEY_DOWN);
         if (op == UP || op == BOTH)
             xkb_state_update_key(state, kc, XKB_KEY_UP);
+
+#if HAVE_TOOLS
+        tools_print_keycode_state("", state, NULL, kc, XKB_CONSUMED_MODE_XKB, PRINT_ALL_FIELDS);
+#endif
+        fprintf(stderr, "op %-6s got %u syms for keycode %3u: [", opstr, nsyms, kc);
 
         for (i = 0; i < nsyms; i++) {
             keysym = va_arg(ap, int);

--- a/test/keyseq.c
+++ b/test/keyseq.c
@@ -299,7 +299,7 @@ main(void)
                         KEY_RIGHTALT,    DOWN,  XKB_KEY_ISO_Level5_Shift,  NEXT,
                         /* XXX: xkeyboard-config is borked when de(neo) is
                          *      not the first group - not our fault. We test
-                         *      Level5 seprately below with only de(neo). */
+                         *      Level5 separately below with only de(neo). */
                         /* KEY_5,           BOTH,  XKB_KEY_periodcentered,    NEXT, */
                         /* KEY_E,           BOTH,  XKB_KEY_Up,                NEXT, */
                         /* KEY_SPACE,       BOTH,  XKB_KEY_KP_0,              NEXT, */

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -146,7 +146,7 @@ print_keys_modmaps(struct xkb_keymap *keymap) {
 #endif
 
 void
-tools_print_keycode_state(char *prefix,
+tools_print_keycode_state(const char *prefix,
                           struct xkb_state *state,
                           struct xkb_compose_state *compose_state,
                           xkb_keycode_t keycode,

--- a/tools/tools-common.h
+++ b/tools/tools-common.h
@@ -61,7 +61,7 @@ print_keys_modmaps(struct xkb_keymap *keymap);
 #endif
 
 void
-tools_print_keycode_state(char *prefix,
+tools_print_keycode_state(const char *prefix,
                           struct xkb_state *state,
                           struct xkb_compose_state *compose_state,
                           xkb_keycode_t keycode,


### PR DESCRIPTION
`test_key_seq` takes a list of key operations and if one fails it can be a bit tricky to figure out why (e.g. in my case I knew it was RALT but didn't realise it was the up, not the down that triggered the error).

Let's help with this by printing the operation and the keymap state just like e.g. `interactive-evdev` does.