### PR TITLE
Add test_unit to all tests

### DIFF
--- a/test/atom.c
+++ b/test/atom.c
@@ -156,6 +156,8 @@ main(void)
     struct atom_table *table;
     xkb_atom_t atom1, atom2, atom3;
 
+    test_init();
+
     table = atom_table_new();
     assert(table);
 

--- a/test/buffercomp.c
+++ b/test/buffercomp.c
@@ -169,6 +169,8 @@ test_recursive(void)
 int
 main(int argc, char *argv[])
 {
+    test_init();
+
     struct xkb_context *ctx = test_get_context(0);
     struct xkb_keymap *keymap;
     char *original, *dump;

--- a/test/common.c
+++ b/test/common.c
@@ -51,6 +51,15 @@
 
 #include "tools/tools-common.h"
 
+
+/* Setup test */
+void
+test_init(void)
+{
+    /* Make stdout always unbuffered, to ensure we always get it entirely */
+    setbuf(stdout, NULL);
+}
+
 /*
  * Test a sequence of keysyms, resulting from a sequence of key presses,
  * against the keysyms they're supposed to generate.
@@ -297,8 +306,6 @@ test_get_context(enum test_context_flags test_flags)
     enum xkb_context_flags ctx_flags;
     struct xkb_context *ctx;
     char *path;
-
-    setbuf(stdout, NULL);
 
     ctx_flags = XKB_CONTEXT_NO_DEFAULT_INCLUDES;
     if (test_flags & CONTEXT_ALLOW_ENVIRONMENT_NAMES) {

--- a/test/compose.c
+++ b/test/compose.c
@@ -942,6 +942,8 @@ main(int argc, char *argv[])
 {
     struct xkb_context *ctx;
 
+    test_init();
+
     ctx = test_get_context(CONTEXT_NO_FLAG);
     assert(ctx);
 

--- a/test/context.c
+++ b/test/context.c
@@ -290,6 +290,8 @@ test_include_order(void)
 int
 main(void)
 {
+    test_init();
+
     struct xkb_context *context = test_get_context(0);
     xkb_atom_t atom;
 

--- a/test/filecomp.c
+++ b/test/filecomp.c
@@ -40,6 +40,8 @@ test_file(struct xkb_context *ctx, const char *path_rel)
 int
 main(void)
 {
+    test_init();
+
     struct xkb_context *ctx = test_get_context(0);
 
     assert(test_file(ctx, "keymaps/basic.xkb"));

--- a/test/keymap.c
+++ b/test/keymap.c
@@ -233,6 +233,8 @@ test_multiple_keysyms_per_level(void)
 int
 main(void)
 {
+    test_init();
+
     test_garbage_key();
     test_keymap();
     test_numeric_keysyms();

--- a/test/keyseq.c
+++ b/test/keyseq.c
@@ -29,6 +29,8 @@
 int
 main(void)
 {
+    test_init();
+
     struct xkb_context *ctx = test_get_context(0);
     struct xkb_keymap *keymap;
 

--- a/test/keysym.c
+++ b/test/keysym.c
@@ -298,6 +298,8 @@ test_utf32_to_keysym(uint32_t ucs, xkb_keysym_t expected)
 int
 main(void)
 {
+    test_init();
+
     /* Bounds */
     assert(XKB_KEYSYM_MIN == 0);
     assert(XKB_KEYSYM_MIN < XKB_KEYSYM_MAX);

--- a/test/log.c
+++ b/test/log.c
@@ -75,6 +75,8 @@ main(void)
     struct xkb_context *ctx;
     int ret;
 
+    test_init();
+
     ret = setenv("XKB_LOG_LEVEL", "warn", 1);
     assert(ret == 0);
     ret = setenv("XKB_LOG_VERBOSITY", "5", 1);

--- a/test/messages.c
+++ b/test/messages.c
@@ -59,5 +59,7 @@ test_message_get(void)
 int
 main(void)
 {
+    test_init();
+
     test_message_get();
 }

--- a/test/modifiers.c
+++ b/test/modifiers.c
@@ -154,6 +154,8 @@ test_modmap_none(void)
 int
 main(void)
 {
+    test_init();
+
     test_modmap_none();
 
     return 0;

--- a/test/registry.c
+++ b/test/registry.c
@@ -1068,6 +1068,8 @@ test_invalid_include(void)
 int
 main(void)
 {
+    test_init();
+
     test_no_include_paths();
     test_invalid_include();
     test_load_basic();

--- a/test/rules-file-includes.c
+++ b/test/rules-file-includes.c
@@ -93,6 +93,8 @@ main(int argc, char *argv[])
 {
     struct xkb_context *ctx;
 
+    test_init();
+
     setenv("XKB_CONFIG_ROOT", TEST_XKB_CONFIG_ROOT, 1);
 
     ctx = test_get_context(0);

--- a/test/rules-file.c
+++ b/test/rules-file.c
@@ -91,6 +91,8 @@ main(int argc, char *argv[])
 {
     struct xkb_context *ctx;
 
+    test_init();
+
     ctx = test_get_context(0);
     assert(ctx);
 

--- a/test/rulescomp.c
+++ b/test/rulescomp.c
@@ -110,6 +110,8 @@ test_rmlvo_env(struct xkb_context *ctx, const char *rules, const char *model,
 int
 main(int argc, char *argv[])
 {
+    test_init();
+
     struct xkb_context *ctx = test_get_context(CONTEXT_ALLOW_ENVIRONMENT_NAMES);
 
     assert(ctx);

--- a/test/state.c
+++ b/test/state.c
@@ -712,6 +712,8 @@ test_ctrl_string_transformation(struct xkb_keymap *keymap)
 int
 main(void)
 {
+    test_init();
+
     struct xkb_context *context = test_get_context(0);
     struct xkb_keymap *keymap;
 

--- a/test/stringcomp.c
+++ b/test/stringcomp.c
@@ -34,6 +34,8 @@
 int
 main(int argc, char *argv[])
 {
+    test_init();
+
     struct xkb_context *ctx = test_get_context(0);
     struct xkb_keymap *keymap;
     char *original, *dump, *dump2;

--- a/test/test.h
+++ b/test/test.h
@@ -44,6 +44,9 @@
     assert_printf(streq_not_null(expected, got), \
                   test_name ". Expected \"%s\", got: \"%s\"\n", expected, got)
 
+void
+test_init(void);
+
 /* The offset between KEY_* numbering, and keycodes in the XKB evdev
  * dataset. */
 #define EVDEV_OFFSET 8

--- a/test/utf8.c
+++ b/test/utf8.c
@@ -29,6 +29,7 @@
 #include <stddef.h>
 #include <string.h>
 
+#include "test.h"
 #include "utf8.h"
 #include "utils.h"
 
@@ -180,6 +181,8 @@ test_utf32_to_utf8(void)
 int
 main(void)
 {
+    test_init();
+
     test_is_valid_utf8();
     test_utf32_to_utf8();
 

--- a/test/utils.c
+++ b/test/utils.c
@@ -36,6 +36,8 @@ main(void)
 {
     char buffer[10];
 
+    test_init();
+
     assert(!snprintf_safe(buffer, 0, "foo"));
     assert(!snprintf_safe(buffer, 1, "foo"));
     assert(!snprintf_safe(buffer, 3, "foo"));

--- a/test/x11.c
+++ b/test/x11.c
@@ -86,5 +86,7 @@ err_conn:
 }
 
 int main(void) {
+    test_init();
+
     return x11_tests_run();
 }

--- a/test/x11comp.c
+++ b/test/x11comp.c
@@ -117,5 +117,7 @@ err_conn:
 }
 
 int main(void) {
+    test_init();
+
     return x11_tests_run();
 }


### PR DESCRIPTION
Currently it only ensure we do not buffer `stdout`.

Follow-up of #449 (see [this comment](https://github.com/xkbcommon/libxkbcommon/pull/449#issuecomment-1951707681)).