### PR TITLE
Scan-build and covscan fixes

### DIFF
--- a/src/compose/dump.h
+++ b/src/compose/dump.h
@@ -45,7 +45,7 @@ escape_utf8_string_literal(const char *from)
 {
     const size_t length = strlen(from);
     /* Longest escape is converting ASCII character to "\xNN" */
-    char* to = calloc(4 * length + 1, sizeof(to));
+    char* to = calloc(4 * length + 1, sizeof(*to));
     if (!to)
         return NULL;
 

--- a/src/compose/table.c
+++ b/src/compose/table.c
@@ -37,7 +37,7 @@ xkb_compose_table_new(struct xkb_context *ctx,
 {
     char *resolved_locale;
     struct xkb_compose_table *table;
-    struct compose_node dummy;
+    struct compose_node dummy = {0};
 
     resolved_locale = resolve_locale(ctx, locale);
     if (!resolved_locale)

--- a/test/compose.c
+++ b/test/compose.c
@@ -896,6 +896,7 @@ test_encode_escape_sequences(struct xkb_context *ctx)
     char buf[1 + MAX_CODE_POINTS_COUNT * 4];
     for (int ascii = 1; ascii >= 0; ascii--) {
         for (size_t s = 0; s < SAMPLE_SIZE; s++) {
+            memset(buf, 0xab, sizeof(buf));
             /* Create the string */
             size_t length = 1 + (rand() % MAX_CODE_POINTS_COUNT);
             size_t c = 0;

--- a/test/compose.c
+++ b/test/compose.c
@@ -965,7 +965,8 @@ main(int argc, char *argv[])
 #ifdef __linux__
     const char *srcdir = getenv("top_srcdir");
     clearenv();
-    setenv("top_srcdir", srcdir, 1);
+    if (srcdir)
+        setenv("top_srcdir", srcdir, 1);
 #else
     unsetenv("XCOMPOSEFILE");
     unsetenv("XDG_CONFIG_HOME");

--- a/test/compose.c
+++ b/test/compose.c
@@ -952,7 +952,7 @@ main(int argc, char *argv[])
     if (argc == 2) {
         seed = atoi(argv[1]);
     } else {
-        seed = time(NULL);
+        seed = (int)time(NULL);
     }
     fprintf(stderr, "Seed for the pseudo-random generator: %d\n", seed);
     srand(seed);

--- a/test/keysym.c
+++ b/test/keysym.c
@@ -391,7 +391,7 @@ main(void)
         test_icu_case_mappings(ks);
 #endif
     }
-    iter = xkb_keysym_iterator_unref(iter);
+    xkb_keysym_iterator_unref(iter);
     assert(ks_prev == XKB_KEYSYM_MAX_ASSIGNED);
     assert(count == XKB_KEYSYM_UNICODE_MAX - XKB_KEYSYM_UNICODE_MIN + 1 + count_non_unicode);
 

--- a/test/registry.c
+++ b/test/registry.c
@@ -513,7 +513,7 @@ cmp_layouts(struct test_layout *tl, struct rxkb_layout *l)
         return false;
 
     iso3166 = rxkb_layout_get_iso3166_first(l);
-    for (size_t i = 0; i < sizeof(tl->iso3166); i++) {
+    for (size_t i = 0; i < ARRAY_SIZE(tl->iso3166); i++) {
         const char *iso = tl->iso3166[i];
         if (iso == NULL && iso3166 == NULL)
             break;
@@ -528,7 +528,7 @@ cmp_layouts(struct test_layout *tl, struct rxkb_layout *l)
         return false;
 
     iso639 = rxkb_layout_get_iso639_first(l);
-    for (size_t i = 0; i < sizeof(tl->iso639); i++) {
+    for (size_t i = 0; i < ARRAY_SIZE(tl->iso639); i++) {
         const char *iso = tl->iso639[i];
         if (iso == NULL && iso639 == NULL)
             break;

--- a/test/xvfb-wrapper.c
+++ b/test/xvfb-wrapper.c
@@ -152,7 +152,7 @@ x11_tests_run()
          t++)
         count++;
 
-    int rc;
+    int rc = 0;
     for (const struct test_function *t = &__start_test_func_sec;
          t < &__stop_test_func_sec;
          t++) {

--- a/tools/interactive-wayland.c
+++ b/tools/interactive-wayland.c
@@ -713,7 +713,7 @@ usage(FILE *fp, char *progname)
 int
 main(int argc, char *argv[])
 {
-    int ret;
+    int ret = 0;
     struct interactive_dpy inter;
     struct wl_registry *registry;
     const char *locale;

--- a/tools/interactive-x11.c
+++ b/tools/interactive-x11.c
@@ -370,7 +370,7 @@ main(int argc, char *argv[])
     uint8_t first_xkb_event;
     int32_t core_kbd_device_id;
     struct xkb_context *ctx;
-    struct keyboard core_kbd;
+    struct keyboard core_kbd = {0};
     const char *locale;
     struct xkb_compose_table *compose_table = NULL;
 


### PR DESCRIPTION
This fixes a bunch of minor covscan/scan-build complaints, mostly in the test code.

I think there's only one legitimate bug in `test/registry.c` where we need `sizeof()` -> `ARRAY_SIZE()`. The rest is mostly to shut up the analyziers.

There are still a few left over but they're deep in the parsing code and I couldn't immediately tell if they were actual bugs (I think they are false positives).