### PR TITLE
Enable out-of-range group action configuration

### DIFF
--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -993,6 +993,33 @@ char *
 xkb_keymap_get_as_string(struct xkb_keymap *keymap,
                          enum xkb_keymap_format format);
 
+/**
+ * Set the out-of-range layout action to “redirect into range”:
+ *
+ * - If the effective layout is invalid, it is set to the given layout.
+ * - If the given layout is invalid, it is set to the first one (0).
+ *
+ * @memberof xkb_keymap
+ * @sa xkb_keymap_set_out_of_range_layout_clamp
+ */
+void
+xkb_keymap_set_out_of_range_layout_redirect(struct xkb_keymap *keymap,
+                                            xkb_layout_index_t layout);
+
+/**
+ * Set the out-of-range layout action to “clamp into range”: if the effective
+ * layout is invalid, it is set to nearest valid layout:
+ *
+ * - effective layout larger than the highest supported layout are mapped to
+ *   the highest supported layout;
+ * - effective layout less than 0 are mapped to 0.
+ *
+ * @memberof xkb_keymap
+ * @sa xkb_keymap_set_out_of_range_layout_redirect
+ */
+void
+xkb_keymap_set_out_of_range_layout_clamp(struct xkb_keymap *keymap);
+
 /** @} */
 
 /**

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -243,6 +243,20 @@ xkb_keymap_new_from_file(struct xkb_context *ctx,
     return keymap;
 }
 
+XKB_EXPORT void
+xkb_keymap_set_out_of_range_layout_redirect(struct xkb_keymap *keymap,
+                                            xkb_layout_index_t layout)
+{
+    keymap->out_of_range_group_action = RANGE_REDIRECT;
+    keymap->out_of_range_group_number = layout;
+}
+
+XKB_EXPORT void
+xkb_keymap_set_out_of_range_layout_clamp(struct xkb_keymap *keymap)
+{
+    keymap->out_of_range_group_action = RANGE_SATURATE;
+}
+
 XKB_EXPORT char *
 xkb_keymap_get_as_string(struct xkb_keymap *keymap,
                          enum xkb_keymap_format format)

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -370,6 +370,9 @@ struct xkb_keymap {
     enum xkb_keymap_format format;
 
     enum xkb_action_controls enabled_ctrls;
+    /* groups_wrap control */
+    enum xkb_range_exceed_type out_of_range_group_action;
+    xkb_layout_index_t out_of_range_group_number;
 
     xkb_keycode_t min_key_code;
     xkb_keycode_t max_key_code;

--- a/test/keyseq.c
+++ b/test/keyseq.c
@@ -402,6 +402,39 @@ main(void)
                         KEY_COMPOSE,   BOTH, XKB_KEY_ISO_Next_Group, NEXT,
                         KEY_H,         BOTH, XKB_KEY_h,              FINISH));
 
+    /* Out-of-range group action: redirect */
+    xkb_keymap_set_out_of_range_layout_redirect(keymap, 1);
+    assert(test_key_seq(keymap,
+                        KEY_H,         BOTH, XKB_KEY_h,              NEXT,
+                        KEY_LEFTSHIFT, DOWN, XKB_KEY_Shift_L,        NEXT,
+                        KEY_LEFTALT,   BOTH, XKB_KEY_ISO_Prev_Group, NEXT,
+                        KEY_LEFTSHIFT, UP,   XKB_KEY_Shift_L,        NEXT,
+                        /* Negative group: redirect to second layout */
+                        KEY_H,         BOTH, XKB_KEY_hebrew_yod,     NEXT,
+                        KEY_COMPOSE,   BOTH, XKB_KEY_ISO_Next_Group, NEXT,
+                        KEY_H,         BOTH, XKB_KEY_Cyrillic_er,    NEXT,
+                        KEY_COMPOSE,   BOTH, XKB_KEY_ISO_Next_Group, NEXT,
+                        /* Greater that last group: redirect to second layout */
+                        KEY_H,         BOTH, XKB_KEY_hebrew_yod,     FINISH));
+
+    /* Out-of-range group action: clamp */
+    xkb_keymap_set_out_of_range_layout_clamp(keymap);
+    assert(test_key_seq(keymap,
+                        KEY_H,         BOTH, XKB_KEY_h,              NEXT,
+                        KEY_LEFTSHIFT, DOWN, XKB_KEY_Shift_L,        NEXT,
+                        KEY_LEFTALT,   BOTH, XKB_KEY_ISO_Prev_Group, NEXT,
+                        KEY_LEFTSHIFT, UP,   XKB_KEY_Shift_L,        NEXT,
+                        /* Negative group: redirect to first layout */
+                        KEY_H,         BOTH, XKB_KEY_h,              NEXT,
+                        KEY_COMPOSE,   BOTH, XKB_KEY_ISO_Next_Group, NEXT,
+                        KEY_H,         BOTH, XKB_KEY_hebrew_yod,     NEXT,
+                        KEY_COMPOSE,   BOTH, XKB_KEY_ISO_Next_Group, NEXT,
+                        KEY_H,         BOTH, XKB_KEY_Cyrillic_er,    NEXT,
+                        KEY_COMPOSE,   BOTH, XKB_KEY_ISO_Next_Group, NEXT,
+                        KEY_COMPOSE,   BOTH, XKB_KEY_ISO_Next_Group, NEXT,
+                        /* Greater that last group: redirect to last layout */
+                        KEY_H,         BOTH, XKB_KEY_Cyrillic_er,    FINISH));
+
     xkb_keymap_unref(keymap);
     keymap = test_compile_rules(ctx, "evdev", "", "us,il,ru", "",
                                 "grp:switch,grp:lswitch,grp:menu_toggle");

--- a/xkbcommon.map
+++ b/xkbcommon.map
@@ -119,3 +119,8 @@ global:
     xkb_compose_table_iterator_free;
     xkb_compose_table_iterator_next;
 } V_1.0.0;
+
+V_1.8.0 {
+    xkb_keymap_set_out_of_range_layout_redirect;
+    xkb_keymap_set_out_of_range_layout_clamp;
+} V_1.6.0;


### PR DESCRIPTION
In #487 I added keymap compile flags to configure the out-of-range group action, but it should be separate PR. Now I am also not sure the flags are the best API for this, so I added the following:

- `xkb_keymap_set_out_of_range_layout_redirect`
- `xkb_keymap_set_out_of_range_layout_clamp`

I have not added a function for the wrap action because it is the default, but we may need it for completion.

Another question is if it’s better to add only one function and expose `xkb_range_exceed_type`?

TODO:
- [ ] Changelog entry