### PR TITLE
Small fix: in RMLVO, use `variant_idx` to index variants instead of `layout_idx`

### DIFF
--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -879,7 +879,7 @@ matcher_rule_apply_if_matches(struct matcher *m, struct scanner *s)
             matched = match_value_and_mark(m, value, to, match_type);
         }
         else if (mlvo == MLVO_VARIANT) {
-            xkb_layout_index_t idx = m->mapping.layout_idx;
+            xkb_layout_index_t idx = m->mapping.variant_idx;
             idx = (idx == XKB_LAYOUT_INVALID ? 0 : idx);
             to = &darray_item(m->rmlvo.variants, idx);
             matched = match_value_and_mark(m, value, to, match_type);


### PR DESCRIPTION
This pull request modifies a line of code in `xkbcomp/rules.c` , in which the `mapping.layout_idx` was used to index the `rmlvo.variants`. 

Is it correct that instead, `mapping.variant_idx` should be used here?

Thanks

