### PR TITLE
actions: Add support for multiple actions per level

### DIFF
--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -863,7 +863,13 @@ xkb_context_set_log_fn(struct xkb_context *context,
 /** Flags for keymap compilation. */
 enum xkb_keymap_compile_flags {
     /** Do not apply any flags. */
-    XKB_KEYMAP_COMPILE_NO_FLAGS = 0
+    XKB_KEYMAP_COMPILE_NO_FLAGS = 0,
+    XKB_KEYMAP_COMPILE_RANGE_REDIRECT_TO_0 = (1 << 0),
+    XKB_KEYMAP_COMPILE_RANGE_SATURATE = (1 << 1),
+    _XKB_KEYMAP_COMPILE_ALL =                    \
+        ( XKB_KEYMAP_COMPILE_NO_FLAGS            \
+        | XKB_KEYMAP_COMPILE_RANGE_REDIRECT_TO_0 \
+        | XKB_KEYMAP_COMPILE_RANGE_SATURATE )
 };
 
 /**

--- a/src/keymap-priv.c
+++ b/src/keymap-priv.c
@@ -69,6 +69,16 @@ xkb_keymap_new(struct xkb_context *ctx,
     keymap->format = format;
     keymap->flags = flags;
 
+    if (flags & XKB_KEYMAP_COMPILE_RANGE_REDIRECT_TO_0) {
+        keymap->out_of_range_group_action = RANGE_REDIRECT;
+        keymap->out_of_range_group_number = 0;
+    } else if (flags & XKB_KEYMAP_COMPILE_RANGE_SATURATE) {
+        keymap->out_of_range_group_action = RANGE_SATURATE;
+    } else {
+        keymap->out_of_range_group_action = RANGE_WRAP;
+    }
+    log_err(ctx, 0, "xkb_keymap_new: flags: %d, out_of_range_group_action=%u\n", flags, keymap->out_of_range_group_action);
+
     update_builtin_keymap_fields(keymap);
 
     return keymap;
@@ -147,6 +157,95 @@ XkbLevelsSameSyms(const struct xkb_level *a, const struct xkb_level *b)
     if (a->num_syms != b->num_syms)
         return false;
     if (a->num_syms <= 1)
-        return a->u.sym == b->u.sym;
-    return memcmp(a->u.syms, b->u.syms, sizeof(*a->u.syms) * a->num_syms) == 0;
+        return a->s.sym == b->s.sym;
+    return memcmp(a->s.syms, b->s.syms, sizeof(*a->s.syms) * a->num_syms) == 0;
+}
+
+bool
+XkbLevelHasNoAction(const struct xkb_level *level)
+{
+    if (level->num_syms == 0)
+        return true;
+    if (level->num_syms == 1)
+        return level->a.action.type == ACTION_TYPE_NONE;
+    for (unsigned int k = 0; k < level->num_syms; k++) {
+        if (level->a.actions[k].type != ACTION_TYPE_NONE)
+            return false;
+    }
+    return true;
+}
+
+xkb_layout_index_t
+XkbWrapGroupIntoRange(int32_t group,
+                      xkb_layout_index_t num_groups,
+                      enum xkb_range_exceed_type out_of_range_group_action,
+                      xkb_layout_index_t out_of_range_group_number)
+{
+    if (num_groups == 0)
+        return XKB_LAYOUT_INVALID;
+
+    if (group >= 0 && (xkb_layout_index_t) group < num_groups)
+        return group;
+
+    switch (out_of_range_group_action) {
+    case RANGE_REDIRECT:
+        if (out_of_range_group_number >= num_groups)
+            return 0;
+        return out_of_range_group_number;
+
+    case RANGE_SATURATE:
+        if (group < 0)
+            return 0;
+        else
+            return num_groups - 1;
+
+    case RANGE_WRAP:
+    default:
+        /*
+         * C99 says a negative dividend in a modulo operation always
+         * gives a negative result.
+         */
+        if (group < 0)
+            return ((int) num_groups + (group % (int) num_groups));
+        else
+            return group % num_groups;
+    }
+}
+
+unsigned int
+xkb_keymap_key_get_actions_by_level(struct xkb_keymap *keymap,
+                                    xkb_keycode_t kc,
+                                    xkb_layout_index_t layout,
+                                    xkb_level_index_t level,
+                                    const union xkb_action **actions)
+{
+    const struct xkb_key *key = XkbKey(keymap, kc);
+    unsigned int count;
+
+    if (!key)
+        goto err;
+
+    layout = XkbWrapGroupIntoRange(layout, key->num_groups,
+                                   key->out_of_range_group_action,
+                                   key->out_of_range_group_number);
+    if (layout == XKB_LAYOUT_INVALID)
+        goto err;
+
+    if (level >= XkbKeyNumLevels(key, layout))
+        goto err;
+
+    count = key->groups[layout].levels[level].num_syms;
+    if (count == 0)
+        goto err;
+
+    if (count == 1)
+        *actions = &key->groups[layout].levels[level].a.action;
+    else
+        *actions = key->groups[layout].levels[level].a.actions;
+
+    return count;
+
+err:
+    *actions = NULL;
+    return 0;
 }

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -75,8 +75,10 @@ xkb_keymap_unref(struct xkb_keymap *keymap)
                 for (unsigned i = 0; i < key->num_groups; i++) {
                     if (key->groups[i].levels) {
                         for (unsigned j = 0; j < XkbKeyNumLevels(key, i); j++)
-                            if (key->groups[i].levels[j].num_syms > 1)
-                                free(key->groups[i].levels[j].u.syms);
+                            if (key->groups[i].levels[j].num_syms > 1) {
+                                free(key->groups[i].levels[j].s.syms);
+                                free(key->groups[i].levels[j].a.actions);
+                            }
                         free(key->groups[i].levels);
                     }
                 }
@@ -132,7 +134,7 @@ xkb_keymap_new_from_names(struct xkb_context *ctx,
         return NULL;
     }
 
-    if (flags & ~(XKB_KEYMAP_COMPILE_NO_FLAGS)) {
+    if (flags & ~(_XKB_KEYMAP_COMPILE_ALL)) {
         log_err_func(ctx, "unrecognized flags: %#x\n", flags);
         return NULL;
     }
@@ -180,7 +182,7 @@ xkb_keymap_new_from_buffer(struct xkb_context *ctx,
         return NULL;
     }
 
-    if (flags & ~(XKB_KEYMAP_COMPILE_NO_FLAGS)) {
+    if (flags & ~(_XKB_KEYMAP_COMPILE_ALL)) {
         log_err_func(ctx, "unrecognized flags: %#x\n", flags);
         return NULL;
     }
@@ -221,7 +223,7 @@ xkb_keymap_new_from_file(struct xkb_context *ctx,
         return NULL;
     }
 
-    if (flags & ~(XKB_KEYMAP_COMPILE_NO_FLAGS)) {
+    if (flags & ~(_XKB_KEYMAP_COMPILE_ALL)) {
         log_err_func(ctx, "unrecognized flags: %#x\n", flags);
         return NULL;
     }
@@ -503,9 +505,9 @@ xkb_keymap_key_get_syms_by_level(struct xkb_keymap *keymap,
         goto err;
 
     if (num_syms == 1)
-        *syms_out = &key->groups[layout].levels[level].u.sym;
+        *syms_out = &key->groups[layout].levels[level].s.sym;
     else
-        *syms_out = key->groups[layout].levels[level].u.syms;
+        *syms_out = key->groups[layout].levels[level].s.syms;
 
     return num_syms;
 

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -316,12 +316,15 @@ enum xkb_explicit_components {
 };
 
 struct xkb_level {
-    union xkb_action action;
     unsigned int num_syms;
     union {
         xkb_keysym_t sym;       /* num_syms == 1 */
         xkb_keysym_t *syms;     /* num_syms > 1  */
-    } u;
+    } s;
+    union {
+        union xkb_action action;   /* num_syms == 1 */
+        union xkb_action *actions; /* num_syms >  1 */
+    } a;
 };
 
 struct xkb_group {
@@ -370,6 +373,9 @@ struct xkb_keymap {
     enum xkb_keymap_format format;
 
     enum xkb_action_controls enabled_ctrls;
+    /* groups_wrap control */
+    enum xkb_range_exceed_type out_of_range_group_action;
+    xkb_layout_index_t out_of_range_group_number;
 
     xkb_keycode_t min_key_code;
     xkb_keycode_t max_key_code;
@@ -473,6 +479,9 @@ XkbModNameToIndex(const struct xkb_mod_set *mods, xkb_atom_t name,
 bool
 XkbLevelsSameSyms(const struct xkb_level *a, const struct xkb_level *b);
 
+bool
+XkbLevelHasNoAction(const struct xkb_level *level);
+
 xkb_layout_index_t
 XkbWrapGroupIntoRange(int32_t group,
                       xkb_layout_index_t num_groups,
@@ -481,6 +490,13 @@ XkbWrapGroupIntoRange(int32_t group,
 
 xkb_mod_mask_t
 mod_mask_get_effective(struct xkb_keymap *keymap, xkb_mod_mask_t mods);
+
+unsigned int
+xkb_keymap_key_get_actions_by_level(struct xkb_keymap *keymap,
+                                    xkb_keycode_t kc,
+                                    xkb_layout_index_t layout,
+                                    xkb_level_index_t level,
+                                    const union xkb_action **actions);
 
 struct xkb_keymap_format_ops {
     bool (*keymap_new_from_names)(struct xkb_keymap *keymap,

--- a/src/state.c
+++ b/src/state.c
@@ -159,43 +159,6 @@ xkb_state_key_get_level(struct xkb_state *state, xkb_keycode_t kc,
     return entry->level;
 }
 
-xkb_layout_index_t
-XkbWrapGroupIntoRange(int32_t group,
-                      xkb_layout_index_t num_groups,
-                      enum xkb_range_exceed_type out_of_range_group_action,
-                      xkb_layout_index_t out_of_range_group_number)
-{
-    if (num_groups == 0)
-        return XKB_LAYOUT_INVALID;
-
-    if (group >= 0 && (xkb_layout_index_t) group < num_groups)
-        return group;
-
-    switch (out_of_range_group_action) {
-    case RANGE_REDIRECT:
-        if (out_of_range_group_number >= num_groups)
-            return 0;
-        return out_of_range_group_number;
-
-    case RANGE_SATURATE:
-        if (group < 0)
-            return 0;
-        else
-            return num_groups - 1;
-
-    case RANGE_WRAP:
-    default:
-        /*
-         * C99 says a negative dividend in a modulo operation always
-         * gives a negative result.
-         */
-        if (group < 0)
-            return ((int) num_groups + (group % (int) num_groups));
-        else
-            return group % num_groups;
-    }
-}
-
 /**
  * Returns the layout to use for the given key and state, taking
  * wrapping/clamping/etc into account, or XKB_LAYOUT_INVALID.
@@ -213,23 +176,27 @@ xkb_state_key_get_layout(struct xkb_state *state, xkb_keycode_t kc)
                                  key->out_of_range_group_number);
 }
 
-static const union xkb_action *
-xkb_key_get_action(struct xkb_state *state, const struct xkb_key *key)
+static unsigned int
+xkb_key_get_actions(struct xkb_state *state, const struct xkb_key *key,
+                    const union xkb_action **actions)
 {
-    static const union xkb_action dummy = { .type = ACTION_TYPE_NONE };
-
     xkb_layout_index_t layout;
     xkb_level_index_t level;
 
     layout = xkb_state_key_get_layout(state, key->keycode);
     if (layout == XKB_LAYOUT_INVALID)
-        return &dummy;
+        goto err;
 
     level = xkb_state_key_get_level(state, key->keycode, layout);
     if (level == XKB_LEVEL_INVALID)
-        return &dummy;
+        goto err;
 
-    return &key->groups[layout].levels[level].action;
+    return xkb_keymap_key_get_actions_by_level(state->keymap, key->keycode,
+                                               layout, level, actions);
+
+err:
+    *actions = NULL;
+    return 0;
 }
 
 static struct xkb_filter *
@@ -447,32 +414,35 @@ xkb_filter_mod_latch_func(struct xkb_state *state,
          * keypress, then either break the latch if any random key is pressed,
          * or promote it to a lock or plain base set if it's the same
          * modifier. */
-        const union xkb_action *action = xkb_key_get_action(state, key);
-        if (action->type == ACTION_TYPE_MOD_LATCH &&
-            action->mods.flags == filter->action.mods.flags &&
-            action->mods.mods.mask == filter->action.mods.mods.mask) {
-            filter->action = *action;
-            if (filter->action.mods.flags & ACTION_LATCH_TO_LOCK) {
-                filter->action.type = ACTION_TYPE_MOD_LOCK;
-                filter->func = xkb_filter_mod_lock_func;
-                state->components.locked_mods |= filter->action.mods.mods.mask;
+        const union xkb_action *actions = NULL;
+        unsigned int count = xkb_key_get_actions(state, key, &actions);
+        for (unsigned int k = 0; k < count; k++) {
+            if (actions[k].type == ACTION_TYPE_MOD_LATCH &&
+                actions[k].mods.flags == filter->action.mods.flags &&
+                actions[k].mods.mods.mask == filter->action.mods.mods.mask) {
+                filter->action = actions[k];
+                if (filter->action.mods.flags & ACTION_LATCH_TO_LOCK) {
+                    filter->action.type = ACTION_TYPE_MOD_LOCK;
+                    filter->func = xkb_filter_mod_lock_func;
+                    state->components.locked_mods |= filter->action.mods.mods.mask;
+                }
+                else {
+                    filter->action.type = ACTION_TYPE_MOD_SET;
+                    filter->func = xkb_filter_mod_set_func;
+                    state->set_mods = filter->action.mods.mods.mask;
+                }
+                filter->key = key;
+                state->components.latched_mods &= ~filter->action.mods.mods.mask;
+                /* XXX beep beep! */
+                return XKB_FILTER_CONSUME;
             }
-            else {
-                filter->action.type = ACTION_TYPE_MOD_SET;
-                filter->func = xkb_filter_mod_set_func;
-                state->set_mods = filter->action.mods.mods.mask;
+            else if (xkb_action_breaks_latch(&(actions[k]))) {
+                /* XXX: This may be totally broken, we might need to break the
+                *      latch in the next run after this press? */
+                state->components.latched_mods &= ~filter->action.mods.mods.mask;
+                filter->func = NULL;
+                return XKB_FILTER_CONTINUE;
             }
-            filter->key = key;
-            state->components.latched_mods &= ~filter->action.mods.mods.mask;
-            /* XXX beep beep! */
-            return XKB_FILTER_CONSUME;
-        }
-        else if (xkb_action_breaks_latch(action)) {
-            /* XXX: This may be totally broken, we might need to break the
-             *      latch in the next run after this press? */
-            state->components.latched_mods &= ~filter->action.mods.mods.mask;
-            filter->func = NULL;
-            return XKB_FILTER_CONTINUE;
         }
     }
     else if (direction == XKB_KEY_UP && key == filter->key) {
@@ -543,7 +513,8 @@ xkb_filter_apply_all(struct xkb_state *state,
                      enum xkb_key_direction direction)
 {
     struct xkb_filter *filter;
-    const union xkb_action *action;
+    const union xkb_action *actions = NULL;
+    unsigned int count;
     bool consumed;
 
     /* First run through all the currently active filters and see if any of
@@ -559,26 +530,35 @@ xkb_filter_apply_all(struct xkb_state *state,
     if (consumed || direction == XKB_KEY_UP)
         return;
 
-    action = xkb_key_get_action(state, key);
+    count = xkb_key_get_actions(state, key, &actions);
 
-    /*
-     * It's possible for the keymap to set action->type explicitly, like so:
-     *     interpret XF86_Next_VMode {
-     *         action = Private(type=0x86, data="+VMode");
-     *     };
-     * We don't handle those.
-     */
-    if (action->type >= _ACTION_TYPE_NUM_ENTRIES)
-        return;
+    for (unsigned int k = 0; k < count; k++) {
+        if (count > 1) {
+            log_vrb(
+                state->keymap->ctx, 0, 0,
+                "xkb_filter_apply_all: key: %u, index: %u, action type: %d\n",
+                key->keycode, k, actions[k].type
+            );
+        }
+        /*
+        * It's possible for the keymap to set action->type explicitly, like so:
+        *     interpret XF86_Next_VMode {
+        *         action = Private(type=0x86, data="+VMode");
+        *     };
+        * We don't handle those.
+        */
+        if (actions[k].type >= _ACTION_TYPE_NUM_ENTRIES)
+            return;
 
-    if (!filter_action_funcs[action->type].new)
-        return;
+        if (!filter_action_funcs[actions[k].type].new)
+            return;
 
-    filter = xkb_filter_new(state);
-    filter->key = key;
-    filter->func = filter_action_funcs[action->type].func;
-    filter->action = *action;
-    filter_action_funcs[action->type].new(state, filter);
+        filter = xkb_filter_new(state);
+        filter->key = key;
+        filter->func = filter_action_funcs[actions[k].type].func;
+        filter->action = actions[k];
+        filter_action_funcs[actions[k].type].new(state, filter);
+    }
 }
 
 XKB_EXPORT struct xkb_state *
@@ -687,19 +667,26 @@ xkb_state_update_derived(struct xkb_state *state)
                               state->components.latched_mods |
                               state->components.locked_mods);
 
-    /* TODO: Use groups_wrap control instead of always RANGE_WRAP. */
-
     wrapped = XkbWrapGroupIntoRange(state->components.locked_group,
                                     state->keymap->num_groups,
-                                    RANGE_WRAP, 0);
+                                    state->keymap->out_of_range_group_action,
+                                    state->keymap->out_of_range_group_number);
     state->components.locked_group =
         (wrapped == XKB_LAYOUT_INVALID ? 0 : wrapped);
+
 
     wrapped = XkbWrapGroupIntoRange(state->components.base_group +
                                     state->components.latched_group +
                                     state->components.locked_group,
                                     state->keymap->num_groups,
-                                    RANGE_WRAP, 0);
+                                    state->keymap->out_of_range_group_action,
+                                    state->keymap->out_of_range_group_number);
+
+    log_err(state->keymap->ctx, 0,
+        "xkb_state_update_derived: base_group: %d, latched_group: %d, locked_group: %d, wrapped: %u, out_of_range_group_action: %u\n",
+        state->components.base_group, state->components.latched_group, state->components.locked_group,
+        wrapped, state->keymap->out_of_range_group_action);
+
     state->components.group =
         (wrapped == XKB_LAYOUT_INVALID ? 0 : wrapped);
 

--- a/src/x11/keymap.c
+++ b/src/x11/keymap.c
@@ -479,7 +479,7 @@ get_sym_maps(struct xkb_keymap *keymap, xcb_connection_t *conn,
                     if (level < key->groups[group].type->num_levels &&
                         wire_keysym != XKB_KEY_NoSymbol) {
                         key->groups[group].levels[level].num_syms = 1;
-                        key->groups[group].levels[level].u.sym = wire_keysym;
+                        key->groups[group].levels[level].s.sym = wire_keysym;
                     }
 
                     syms_iter++;
@@ -527,7 +527,7 @@ get_actions(struct xkb_keymap *keymap, xcb_connection_t *conn,
                     xcb_xkb_action_t *wire_action = acts_iter.data;
 
                     if (level < key->groups[group].type->num_levels) {
-                        union xkb_action *action = &key->groups[group].levels[level].action;
+                        union xkb_action *action = &key->groups[group].levels[level].a.action;
 
                         translate_action(action, wire_action);
                     }
@@ -1142,7 +1142,7 @@ xkb_x11_keymap_new_from_device(struct xkb_context *ctx,
     struct xkb_keymap *keymap;
     const enum xkb_keymap_format format = XKB_KEYMAP_FORMAT_TEXT_V1;
 
-    if (flags & ~(XKB_KEYMAP_COMPILE_NO_FLAGS)) {
+    if (flags & ~(_XKB_KEYMAP_COMPILE_ALL)) {
         log_err_func(ctx, "unrecognized flags: %#x\n", flags);
         return NULL;
     }

--- a/src/xkbcomp/ast-build.c
+++ b/src/xkbcomp/ast-build.c
@@ -200,7 +200,54 @@ ExprCreateActionList(ExprDef *actions)
     ExprDef *expr = ExprCreate(EXPR_ACTION_LIST, EXPR_TYPE_ACTIONS, sizeof(ExprActionList));
     if (!expr)
         return NULL;
-    expr->actions.actions = actions;
+
+    darray_init(expr->actions.actions);
+    darray_init(expr->actions.actionsMapIndex);
+    darray_init(expr->actions.actionsNumEntries);
+
+    darray_append(expr->actions.actions, actions);
+    darray_append(expr->actions.actionsMapIndex, 0);
+    darray_append(expr->actions.actionsNumEntries, 1);
+    return expr;
+}
+
+ExprDef *
+ExprCreateMultiActionList(ExprDef *expr)
+{
+    unsigned nLevels = darray_size(expr->actions.actionsMapIndex);
+
+    darray_resize(expr->actions.actionsMapIndex, 1);
+    darray_resize(expr->actions.actionsNumEntries, 1);
+    darray_item(expr->actions.actionsMapIndex, 0) = 0;
+    darray_item(expr->actions.actionsNumEntries, 0) = nLevels;
+
+    return expr;
+}
+
+ExprDef *
+ExprAppendActionList(ExprDef *expr, ExprDef *action)
+{
+    unsigned nSyms = darray_size(expr->actions.actions);
+
+    darray_append(expr->actions.actionsMapIndex, nSyms);
+    darray_append(expr->actions.actionsNumEntries, 1);
+    darray_append(expr->actions.actions, action);
+
+    return expr;
+}
+
+ExprDef *
+ExprAppendMultiActionList(ExprDef *expr, ExprDef *append)
+{
+    unsigned nSyms = darray_size(expr->actions.actions);
+    unsigned numEntries = darray_size(append->actions.actions);
+
+    darray_append(expr->actions.actionsMapIndex, nSyms);
+    darray_append(expr->actions.actionsNumEntries, numEntries);
+    darray_concat(expr->actions.actions, append->actions.actions);
+
+    FreeStmt((ParseCommon *) append);
+
     return expr;
 }
 
@@ -599,6 +646,8 @@ FreeExpr(ExprDef *expr)
     if (!expr)
         return;
 
+    ExprDef** action;
+
     switch (expr->expr.op) {
     case EXPR_NEGATE:
     case EXPR_UNARY_PLUS:
@@ -621,7 +670,12 @@ FreeExpr(ExprDef *expr)
         break;
 
     case EXPR_ACTION_LIST:
-        FreeStmt((ParseCommon *) expr->actions.actions);
+        darray_foreach(action, expr->actions.actions) {
+            FreeStmt((ParseCommon *) *action);
+        }
+        darray_free(expr->actions.actions);
+        darray_free(expr->actions.actionsMapIndex);
+        darray_free(expr->actions.actionsNumEntries);
         break;
 
     case EXPR_ARRAY_REF:

--- a/src/xkbcomp/ast-build.h
+++ b/src/xkbcomp/ast-build.h
@@ -65,6 +65,15 @@ ExprDef *
 ExprCreateActionList(ExprDef *actions);
 
 ExprDef *
+ExprCreateMultiActionList(ExprDef *expr);
+
+ExprDef *
+ExprAppendActionList(ExprDef *expr, ExprDef *action);
+
+ExprDef *
+ExprAppendMultiActionList(ExprDef *expr, ExprDef *append);
+
+ExprDef *
 ExprCreateMultiKeysymList(ExprDef *list);
 
 ExprDef *

--- a/src/xkbcomp/ast.h
+++ b/src/xkbcomp/ast.h
@@ -231,7 +231,9 @@ typedef struct {
 
 typedef struct {
     ExprCommon expr;
-    ExprDef *actions;
+    darray(ExprDef*) actions;
+    darray(unsigned int) actionsMapIndex;
+    darray(unsigned int) actionsNumEntries;
 } ExprActionList;
 
 typedef struct {

--- a/src/xkbcomp/keymap-dump.c
+++ b/src/xkbcomp/keymap-dump.c
@@ -407,6 +407,43 @@ write_action(struct xkb_keymap *keymap, struct buf *buf,
 }
 
 static bool
+write_actions(struct xkb_keymap *keymap, struct buf *buf,
+              const struct xkb_key *key, xkb_layout_index_t group)
+{
+    static const union xkb_action noAction = { .type = ACTION_TYPE_NONE };
+
+    for (xkb_level_index_t level = 0; level < XkbKeyNumLevels(key, group);
+         level++) {
+        const union xkb_action *actions;
+        int count;
+
+        if (level != 0)
+            write_buf(buf, ", ");
+
+
+        count = xkb_keymap_key_get_actions_by_level(keymap, key->keycode,
+                                                    group, level, &actions);
+        if (count == 0) {
+            write_action(keymap, buf, &noAction, NULL, NULL);
+        }
+        else if (count == 1) {
+            write_action(keymap, buf, &(actions[0]), NULL, NULL);
+        }
+        else {
+            write_buf(buf, "{ ");
+            for (int k = 0; k < count; k++) {
+                if (k != 0)
+                    write_buf(buf, ", ");
+                write_action(keymap, buf, &(actions[k]), NULL, NULL);
+            }
+            write_buf(buf, " }");
+        }
+    }
+
+    return true;
+}
+
+static bool
 write_compat(struct xkb_keymap *keymap, struct buf *buf)
 {
     const struct xkb_led *led;
@@ -569,8 +606,6 @@ write_key(struct xkb_keymap *keymap, struct buf *buf,
         write_buf(buf, " ] };\n");
     }
     else {
-        xkb_level_index_t level;
-
         for (group = 0; group < key->num_groups; group++) {
             if (group != 0)
                 write_buf(buf, ",");
@@ -580,13 +615,8 @@ write_key(struct xkb_keymap *keymap, struct buf *buf,
             write_buf(buf, " ]");
             if (show_actions) {
                 write_buf(buf, ",\n\t\tactions[Group%u]= [ ", group + 1);
-                for (level = 0; level < XkbKeyNumLevels(key, group); level++) {
-                    if (level != 0)
-                        write_buf(buf, ", ");
-                    write_action(keymap, buf,
-                                    &key->groups[group].levels[level].action,
-                                    NULL, NULL);
-                }
+                if (!write_actions(keymap, buf, key, group))
+                    return false;
                 write_buf(buf, " ]");
             }
         }

--- a/src/xkbcomp/keymap.c
+++ b/src/xkbcomp/keymap.c
@@ -29,6 +29,7 @@
 
 #include "config.h"
 
+#include "darray.h"
 #include "xkbcomp-priv.h"
 
 static void
@@ -63,14 +64,17 @@ static const struct xkb_sym_interpret default_interpret = {
     .action = { .type = ACTION_TYPE_NONE },
 };
 
+typedef darray(const struct xkb_sym_interpret*) xkb_sym_interprets;
+
 /**
  * Find an interpretation which applies to this particular level, either by
  * finding an exact match for the symbol and modifier combination, or a
  * generic XKB_KEY_NoSymbol match.
  */
-static const struct xkb_sym_interpret *
+static bool
 FindInterpForKey(struct xkb_keymap *keymap, const struct xkb_key *key,
-                 xkb_layout_index_t group, xkb_level_index_t level)
+                 xkb_layout_index_t group, xkb_level_index_t level,
+                 xkb_sym_interprets *interprets)
 {
     const xkb_keysym_t *syms;
     int num_syms;
@@ -78,7 +82,7 @@ FindInterpForKey(struct xkb_keymap *keymap, const struct xkb_key *key,
     num_syms = xkb_keymap_key_get_syms_by_level(keymap, key->keycode, group,
                                                 level, &syms);
     if (num_syms == 0)
-        return NULL;
+        return false;
 
     /*
      * There may be multiple matchings interprets; we should always return
@@ -86,44 +90,52 @@ FindInterpForKey(struct xkb_keymap *keymap, const struct xkb_key *key,
      * sym_interprets array from the most specific to the least specific,
      * such that when we find a match we return immediately.
      */
-    for (unsigned i = 0; i < keymap->num_sym_interprets; i++) {
-        const struct xkb_sym_interpret *interp = &keymap->sym_interprets[i];
-
-        xkb_mod_mask_t mods;
+    unsigned int i;
+    for (int s = 0; s < num_syms; s++) {
         bool found = false;
+        for (i = 0; i < keymap->num_sym_interprets; i++) {
+            const struct xkb_sym_interpret *interp = &keymap->sym_interprets[i];
+            xkb_mod_mask_t mods;
 
-        if ((num_syms > 1 || interp->sym != syms[0]) &&
-            interp->sym != XKB_KEY_NoSymbol)
-            continue;
+            found = false;
 
-        if (interp->level_one_only && level != 0)
-            mods = 0;
-        else
-            mods = key->modmap;
+            if (interp->sym != syms[s] && interp->sym != XKB_KEY_NoSymbol)
+                continue;
 
-        switch (interp->match) {
-        case MATCH_NONE:
-            found = !(interp->mods & mods);
-            break;
-        case MATCH_ANY_OR_NONE:
-            found = (!mods || (interp->mods & mods));
-            break;
-        case MATCH_ANY:
-            found = (interp->mods & mods);
-            break;
-        case MATCH_ALL:
-            found = ((interp->mods & mods) == interp->mods);
-            break;
-        case MATCH_EXACTLY:
-            found = (interp->mods == mods);
-            break;
+            // FIXME if interp->sym == XKB_KEY_NoSymbol, we may get the same interpret for multiple keysyms!
+
+            if (interp->level_one_only && level != 0)
+                mods = 0;
+            else
+                mods = key->modmap;
+
+            switch (interp->match) {
+            case MATCH_NONE:
+                found = !(interp->mods & mods);
+                break;
+            case MATCH_ANY_OR_NONE:
+                found = (!mods || (interp->mods & mods));
+                break;
+            case MATCH_ANY:
+                found = (interp->mods & mods);
+                break;
+            case MATCH_ALL:
+                found = ((interp->mods & mods) == interp->mods);
+                break;
+            case MATCH_EXACTLY:
+                found = (interp->mods == mods);
+                break;
+            }
+
+            if (found) {
+                darray_append(*interprets, interp);
+                break;
+            }
         }
-
-        if (found)
-            return interp;
+        if (!found)
+            darray_append(*interprets, &default_interpret);
     }
-
-    return &default_interpret;
+    return true;
 }
 
 static bool
@@ -139,23 +151,41 @@ ApplyInterpsToKey(struct xkb_keymap *keymap, struct xkb_key *key)
 
     for (group = 0; group < key->num_groups; group++) {
         for (level = 0; level < XkbKeyNumLevels(key, group); level++) {
+            const struct xkb_sym_interpret **interp_iter;
             const struct xkb_sym_interpret *interp;
+            size_t k;
+            xkb_sym_interprets interprets = darray_new();
 
-            interp = FindInterpForKey(keymap, key, group, level);
-            if (!interp)
+            bool found = FindInterpForKey(keymap, key, group, level, &interprets);
+            if (!found)
                 continue;
 
-            /* Infer default key behaviours from the base level. */
-            if (group == 0 && level == 0)
-                if (!(key->explicit & EXPLICIT_REPEAT) && interp->repeat)
-                    key->repeats = true;
+            darray_enumerate(k, interp_iter, interprets) {
+                interp = *interp_iter;
+                /* Infer default key behaviours from the base level. */
+                if (group == 0 && level == 0)
+                    if (!(key->explicit & EXPLICIT_REPEAT) && interp->repeat)
+                        key->repeats = true;
 
-            if ((group == 0 && level == 0) || !interp->level_one_only)
-                if (interp->virtual_mod != XKB_MOD_INVALID)
-                    vmodmap |= (1u << interp->virtual_mod);
+                if ((group == 0 && level == 0) || !interp->level_one_only)
+                    if (interp->virtual_mod != XKB_MOD_INVALID)
+                        vmodmap |= (1u << interp->virtual_mod);
 
-            if (interp->action.type != ACTION_TYPE_NONE)
-                key->groups[group].levels[level].action = interp->action;
+                if (interp->action.type != ACTION_TYPE_NONE) {
+                    if (darray_size(interprets) == 1) {
+                        key->groups[group].levels[level].a.action = interp->action;
+                    } else {
+                        log_vrb(
+                            keymap->ctx, 0, 0,
+                            "ApplyInterpsToKey: key: %u, group: %u, level: %u, action index: %zu, action type: %d\n",
+                            key->keycode, group, level, k, interp->action.type
+                        );
+                        key->groups[group].levels[level].a.actions[k] = interp->action;
+                    }
+                }
+            }
+
+            darray_free(interprets);
         }
     }
 
@@ -177,7 +207,7 @@ UpdateDerivedKeymapFields(struct xkb_keymap *keymap)
     struct xkb_key *key;
     struct xkb_mod *mod;
     struct xkb_led *led;
-    unsigned int i, j;
+    unsigned int i, j, k;
 
     /* Find all the interprets for the key and bind them to actions,
      * which will also update the vmodmap. */
@@ -204,9 +234,18 @@ UpdateDerivedKeymapFields(struct xkb_keymap *keymap)
     /* Update action modifiers. */
     xkb_keys_foreach(key, keymap)
         for (i = 0; i < key->num_groups; i++)
-            for (j = 0; j < XkbKeyNumLevels(key, i); j++)
-                UpdateActionMods(keymap, &key->groups[i].levels[j].action,
-                                 key->modmap);
+            for (j = 0; j < XkbKeyNumLevels(key, i); j++) {
+                if (key->groups[i].levels[j].num_syms == 1) {
+                    UpdateActionMods(keymap, &key->groups[i].levels[j].a.action,
+                                    key->modmap);
+                } else {
+                    for (k = 0; k < key->groups[i].levels[j].num_syms; k++) {
+                        UpdateActionMods(keymap,
+                                         &key->groups[i].levels[j].a.actions[k],
+                                         key->modmap);
+                    }
+                }
+            }
 
     /* Update vmod -> led maps. */
     xkb_leds_foreach(led, keymap)

--- a/src/xkbcomp/parser.y
+++ b/src/xkbcomp/parser.y
@@ -204,9 +204,9 @@ resolve_keysym(const char *name, xkb_keysym_t *sym_rtrn)
 %type <keysym>  KeySym
 %type <any>     Decl
 %type <anyList> DeclList
-%type <expr>    Expr Term Lhs Terminal ArrayInit KeySyms
-%type <expr>    OptKeySymList KeySymList Action Coord CoordList
-%type <exprList> OptExprList ExprList ActionList
+%type <expr>    Expr Term Lhs Terminal ArrayInit Actions KeySyms
+%type <expr>    KeySymList ActionList Action Coord CoordList
+%type <exprList> OptExprList ExprList
 %type <var>     VarDecl SymbolsVarDecl
 %type <varList> VarDeclList SymbolsBody
 %type <vmod>    VModDef
@@ -474,10 +474,12 @@ SymbolsVarDecl  :       Lhs EQUALS Expr         { $$ = VarCreate($1, $3); }
                 |       ArrayInit               { $$ = VarCreate(NULL, $1); }
                 ;
 
-ArrayInit       :       OBRACKET OptKeySymList CBRACKET
+ArrayInit       :       OBRACKET KeySymList CBRACKET
                         { $$ = $2; }
                 |       OBRACKET ActionList CBRACKET
-                        { $$ = ExprCreateActionList($2.head); }
+                        { $$ = $2; }
+                |       OBRACKET CBRACKET
+                        { $$ = NULL; }
                 ;
 
 GroupCompatDecl :       GROUP Integer EQUALS Expr SEMI
@@ -677,9 +679,17 @@ Term            :       MINUS Term
                 ;
 
 ActionList      :       ActionList COMMA Action
-                        { $$.head = $1.head; $$.last->common.next = &$3->common; $$.last = $3; }
+                        { $$ = ExprAppendActionList($1, $3); }
+                |       ActionList COMMA Actions
+                        { $$ = ExprAppendMultiActionList($1, $3); }
                 |       Action
-                        { $$.head = $$.last = $1; }
+                        { $$ = ExprCreateActionList($1); }
+                |       Actions
+                        { $$ = ExprCreateMultiActionList($1); }
+                ;
+
+Actions         :       OBRACE ActionList CBRACE
+                        { $$ = $2; }
                 ;
 
 Action          :       FieldSpec OPAREN OptExprList CPAREN
@@ -704,10 +714,6 @@ Terminal        :       String
                         { $$ = ExprCreateFloat(/* Discard $1 */); }
                 |       KEYNAME
                         { $$ = ExprCreateKeyName($1); }
-                ;
-
-OptKeySymList   :       KeySymList      { $$ = $1; }
-                |                       { $$ = NULL; }
                 ;
 
 KeySymList      :       KeySymList COMMA KeySym

--- a/src/xkbcomp/symbols.c
+++ b/src/xkbcomp/symbols.c
@@ -107,8 +107,10 @@ typedef struct {
 static void
 ClearLevelInfo(struct xkb_level *leveli)
 {
-    if (leveli->num_syms > 1)
-        free(leveli->u.syms);
+    if (leveli->num_syms > 1) {
+        free(leveli->s.syms);
+        free(leveli->a.actions);
+    }
 }
 
 static void
@@ -134,11 +136,16 @@ CopyGroupInfo(GroupInfo *to, const GroupInfo *from)
     darray_init(to->levels);
     darray_copy(to->levels, from->levels);
     for (xkb_level_index_t j = 0; j < darray_size(to->levels); j++)
-        if (darray_item(from->levels, j).num_syms > 1)
-            darray_item(to->levels, j).u.syms =
-                memdup(darray_item(from->levels, j).u.syms,
+        if (darray_item(from->levels, j).num_syms > 1) {
+            darray_item(to->levels, j).s.syms =
+                memdup(darray_item(from->levels, j).s.syms,
                        darray_item(from->levels, j).num_syms,
                        sizeof(xkb_keysym_t));
+            darray_item(to->levels, j).a.actions =
+                memdup(darray_item(from->levels, j).a.actions,
+                       darray_item(from->levels, j).num_syms,
+                       sizeof(union xkb_action));
+        }
 }
 
 static void
@@ -280,60 +287,117 @@ MergeGroups(SymbolsInfo *info, GroupInfo *into, GroupInfo *from, bool clobber,
         struct xkb_level *intoLevel = &darray_item(into->levels, i);
         struct xkb_level *fromLevel = &darray_item(from->levels, i);
 
-        if (fromLevel->action.type == ACTION_TYPE_NONE) {
-            /* it's empty for consistency with other comparisons */
-        }
-        else if (intoLevel->action.type == ACTION_TYPE_NONE) {
-            intoLevel->action = fromLevel->action;
-        }
-        else {
-            union xkb_action *use, *ignore;
-            use = (clobber ? &fromLevel->action : &intoLevel->action);
-            ignore = (clobber ? &intoLevel->action : &fromLevel->action);
-
-            if (report) {
-                log_warn(info->ctx,
-                         XKB_WARNING_CONFLICTING_KEY_ACTION,
-                         "Multiple actions for level %d/group %u on key %s; "
-                         "Using %s, ignoring %s\n",
-                         i + 1, group + 1, KeyNameText(info->ctx, key_name),
-                         ActionTypeText(use->type),
-                         ActionTypeText(ignore->type));
-            }
-
-            intoLevel->action = *use;
-        }
-
         if (fromLevel->num_syms == 0) {
             /* it's empty for consistency with other comparisons */
         }
         else if (intoLevel->num_syms == 0) {
             intoLevel->num_syms = fromLevel->num_syms;
-            if (fromLevel->num_syms > 1)
-                intoLevel->u.syms = fromLevel->u.syms;
-            else
-                intoLevel->u.sym = fromLevel->u.sym;
+            if (fromLevel->num_syms > 1) {
+                intoLevel->s.syms = fromLevel->s.syms;
+                intoLevel->a.actions = fromLevel->a.actions;
+            } else {
+                intoLevel->s.sym = fromLevel->s.sym;
+                intoLevel->a.action = fromLevel->a.action;
+            }
             fromLevel->num_syms = 0;
         }
-        else if (!XkbLevelsSameSyms(fromLevel, intoLevel)) {
-            if (report) {
-                log_warn(info->ctx,
-                         XKB_WARNING_CONFLICTING_KEY_SYMBOL,
-                         "Multiple symbols for level %d/group %u on key %s; "
-                         "Using %s, ignoring %s\n",
-                         i + 1, group + 1, KeyNameText(info->ctx, key_name),
-                         (clobber ? "from" : "to"),
-                         (clobber ? "to" : "from"));
+        else {
+            bool actions_replaced = false;
+            /* Handle keysyms */
+            if (!XkbLevelsSameSyms(fromLevel, intoLevel)) {
+                if (report) {
+                    log_warn(info->ctx,
+                            XKB_WARNING_CONFLICTING_KEY_SYMBOL,
+                            "Multiple symbols for level %d/group %u on key %s; "
+                            "Using %s, ignoring %s\n",
+                            i + 1, group + 1, KeyNameText(info->ctx, key_name),
+                            (clobber ? "from" : "to"),
+                            (clobber ? "to" : "from"));
+                }
+
+                if (clobber) {
+                    // FIXME: Check impact of replacing actions here
+                    ClearLevelInfo(intoLevel);
+                    intoLevel->num_syms = fromLevel->num_syms;
+                    if (fromLevel->num_syms > 1) {
+                        if (report) {
+                            log_warn(
+                                info->ctx,
+                                XKB_WARNING_CONFLICTING_KEY_ACTION,
+                                "Multiple actions for level %d/group %u on key %s; "
+                                "Using from, ignoring to\n",
+                                i + 1, group + 1, KeyNameText(info->ctx, key_name));
+                        }
+                        intoLevel->s.syms = fromLevel->s.syms;
+                        intoLevel->a.actions = fromLevel->a.actions;
+                    } else {
+                        if (report) {
+                            log_warn(info->ctx,
+                                    XKB_WARNING_CONFLICTING_KEY_ACTION,
+                                    "Multiple actions for level %d/group %u on key %s; "
+                                    "Using %s, ignoring %s\n",
+                                    i + 1, group + 1, KeyNameText(info->ctx, key_name),
+                                    ActionTypeText(fromLevel->a.action.type),
+                                    ActionTypeText(intoLevel->a.action.type));
+                        }
+                        intoLevel->s.sym = fromLevel->s.sym;
+                        intoLevel->a.action = fromLevel->a.action;
+                    }
+                    fromLevel->num_syms = 0;
+                    actions_replaced = true;
+                }
             }
 
-            if (clobber) {
-                ClearLevelInfo(intoLevel);
-                intoLevel->num_syms = fromLevel->num_syms;
-                if (fromLevel->num_syms > 1)
-                    intoLevel->u.syms = fromLevel->u.syms;
-                else
-                    intoLevel->u.sym = fromLevel->u.sym;
-                fromLevel->num_syms = 0;
+            /* Handle actions */
+            if (actions_replaced) {
+                /* Already handled, included incompatible actions count */
+            } else if (XkbLevelHasNoAction(fromLevel)) {
+                /* it's empty for consistency with other comparisons */
+            } else if (XkbLevelHasNoAction(intoLevel)) {
+                if (fromLevel->num_syms == 1) {
+                    intoLevel->a.action = fromLevel->a.action;
+                } else {
+                    intoLevel->a.actions = fromLevel->a.actions;
+                }
+            } else {
+                /* Incompatible actions */
+                // FIXME it’s the same count
+                unsigned int count = (clobber ? fromLevel->num_syms : intoLevel->num_syms);
+                if (count == 1) {
+                    union xkb_action *use, *ignore;
+                    use = (clobber ? &fromLevel->a.action : &intoLevel->a.action);
+                    ignore = (clobber ? &intoLevel->a.action : &fromLevel->a.action);
+
+                    if (report) {
+                        log_warn(info->ctx,
+                                XKB_WARNING_CONFLICTING_KEY_ACTION,
+                                "Multiple actions for level %d/group %u on key %s; "
+                                "Using %s, ignoring %s\n",
+                                i + 1, group + 1, KeyNameText(info->ctx, key_name),
+                                ActionTypeText(use->type),
+                                ActionTypeText(ignore->type));
+                    }
+
+                    if (intoLevel->num_syms > 1)
+                        free(intoLevel->a.actions);
+                    intoLevel->a.action = *use;
+                } else {
+                    if (report) {
+                        log_warn(
+                            info->ctx,
+                            XKB_WARNING_CONFLICTING_KEY_ACTION,
+                            "Multiple actions for level %d/group %u on key %s; "
+                            "%s\n",
+                            i + 1, group + 1, KeyNameText(info->ctx, key_name),
+                            clobber ? "Using from, ignoring to"
+                                    : "Using to, ignoring from");
+                    }
+                    if (clobber) {
+                        if (intoLevel->num_syms > 1)
+                            free(intoLevel->a.actions);
+                        intoLevel->a.actions = fromLevel->a.actions;
+                    }
+                }
             }
         }
     }
@@ -722,22 +786,35 @@ AddSymbolsToKey(SymbolsInfo *info, KeyInfo *keyi, ExprDef *arrayNdx,
         struct xkb_level *leveli = &darray_item(groupi->levels, i);
 
         sym_index = darray_item(value->keysym_list.symsMapIndex, i);
-        leveli->num_syms = darray_item(value->keysym_list.symsNumEntries, i);
-        if (leveli->num_syms > 1)
-            leveli->u.syms = calloc(leveli->num_syms, sizeof(*leveli->u.syms));
-
-        for (unsigned j = 0; j < leveli->num_syms; j++) {
-            xkb_keysym_t keysym = darray_item(value->keysym_list.syms,
-                                              sym_index + j);
-
-            if (leveli->num_syms == 1) {
-                if (keysym == XKB_KEY_NoSymbol)
-                    leveli->num_syms = 0;
-                else
-                    leveli->u.sym = keysym;
+        if (leveli->num_syms == 0) {
+            leveli->num_syms = darray_item(value->keysym_list.symsNumEntries, i);
+            if (leveli->num_syms > 1) {
+                /* Allocate keysyms */
+                leveli->s.syms = calloc(leveli->num_syms, sizeof(*leveli->s.syms));
+                /* Initialize actions */
+                leveli->a.actions = calloc(leveli->num_syms, sizeof(*leveli->a.actions));
+                static const union xkb_action dummy = { .type = ACTION_TYPE_NONE };
+                for (unsigned j = 0; j < leveli->num_syms; j++) {
+                    leveli->a.actions[j] = dummy;
+                }
             }
-            else if (leveli->num_syms > 1) {
-                leveli->u.syms[j] = keysym;
+        } else if (leveli->num_syms != darray_item(value->keysym_list.symsMapIndex, i)) {
+            log_err(info->ctx,
+                    XKB_LOG_MESSAGE_NO_ID, // FIXME
+                    "Symbols for key %s, group %u, level %u must have the same "
+                    "number of keysyms than the corresponding actions. "
+                    "Ignoring duplicate definition\n",
+                    KeyInfoText(info, keyi), ndx + 1, i + 1);
+            return false;
+        }
+
+        if (leveli->num_syms <= 1) {
+            leveli->s.sym = darray_item(value->keysym_list.syms, sym_index);
+            if (leveli->s.sym == XKB_KEY_NoSymbol)
+                leveli->num_syms = 0;
+        } else {
+            for (unsigned j = 0; j < leveli->num_syms; j++) {
+                leveli->s.syms[j] = darray_item(value->keysym_list.syms, sym_index + j);
             }
         }
     }
@@ -751,8 +828,7 @@ AddActionsToKey(SymbolsInfo *info, KeyInfo *keyi, ExprDef *arrayNdx,
 {
     xkb_layout_index_t ndx;
     GroupInfo *groupi;
-    unsigned int nActs;
-    ExprDef *act;
+    xkb_level_index_t nLevels;
 
     if (!GetGroupIndex(info, keyi, arrayNdx, ACTIONS, &ndx))
         return false;
@@ -779,27 +855,53 @@ AddActionsToKey(SymbolsInfo *info, KeyInfo *keyi, ExprDef *arrayNdx,
         return false;
     }
 
-    nActs = 0;
-    for (act = value->actions.actions; act; act = (ExprDef *) act->common.next)
-        nActs++;
-
-    if (darray_size(groupi->levels) < nActs)
-        darray_resize0(groupi->levels, nActs);
+    nLevels = darray_size(value->actions.actionsMapIndex);
+    if (darray_size(groupi->levels) < nLevels)
+        darray_resize0(groupi->levels, nLevels);
 
     groupi->defined |= GROUP_FIELD_ACTS;
 
-    act = value->actions.actions;
-    for (unsigned i = 0; i < nActs; i++) {
-        union xkb_action *toAct = &darray_item(groupi->levels, i).action;
+    for (unsigned i = 0; i < nLevels; i++) {
+        unsigned int act_index;
+        struct xkb_level *leveli = &darray_item(groupi->levels, i);
 
-        if (!HandleActionDef(info->ctx, info->actions, &info->mods, act, toAct))
+        act_index = darray_item(value->actions.actionsMapIndex, i);
+        if (leveli->num_syms == 0) {
+            leveli->num_syms = darray_item(value->actions.actionsNumEntries, i);
+            if (leveli->num_syms > 1) {
+                /* Allocate actions */
+                leveli->a.actions = calloc(leveli->num_syms, sizeof(*leveli->a.actions));
+                /* Initialize keysyms */
+                leveli->s.syms = calloc(leveli->num_syms, sizeof(*leveli->s.syms));
+                for (unsigned j = 0; j < leveli->num_syms; j++) {
+                    leveli->s.syms[j] = XKB_KEY_NoSymbol;
+                }
+            }
+        } else if (leveli->num_syms != darray_item(value->actions.actionsNumEntries, i)) {
             log_err(info->ctx,
-                    XKB_ERROR_INVALID_VALUE,
-                    "Illegal action definition for %s; "
-                    "Action for group %u/level %u ignored\n",
+                    XKB_LOG_MESSAGE_NO_ID, // FIXME
+                    "Actions for key %s, group %u, level %u must have the same "
+                    "count than the corresponding keysyms. "
+                    "Ignoring duplicate definition\n",
                     KeyInfoText(info, keyi), ndx + 1, i + 1);
+            return false;
+        }
 
-        act = (ExprDef *) act->common.next;
+        for (unsigned j = 0; j < leveli->num_syms; j++) {
+            ExprDef *act = darray_item(value->actions.actions, act_index + j);
+            union xkb_action *toAct;
+            if (leveli->num_syms == 1) {
+                toAct = &darray_item(groupi->levels, i).a.action;
+            } else {
+                toAct = &darray_item(groupi->levels, i).a.actions[j];
+            }
+            if (!HandleActionDef(info->ctx, info->actions, &info->mods, act, toAct))
+                log_err(info->ctx,
+                        XKB_ERROR_INVALID_VALUE,
+                        "Illegal action definition for %s; "
+                        "Action for group %u/level %u ignored\n",
+                        KeyInfoText(info, keyi), ndx + 1, i + 1);
+        }
     }
 
     return true;
@@ -1320,9 +1422,19 @@ FindKeyForSymbol(struct xkb_keymap *keymap, xkb_keysym_t sym)
                 if (group < key->num_groups &&
                     level < XkbKeyNumLevels(key, group)) {
                     got_one_group = got_one_level = true;
-                    if (key->groups[group].levels[level].num_syms == 1 &&
-                        key->groups[group].levels[level].u.sym == sym)
+                    // FIXME: why must we have only one keysym?
+                    // if (key->groups[group].levels[level].num_syms == 1 &&
+                    //     key->groups[group].levels[level].s.sym == sym)
+                    unsigned int num_syms = key->groups[group].levels[level].num_syms;
+                    if (num_syms > 1) {
+                        for (unsigned int k = 0; k < num_syms; k++) {
+                            if (key->groups[group].levels[level].s.syms[k] == sym)
+                                return key;
+                        }
+                    } else if (num_syms &&
+                               key->groups[group].levels[level].s.sym == sym) {
                         return key;
+                    }
                 }
             }
             level++;
@@ -1355,9 +1467,9 @@ FindAutomaticType(struct xkb_context *ctx, GroupInfo *groupi)
     (darray_item(groupi->levels, level).num_syms == 0 ? \
         XKB_KEY_NoSymbol : \
      darray_item(groupi->levels, level).num_syms == 1 ? \
-        darray_item(groupi->levels, level).u.sym : \
+        darray_item(groupi->levels, level).s.sym : \
      /* num_syms > 1 */ \
-        darray_item(groupi->levels, level).u.syms[0])
+        darray_item(groupi->levels, level).s.syms[0])
 
     if (width == 1 || width <= 0)
         return xkb_atom_intern_literal(ctx, "ONE_LEVEL");

--- a/test/common.c
+++ b/test/common.c
@@ -428,3 +428,33 @@ test_compile_rules(struct xkb_context *context, const char *rules,
 
     return keymap;
 }
+
+struct xkb_keymap *
+test_compile_rules_with_flags(struct xkb_context *context, const char *rules,
+                              const char *model, const char *layout,
+                              const char *variant, const char *options,
+                              enum xkb_keymap_compile_flags flags)
+{
+    struct xkb_keymap *keymap;
+    struct xkb_rule_names rmlvo = {
+        .rules = isempty(rules) ? NULL : rules,
+        .model = isempty(model) ? NULL : model,
+        .layout = isempty(layout) ? NULL : layout,
+        .variant = isempty(variant) ? NULL : variant,
+        .options = isempty(options) ? NULL : options
+    };
+
+    if (!rules && !model && !layout && !variant && !options)
+        keymap = xkb_keymap_new_from_names(context, NULL, flags);
+    else
+        keymap = xkb_keymap_new_from_names(context, &rmlvo, flags);
+
+    if (!keymap) {
+        fprintf(stderr,
+                "Failed to compile RMLVO: '%s', '%s', '%s', '%s', '%s'\n",
+                rules, model, layout, variant, options);
+        return NULL;
+    }
+
+    return keymap;
+}

--- a/test/data/symbols/awesome
+++ b/test/data/symbols/awesome
@@ -19,8 +19,14 @@ xkb_symbols "awesome" {
     key <AC01> { [ a,  A,          Return,     Return      ] };
     key <AC02> { [ s,  S,          Left] };
     key <AC03> { [ d,  D,          Down] };
-    key <AC04> { [ f,  F,          Righ] };
+    key <AC04> { [ f,  F,          Right] };
     key <AC05> { [ g,  G,          BackSpace,  BackSpace   ] };
 
     key <AB05> { [ b,  B,          Delete,     Delete      ] };
+
+    key <LCTL> {
+        groupsRedirect=0,
+        symbols[1] = [ {Control_L,                  ISO_First_Group    } ],
+        actions[1] = [ {SetMods(modifiers=Control), SetGroup(group=-4) } ]
+    };
 };

--- a/test/keymap.c
+++ b/test/keymap.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "evdev-scancodes.h"
 #include "test.h"
 #include "keymap.h"
 
@@ -230,6 +231,80 @@ test_multiple_keysyms_per_level(void)
     xkb_context_unref(context);
 }
 
+static void
+test_multiple_actions_per_level(void)
+{
+    struct xkb_context *context = test_get_context(0);
+    struct xkb_keymap *keymap;
+    xkb_keycode_t kc;
+    int keysyms_count;
+    const xkb_layout_index_t first_layout = 0;
+    const xkb_keysym_t *keysyms;
+    xkb_mod_index_t ctrl;
+    xkb_layout_index_t layout;
+    xkb_mod_mask_t base_mods;
+
+    assert(context);
+
+    keymap = test_compile_rules_with_flags(
+        context, "evdev", "pc104", "awesome,cz", NULL, "grp:menu_toggle",
+        XKB_KEYMAP_COMPILE_RANGE_REDIRECT_TO_0);
+    assert(keymap);
+
+    ctrl = xkb_keymap_mod_get_index(keymap, XKB_MOD_NAME_CTRL);
+
+    kc = xkb_keymap_key_by_name(keymap, "LCTL");
+    keysyms_count = xkb_keymap_key_get_syms_by_level(keymap, kc, first_layout, 0, &keysyms);
+    assert(keysyms_count == 2);
+    assert(keysyms[0] == XKB_KEY_Control_L);
+    assert(keysyms[1] == XKB_KEY_ISO_First_Group);
+
+    struct xkb_state *state = xkb_state_new(keymap);
+    assert(state);
+    layout = xkb_state_key_get_layout(state, KEY_LEFTCTRL + EVDEV_OFFSET);
+    assert(layout == 0);
+    xkb_state_update_key(state, KEY_LEFTCTRL + EVDEV_OFFSET, XKB_KEY_DOWN);
+    base_mods = xkb_state_serialize_mods(state, XKB_STATE_MODS_DEPRESSED);
+    assert(base_mods == (1U << ctrl));
+    layout = xkb_state_key_get_layout(state, XKB_KEY_2 + EVDEV_OFFSET);
+    assert(layout == 0);
+    xkb_state_update_key(state, KEY_LEFTCTRL + EVDEV_OFFSET, XKB_KEY_UP);
+    base_mods = xkb_state_serialize_mods(state, XKB_STATE_MODS_DEPRESSED);
+    assert(base_mods == 0);
+    layout = xkb_state_key_get_layout(state, XKB_KEY_2 + EVDEV_OFFSET);
+    assert(layout == 0);
+    xkb_state_update_key(state, KEY_COMPOSE + EVDEV_OFFSET, XKB_KEY_DOWN);
+    xkb_state_update_key(state, KEY_COMPOSE + EVDEV_OFFSET, XKB_KEY_UP);
+    layout = xkb_state_key_get_layout(state, XKB_KEY_2 + EVDEV_OFFSET);
+    assert(layout == 1);
+    xkb_state_update_key(state, KEY_LEFTCTRL + EVDEV_OFFSET, XKB_KEY_DOWN);
+    base_mods = xkb_state_serialize_mods(state, XKB_STATE_MODS_DEPRESSED);
+    assert(base_mods == (1U << ctrl));
+    layout = xkb_state_key_get_layout(state, XKB_KEY_2 + EVDEV_OFFSET);
+    assert(layout == 0);
+    xkb_state_update_key(state, KEY_LEFTCTRL + EVDEV_OFFSET, XKB_KEY_UP);
+    base_mods = xkb_state_serialize_mods(state, XKB_STATE_MODS_DEPRESSED);
+    assert(base_mods == 0);
+    layout = xkb_state_key_get_layout(state, XKB_KEY_2 + EVDEV_OFFSET);
+    assert(layout == 1);
+    xkb_state_unref(state);
+
+    assert(test_key_seq(keymap,
+                        KEY_2,        BOTH, XKB_KEY_2,         NEXT,
+                        KEY_LEFTCTRL, DOWN, XKB_KEY_Control_L, XKB_KEY_ISO_First_Group, NEXT,
+                        KEY_2,        BOTH, XKB_KEY_2,         NEXT,
+                        KEY_LEFTCTRL, UP,   XKB_KEY_Control_L, XKB_KEY_ISO_First_Group, NEXT,
+                        KEY_COMPOSE,  BOTH, XKB_KEY_ISO_Next_Group, NEXT,
+                        KEY_2,        BOTH, XKB_KEY_ecaron,    NEXT,
+                        KEY_LEFTCTRL, DOWN, XKB_KEY_Control_L, XKB_KEY_ISO_First_Group, NEXT,
+                        KEY_2,        BOTH, XKB_KEY_2,         NEXT,
+                        KEY_LEFTCTRL, UP,   XKB_KEY_Control_L, XKB_KEY_ISO_First_Group, NEXT,
+                        KEY_2,        BOTH, XKB_KEY_ecaron,    FINISH));
+
+    xkb_keymap_unref(keymap);
+    xkb_context_unref(context);
+}
+
 int
 main(void)
 {
@@ -239,6 +314,7 @@ main(void)
     test_keymap();
     test_numeric_keysyms();
     test_multiple_keysyms_per_level();
+    test_multiple_actions_per_level();
 
     return 0;
 }

--- a/test/stringcomp.c
+++ b/test/stringcomp.c
@@ -88,6 +88,10 @@ main(int argc, char *argv[])
     /* Now test that the dump of the dump is equal to the dump! */
     dump2 = xkb_keymap_get_as_string(keymap, XKB_KEYMAP_USE_ORIGINAL_FORMAT);
     assert(dump2);
+    if (!streq(dump, dump2)) {
+        fprintf(stderr, "*** dump (%lu) ***\n%s\n", strlen(dump), dump);
+        fprintf(stderr, "*** dump2 (%lu) ***\n%s\n", strlen(dump2), dump2);
+    }
     assert(streq(dump, dump2));
 
     /* Test response to invalid formats and flags. */

--- a/test/test.h
+++ b/test/test.h
@@ -102,6 +102,11 @@ test_compile_rules(struct xkb_context *context, const char *rules,
                    const char *model, const char *layout, const char *variant,
                    const char *options);
 
+struct xkb_keymap *
+test_compile_rules_with_flags(struct xkb_context *context, const char *rules,
+                              const char *model, const char *layout,
+                              const char *variant, const char *options,
+                              enum xkb_keymap_compile_flags flags);
 
 #ifdef _WIN32
 #define setenv(varname, value, overwrite) _putenv_s((varname), (value))


### PR DESCRIPTION
This makes **1 keysym == 1 action**, which seems both useful and more intuitive when using multiple keysyms per level.

The motivation of this new feature are:
- Make multiple keysyms per level more intuitive.
- Explore how to fix the issue with shortcuts in multi-layout settings (see the [`xkeyboard-config` issue](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/issues/416)).

  The idea is to use e.g.:

  ```c
  key <LCTL> {
        symbols[1] = [ {Control_L,                  ISO_First_Group    } ],
        actions[1] = [ {SetMods(modifiers=Control), SetGroup(group=-4) } ]
  };
  ```

  in order to switch temporarily to a reference layout in order to get the same shortcuts on every layout.

  See the `xkeyboard-config` MR “[Add option shortcuts:qwerty](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/merge_requests/717#note_2484076)”.

This is quite a big change, because it breaks the design “1 action per level”.

This is WIP because there might be lots of corner cases.

I will try to break this into smaller commits, although the nature of the change makes it difficult to have smaller commits that compiles.

Fixes #486