### PR TITLE
Experiment: state: support pure virtual modifiers

### DIFF
--- a/src/state.c
+++ b/src/state.c
@@ -1141,9 +1141,15 @@ mod_mask_get_effective(struct xkb_keymap *keymap, xkb_mod_mask_t mods)
     const struct xkb_mod *mod;
     xkb_mod_index_t i;
     xkb_mod_mask_t mask;
+    xkb_mod_mask_t pure_mask = 0;
 
-    /* The effective mask is only real mods for now. */
-    mask = mods & MOD_REAL_MASK_ALL;
+    /* Find pure virtual modifiers, i.e. those not mapped to a real modifier
+     * and include those in the effective mask */
+    xkb_mods_enumerate(i, mod, &keymap->mods)
+        if (mod->type == MOD_VIRT && mod->mapping == 0x0)
+            pure_mask |= (1u << i);
+
+    mask = mods & (MOD_REAL_MASK_ALL | pure_mask);
 
     xkb_mods_enumerate(i, mod, &keymap->mods)
         if (mods & (1u << i))

--- a/test/keyseq.c
+++ b/test/keyseq.c
@@ -305,7 +305,8 @@ main(void)
                         /* KEY_SPACE,       BOTH,  XKB_KEY_KP_0,              NEXT, */
                         /* KEY_KP8,         BOTH,  XKB_KEY_KP_Up,             NEXT, */
                         KEY_ESC,         BOTH,  XKB_KEY_Escape,            NEXT,
-                        KEY_RIGHTALT,    UP,    XKB_KEY_ISO_Level5_Shift,  NEXT,
+                        KEY_1,           BOTH,  XKB_KEY_ordfeminine,       NEXT,
+                        KEY_RIGHTALT,    UP,    XKB_KEY_ISO_Level5_Lock,   NEXT,
 
                         KEY_V,           BOTH,  XKB_KEY_p,               FINISH));
 


### PR DESCRIPTION
Traditionally, virtual modifiers were merely name aliases for real modifiers, e.g. NumLock was usually mapped to Mod2 (see modifier_map statement). Virtual modifiers that were never mapped to a real one had no effect on the keymap state.

This patch introduces the concept of pure virtual modifiers, i.e. virtual modifiers that are not mapped now show up as if the were true modifiers.

Note that pure virtual modifiers cannot be used in an interpret action's AnyOf() and an interpret action for a pure virtual modifier must be AnyOfOrNone() to take effect:

    virtual_modifiers APureMod,...;

    interpret a+AnyOfOrNone(all) {
      virtualModifier= APureMod;
      action= SetMods(modifiers=APureMod);
    };

The above adds a pure virtual modifier for keysym `a`.

Interestingly, this fixes one current issue with our tests: previously the de(neo) layout level5 didn't take effect correctly, with this patch in place it now behaves.

---
This took forever to wrap my head around it almost feels too simple now... The one test case failure was in the `de(neo)` layout but after staring at this - it actually fixes that particular issue.

Related to #447

cc @wismill 