### PR TITLE
CI: Add ruff formatting

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: '3.12'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade meson PyYAML
+          python -m pip install --upgrade meson PyYAML ruff
           sudo apt update
           sudo apt install -y \
             doxygen libxcb-xkb-dev valgrind ninja-build \
@@ -81,3 +81,6 @@ jobs:
           name: doxygen-docs
           path: |
             build/html/
+      - name: Ruff format
+        run:
+          ruff format --line-length=88 --check --diff .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,23 +2,21 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
   - id: check-yaml
   - id: check-added-large-files
-- repo: https://github.com/psf/black
-  rev: 24.2.0
-  hooks:
-  - id: black
-    args: ['--check', '--diff', '.']
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.2.2
+  rev: v0.5.1
   hooks:
   - id: ruff
     # ambiguous-variable-name (E741), line-too-long (E501)
     args: ['--ignore=E741,E501', '.']
+  - id: ruff-format
+    # 88 is the black default
+    args: ['--line-length=88', '--check', '--diff', '.',]
 # [TODO] C linter/formatter
 # Note: There is an old config file for uncrustify (https://uncrustify.sourceforge.net)
 # in the repo, but we may want to migrate to other modern style.

--- a/scripts/perfect_hash.py
+++ b/scripts/perfect_hash.py
@@ -75,6 +75,7 @@ If the procedure fails, G is cyclic, and we go back to step 2, replacing G
 with a new graph, and thereby discarding the vertex values from the failed
 attempt.
 """
+
 from __future__ import absolute_import, division, print_function
 
 import sys

--- a/test/symbols-leak-test.py
+++ b/test/symbols-leak-test.py
@@ -4,6 +4,7 @@
 If this fails, please update the appropriate .map file (adding new version
 nodes as needed).
 """
+
 import os
 import pathlib
 import re


### PR DESCRIPTION
- Drop `black` for pre-commit and use `ruff-format` instead (see [xkeyboard-config](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/merge_requests/647) move)
- Use `ruff format` in CI

Fixes #376