### PR TITLE
Add XKB_LED_NAME_COMPOSE and XKB_LED_NAME_KANA

### DIFF
--- a/changes/api/+compose-and-kana-led-names.features.md
+++ b/changes/api/+compose-and-kana-led-names.features.md
@@ -1,0 +1,4 @@
+`xkbcommon-names.h`: Add `XKB_LED_NAME_COMPOSE` and `XKB_LED_NAME_KANA` definitions
+to cover all LEDs defined in [USB HID](https://usb.org/sites/default/files/hid1_11.pdf).
+
+Contributed by Martin Rys

--- a/include/xkbcommon/xkbcommon-names.h
+++ b/include/xkbcommon/xkbcommon-names.h
@@ -31,6 +31,7 @@
  * @brief Predefined names for common modifiers and LEDs.
  */
 
+/* Real modifiers names are hardcoded in libxkbcommon */
 #define XKB_MOD_NAME_SHIFT      "Shift"
 #define XKB_MOD_NAME_CAPS       "Lock"
 #define XKB_MOD_NAME_CTRL       "Control"
@@ -38,8 +39,13 @@
 #define XKB_MOD_NAME_NUM        "Mod2"
 #define XKB_MOD_NAME_LOGO       "Mod4"
 
-#define XKB_LED_NAME_CAPS       "Caps Lock"
+/* LEDs names are encoded in xkeyboard-config, in the keycodes and compat files.
+ * They have been stable since the beginning of the project and are unlikely to
+ * ever change. */
 #define XKB_LED_NAME_NUM        "Num Lock"
+#define XKB_LED_NAME_CAPS       "Caps Lock"
 #define XKB_LED_NAME_SCROLL     "Scroll Lock"
+#define XKB_LED_NAME_COMPOSE    "Compose"
+#define XKB_LED_NAME_KANA       "Kana"
 
 #endif


### PR DESCRIPTION
The end goal is to be able to press `Num Lock`, `Caps Lock`, `Scroll Lock`, `Compose` or `Kana` and have either of the 5 LEDs on my QMK keyboard light up.

I could use a bit of help here.

This is a continuation of https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/990 and is directly related to the [current WIP for kwin](https://invent.kde.org/plasma/kwin/-/merge_requests/5627) for adding the same two LED keys.

[HID spec](https://usb.org/sites/default/files/hid1_11.pdf) defines five LEDs, but only the first 3 are currently supported by XKB and most of the Linux tooling:

![image](https://gitlab.freedesktop.org/-/project/147/uploads/4e8c6b9467e6ae6caf4b438fa23b5c6c/image.png)

I am not familiar with XKB, where else do I need to put the necessary definitions?