### PR TITLE
improve CI setup

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,10 +18,10 @@ jobs:
       matrix:
         compiler: [clang, gcc]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install dependencies

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade meson PyYAML

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,10 +15,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install dependencies

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,12 +23,7 @@ jobs:
           python-version: '3.12'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade meson PyYAML
-          brew install libxml2 bison ninja graphviz
-          # HACK: force Doxygen version 1.9.6, because 1.9.7 breaks our cool URIs.
-          curl -O https://raw.githubusercontent.com/Homebrew/homebrew-core/d2267b9f2ad247bc9c8273eb755b39566a474a70/Formula/doxygen.rb
-          brew install --formula doxygen.rb
-          rm doxygen.rb
+          brew install bison libxml2 meson ninja pyyaml
           brew link bison --force
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade meson PyYAML

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Move doxygen to target directory
         run: mv doxygen/ public_html/doc/current/
       - name: Check out the static website
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: xkbcommon/website
           persist-credentials: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - name: Install dependencies
         shell: powershell
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,10 +15,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install dependencies


### PR DESCRIPTION
- use py3.12 for ci
- bump action dependencies

---

- https://github.com/Homebrew/homebrew-core/pull/165881


cc @wismill
