### PR TITLE
build: Check for --undefined-version support

### DIFF
--- a/changes/build/+meson_bump.breaking.md
+++ b/changes/build/+meson_bump.breaking.md
@@ -1,0 +1,1 @@
+Raised minimal meson version requirement to 0.58.

--- a/changes/build/481.bugfix.md
+++ b/changes/build/481.bugfix.md
@@ -1,0 +1,2 @@
+Gated the use of `--undefined-version` in the linker because it breaks on older
+GNU `ld`.

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ project(
         'warning_level=2',
         'b_lundef=true',
     ],
-    meson_version : '>= 0.52.0',
+    meson_version : '>= 0.58.0', # Released on May 2021
 )
 pkgconfig = import('pkgconfig')
 cc = meson.get_compiler('c')
@@ -270,9 +270,7 @@ dep_libxkbcommon = declare_dependency(
     link_with: libxkbcommon,
     include_directories: include_directories('include'),
 )
-if meson.version().version_compare('>= 0.54.0')
-    meson.override_dependency('xkbcommon', dep_libxkbcommon)
-endif
+meson.override_dependency('xkbcommon', dep_libxkbcommon)
 pkgconfig.generate(
     libxkbcommon,
     name: 'xkbcommon',
@@ -341,9 +339,7 @@ You can disable X11 support with -Denable-x11=false.''')
         link_with: libxkbcommon_x11,
         include_directories: include_directories('include'),
     )
-    if meson.version().version_compare('>= 0.54.0')
-        meson.override_dependency('xkbcommon-x11', dep_libxkbcommon_x11)
-    endif
+    meson.override_dependency('xkbcommon-x11', dep_libxkbcommon_x11)
     pkgconfig.generate(
         libxkbcommon_x11,
         name: 'xkbcommon-x11',
@@ -409,9 +405,7 @@ if get_option('enable-xkbregistry')
         link_with: libxkbregistry,
         include_directories: include_directories('include'),
     )
-    if meson.version().version_compare('>= 0.54.0')
-        meson.override_dependency('xkbregistry', dep_libxkbregistry)
-    endif
+    meson.override_dependency('xkbregistry', dep_libxkbregistry)
 endif
 
 man_pages = []

--- a/meson.build
+++ b/meson.build
@@ -142,10 +142,17 @@ configh_data.set('_CRT_NONSTDC_NO_DEPRECATE', 1)
 # Reduce unnecessary includes on MSVC.
 configh_data.set('WIN32_LEAN_AND_MEAN', 1)
 
+xkbcommon_map = meson.current_source_dir() / 'xkbcommon.map'
+
 # Supports -Wl,--version-script?
+if cc.has_link_argument('-Wl,--undefined-version')
+    extra_linker_args = ',--undefined-version'
+else
+    extra_linker_args = ''
+endif
 have_version_script = cc.links(
     'int main(){}',
-    args: '-Wl,--undefined-version,--version-script=' + meson.current_source_dir()/'xkbcommon.map',
+    args: f'-Wl,--version-script=@xkbcommon_map@@extra_linker_args@',
     name: '-Wl,--version-script',
 )
 
@@ -235,7 +242,7 @@ libxkbcommon_sources = [
 libxkbcommon_link_args = []
 libxkbcommon_link_deps = []
 if have_version_script
-    libxkbcommon_link_args += '-Wl,--version-script=' + meson.current_source_dir()/'xkbcommon.map'
+    libxkbcommon_link_args += f'-Wl,--version-script=@xkbcommon_map@'
     libxkbcommon_link_deps += 'xkbcommon.map'
 elif cc.get_argument_syntax() == 'msvc'
     libxkbcommon_def = custom_target('xkbcommon.def',


### PR DESCRIPTION
Gate the use of `--undefined-version` in the linker because it breaks on older GNU `ld`: https://gnats.netbsd.org/cgi-bin/query-pr-single.pl?number=58272.

Fixes #481

@glechapelain @eli-schwartz