### PR TITLE
rules: Fix wild card handling

### DIFF
--- a/changes/api/497.bugfix.md
+++ b/changes/api/497.bugfix.md
@@ -1,0 +1,4 @@
+rules: Fix handling of wild card `*` to match the behavior of `libxkbfile`.
+Previously `*` would match any value, even empty one. Now:
+- For `model` and `options`: *always* match.
+- For `layout` and `variant`: match any *non-empty* value.

--- a/doc/rules-format.md
+++ b/doc/rules-format.md
@@ -108,8 +108,10 @@ rules.
 @anchor rules-wildcard-def
 Along with matching values by simple string equality and for
 membership in a [group] defined previously, rules may also contain
-**wildcard** values “\*” which *always match*. These usually appear
-near the end of a rule set to set *default* values.
+**wildcard** values “\*” with the following behavior:
+- For `model` and `options`: *always* match.
+- For `layout` and `variant`: match any *non-empty* value.
+These usually appear near the end of a rule set to set *default* values.
 
 ```c
 ! layout = keycodes

--- a/test/data/rules/groups
+++ b/test/data/rules/groups
@@ -13,6 +13,10 @@
   $layout_group *       = my_symbols+%(v)
   *             *       = default_symbols
 
+! layout        = symbols
+  $layout_group = my_symbols+%(v)
+  *             = default_symbols
+
 ! model         = types
   *             = default_types
 

--- a/test/data/rules/wildcard
+++ b/test/data/rules/wildcard
@@ -1,0 +1,32 @@
+! model = keycodes
+  *     = evdev
+
+! model = geometry
+  *     = pc(pc104)
+
+! layout variant = symbols
+  *      *       = pc+%l%(v)
+
+! layout[1] variant[1] = symbols
+  *         *          = pc+%l[1]%(v[1])
+
+! layout[2] variant[2] = symbols
+  *         *          = +%l[2]%(v[2]):2
+
+! layout[3] variant[3] = symbols
+  *         *          = +%l[3]%(v[3]):3
+
+! layout[4] variant[3] = symbols
+  *         *          = +%l[4]%(v[4]):4
+
+! model layout = compat
+  *     *      = complete
+
+! model layout[1] = compat
+  *     *         = complete
+
+! model layout[2] = compat
+  *     *         = complete
+
+! model = types
+  *     = complete


### PR DESCRIPTION
The handling of wild card `*` is different in libxkbfile and X server: wild card matches empty strings for model and option but not for layout nor variant, while in libxkbcommon wild cards always match empty strings.

See:
- https://gitlab.freedesktop.org/xorg/lib/libxkbfile/-/blob/bf985c68acb1244f51ec91414532a2347fbc1c4c/src/maprules.c#L687
- https://gitlab.freedesktop.org/xorg/lib/libxkbfile/-/blob/bf985c68acb1244f51ec91414532a2347fbc1c4c/src/maprules.c#L712

The difference of handling between the components is unfortunately not documented, but we should follow the behavior of the original implementations for consistency.

- Fixed by implementing the same behavior than libxkbfile.
- Added tests and fixed failing tests.

Fixes #497