### PR TITLE
tools: remove unused `#incldue <ctype.h>`

### DIFF
--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -32,7 +32,6 @@
 
 #include "config.h"
 
-#include <ctype.h>
 #include <errno.h>
 #include <limits.h>
 #include <fcntl.h>


### PR DESCRIPTION
We avoid this header due to its locale dependence. This include seems like a leftover in 44029221e8423f1ca93470952542a0517a208d42.