### PR TITLE
xkbcomp: Require newline after !include line in rules files

### DIFF
--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -978,6 +978,14 @@ include_statement:
     switch (tok = gettok(m, s)) {
     case TOK_IDENTIFIER:
         matcher_include(m, s, include_depth, m->val.string);
+        goto include_statement_end;
+    default:
+        goto unexpected;
+    }
+
+include_statement_end:
+    switch (tok = gettok(m, s)) {
+    case TOK_END_OF_LINE:
         goto initial;
     default:
         goto unexpected;

--- a/test/data/rules/inc-no-newline
+++ b/test/data/rules/inc-no-newline
@@ -1,0 +1,1 @@
+! include %S/inc-dst-simple !include %S/inc-dst-simple ! layout = symbols

--- a/test/rules-file-includes.c
+++ b/test/rules-file-includes.c
@@ -159,6 +159,12 @@ main(int argc, char *argv[])
     };
     assert(test_rules(ctx, &test6));
 
+    struct test_data test7 = {
+      .rules = "inc-no-newline",
+      .should_fail = true,
+    };
+    assert(test_rules(ctx, &test7));
+
     xkb_context_unref(ctx);
     return 0;
 }


### PR DESCRIPTION
Rules file parser allows constructs like
```
!include "foo" !include "bar" !layout = symbols
```
This is most likely an oversight in original code.

Closes #452