### PR TITLE
doc (manuals): clean and expand apropos results

### DIFF
--- a/tools/xkbcli-compile-compose.1
+++ b/tools/xkbcli-compile-compose.1
@@ -1,10 +1,10 @@
-.Dd November 7, 2023
+.Dd June 4, 2024
 .Dt XKBCLI\-COMPILE\-COMPOSE 1
 .Os
 .
 .Sh NAME
-.Nm "xkbcli compile-compose"
-.Nd compile a Compose file
+.Nm "xkbcli\-compile\-compose"
+.Nd compile an X Keyboard Compose file
 .
 .Sh SYNOPSIS
 .Nm

--- a/tools/xkbcli-compile-keymap.1
+++ b/tools/xkbcli-compile-keymap.1
@@ -1,10 +1,10 @@
-.Dd July 27, 2020
+.Dd June 4, 2024
 .Dt XKBCLI\-COMPILE\-KEYMAP 1
 .Os
 .
 .Sh NAME
-.Nm "xkbcli compile\-keymap"
-.Nd compile an XKB keymap
+.Nm "xkbcli\-compile\-keymap"
+.Nd compile an X Keyboard keymap
 .
 .Sh SYNOPSIS
 .Nm

--- a/tools/xkbcli-how-to-type.1
+++ b/tools/xkbcli-how-to-type.1
@@ -1,9 +1,9 @@
-.Dd July 27, 2020
+.Dd June 4, 2024
 .Dt XKBCLI\-HOW\-TO\-TYPE 1
 .Os
 .
 .Sh NAME
-.Nm "xkbcli how\-to\-type"
+.Nm "xkbcli\-how\-to\-type"
 .Nd query how to type a given Unicode codepoint
 .
 .Sh SYNOPSIS

--- a/tools/xkbcli-interactive-evdev.1
+++ b/tools/xkbcli-interactive-evdev.1
@@ -1,10 +1,10 @@
-.Dd July 27, 2020
+.Dd June 4, 2024
 .Dt XKBCLI\-INTERACTIVE\-EVDEV 1
 .Os
 .
 .Sh NAME
-.Nm "xkbcli interactive\-evdev"
-.Nd interactive debugger for XKB keymaps
+.Nm "xkbcli\-interactive\-evdev"
+.Nd interactive debugger for X Keyboard keymaps
 .
 .Sh SYNOPSIS
 .Nm

--- a/tools/xkbcli-interactive-wayland.1
+++ b/tools/xkbcli-interactive-wayland.1
@@ -1,10 +1,10 @@
-.Dd July 27, 2020
+.Dd June 4, 2024
 .Dt XKBCLI\-INTERACTIVE\-WAYLAND 1
 .Os
 .
 .Sh NAME
-.Nm "xkbcli interactive\-wayland"
-.Nd interactive debugger for XKB keymaps
+.Nm "xkbcli\-interactive\-wayland"
+.Nd interactive debugger for X Keyboard keymaps
 .
 .Sh SYNOPSIS
 .Nm

--- a/tools/xkbcli-interactive-x11.1
+++ b/tools/xkbcli-interactive-x11.1
@@ -1,10 +1,10 @@
-.Dd July 27, 2020
+.Dd June 4, 2024
 .Dt XKBCLI\-INTERACTIVE\-X11 1
 .Os
 .
 .Sh NAME
-.Nm "xkbcli interactive\-x11"
-.Nd interactive debugger for XKB keymaps
+.Nm "xkbcli\-interactive\-x11"
+.Nd interactive debugger for X Keyboard keymaps
 .
 .Sh SYNOPSIS
 .Nm

--- a/tools/xkbcli-list.1
+++ b/tools/xkbcli-list.1
@@ -1,10 +1,10 @@
-.Dd November 1, 2021
+.Dd June 04, 2024
 .Dt XKBCLI\-LIST 1
 .Os
 .
 .Sh NAME
-.Nm "xkbcli list"
-.Nd list available XKB models, layouts, variants and options
+.Nm "xkbcli\-list"
+.Nd list available X Keyboard models, layouts, variants and options
 .
 .Sh SYNOPSIS
 .Nm

--- a/tools/xkbcli.1
+++ b/tools/xkbcli.1
@@ -1,10 +1,10 @@
-.Dd July 27, 2020
+.Dd June 4, 2024
 .Dt XKBCLI 1
 .Os
 .
 .Sh NAME
 .Nm xkbcli
-.Nd tool to interact with XKB keymaps
+.Nd tool to interact with X Keyboard keymaps
 .
 .Sh SYNOPSIS
 .Nm


### PR DESCRIPTION
Previously on FreeBSD/mandoc (probably affecting others), everything except xkbcli was being listed twice and wrapping in apropos because mdoc(7) names should not have spaces or be different than the title.

Further, xkb is already parsed in search results by being in the name, so expand xkb to "X keyboard" so that they match for apropos keyboard. We did this already in xkbutils, which matches setxkbmap.

These don't need to be quoted literals, and - doesn't need to be escaped, but I left them because there may be environments which are not to spec, but I'm happy to ammend this commit if that cleanup seems desirable (works on Linux/groff).