### PR TITLE
Do not accept statements like garbage.level_name in types files

### DIFF
--- a/src/xkbcomp/types.c
+++ b/src/xkbcomp/types.c
@@ -618,12 +618,20 @@ HandleKeyTypeBody(KeyTypesInfo *info, VarDef *def, KeyTypeInfo *type)
         if (!ok)
             continue;
 
-        if (elem && istreq(elem, "type")) {
-            log_err(info->ctx,
-                    XKB_ERROR_INVALID_SET_DEFAULT_STATEMENT,
-                    "Support for changing the default type has been removed; "
-                    "Statement ignored\n");
-            continue;
+        if (elem) {
+            if (istreq(elem, "type")) {
+                log_err(info->ctx,
+                        XKB_ERROR_INVALID_SET_DEFAULT_STATEMENT,
+                        "Support for changing the default type has been removed; "
+                        "Statement ignored\n");
+                continue;
+            }
+            else {
+                log_err(info->ctx, XKB_LOG_MESSAGE_NO_ID,
+                        "Qualified statement %s.%s is not allowed here,"
+                        "only plain %s is accepted.\n", elem, field, field);
+                return false;
+            }
         }
 
         ok = SetKeyTypeField(info, type, field, arrayNdx, def->value);

--- a/test/data/rules/evdev
+++ b/test/data/rules/evdev
@@ -930,6 +930,7 @@
   $macs		=	complete+numpad(mac)
   $applealu	=	complete+numpad(mac)
   $nokiamodels	=	complete+nokia
+  garbage	=	garbage
   *		=	complete
 
 ! layout	option	=	symbols

--- a/test/data/types/garbage
+++ b/test/data/types/garbage
@@ -1,0 +1,7 @@
+default xkb_types "basic" {
+    type "ONE_LEVEL" {
+	garbage.modifiers = None;
+	garbage.map[None] = Level1;
+	garbage.level_name[Level1]= "Any";
+    };
+};

--- a/test/keymap.c
+++ b/test/keymap.c
@@ -76,6 +76,20 @@ test_garbage_key(void)
 }
 
 static void
+test_garbage_type(void)
+{
+    struct xkb_context *context = test_get_context(0);
+    struct xkb_keymap *keymap;
+
+    assert(context);
+
+    keymap = test_compile_rules(context, NULL, "garbage", NULL, NULL, NULL);
+    assert(!keymap);
+
+    xkb_context_unref(context);
+}
+
+static void
 test_keymap(void)
 {
     struct xkb_context *context = test_get_context(0);
@@ -236,6 +250,7 @@ main(void)
     test_init();
 
     test_garbage_key();
+    test_garbage_type();
     test_keymap();
     test_numeric_keysyms();
     test_multiple_keysyms_per_level();


### PR DESCRIPTION
Fix parser accepting clearly nonsensical type definitions like

type "ONE_LEVEL" {
    garbage.modifiers = None;
    garbage.map[None] = Level1;
    garbage.level_name[Level1] = "Any";
};

and ignoring the garbage part.

Closes #457