### PR TITLE
meson: disable doc builds by default

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup
         run: |
           # -gdwarf-4 - see https://github.com/llvm/llvm-project/issues/56550.
-          CFLAGS='-gdwarf-4' meson setup build -Denable-cool-uris=true
+          CFLAGS='-gdwarf-4' meson setup build -Denable-docs=true -Denable-cool-uris=true
         env:
           CC: ${{ matrix.compiler }}
       - name: Build

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -63,7 +63,7 @@ option(
 option(
     'enable-docs',
     type: 'boolean',
-    value: true,
+    value: false,
     description: 'Enable building the documentation',
 )
 option(


### PR DESCRIPTION
The only docs we build is the doxygen API and I reckon there's a near-zero amount of users who actually want these built locally instead of just browsing the online doc.

Let's not build this by default, dropping the requirement on doxygen and speeding up the build by quite a fair bit.


--
Replaces #471 because for some reason github doesn't notice my force-pushes on that.