### PR TITLE
xkbcli how-to-type: Enhance arguments parsing & doc

### DIFF
--- a/changes/tools/+how-to-type-format.feature.md
+++ b/changes/tools/+how-to-type-format.feature.md
@@ -1,0 +1,11 @@
+`xkbcli how-to-type`: added new input formats and their corresponding documentation.
+
+*Unicode code points* can be passed in the following formats:
+- Literal character (requires UTF-8 character encoding of the terminal);
+- Decimal number;
+- Hexadecimal number: either `0xNNNN` or `U+NNNN`.
+
+*Keysyms* can to be passed in the following formats:
+- Decimal number;
+- Hexadecimal number: `0xNNNN`;
+- Name.

--- a/meson.build
+++ b/meson.build
@@ -753,7 +753,13 @@ test(
 )
 test(
     'utf8',
-    executable('test-utf8', 'test/utf8.c', dependencies: test_dep),
+    executable(
+        'test-utf8',
+        'test/utf8.c',
+        'src/utf8-decoding.c',
+        'src/utf8-decoding.h',
+        dependencies: test_dep
+    ),
     env: test_env,
 )
 test(

--- a/meson.build
+++ b/meson.build
@@ -518,6 +518,8 @@ if build_tools
     # Tool: how-to-type
     executable('xkbcli-how-to-type',
                'tools/how-to-type.c',
+               'src/utf8-decoding.c',
+               'src/utf8-decoding.h',
                dependencies: tools_dep,
                install: true,
                install_dir: dir_libexec)

--- a/src/utf8-decoding.c
+++ b/src/utf8-decoding.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2024 Pierre Le Marre <dev@wismill.eu>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "config.h"
+
+#include "utf8-decoding.h"
+
+/* Array mapping the leading byte to the length of a UTF-8 sequence.
+ * A value of zero indicates that the byte can not begin a UTF-8 sequence. */
+static const uint8_t utf8_sequence_length_by_leading_byte[256] = {
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 0x00-0x0F */
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 0x10-0x1F */
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 0x20-0x2F */
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 0x30-0x3F */
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 0x40-0x4F */
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 0x50-0x5F */
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 0x60-0x6F */
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 0x70-0x7F */
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0x80-0x8F */
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0x90-0x9F */
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0xA0-0xAF */
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0xB0-0xBF */
+    0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, /* 0xC0-0xCF */
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, /* 0xD0-0xDF */
+    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, /* 0xE0-0xEF */
+    4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0xF0-0xFF */
+};
+
+/* Length of next utf-8 sequence */
+uint8_t
+utf8_sequence_length(const char *s)
+{
+    return utf8_sequence_length_by_leading_byte[(unsigned char)s[0]];
+}
+
+/* Reads the next UTF-8 sequence in a string */
+uint32_t
+utf8_next_code_point(const char *s, size_t max_size, size_t *size_out)
+{
+    uint32_t cp = 0;
+    uint8_t len = utf8_sequence_length(s);
+    *size_out = 0;
+
+    if (!max_size || len > max_size)
+        return INVALID_UTF8_CODE_POINT;
+
+    /* Handle leading byte */
+    switch (len) {
+    case 1:
+        *size_out = 1;
+        return (uint32_t)s[0];
+    case 2:
+        cp = (uint32_t)s[0] & 0x1f;
+        break;
+    case 3:
+        cp = (uint32_t)s[0] & 0x0f;
+        break;
+    case 4:
+        cp = (uint32_t)s[0] & 0x07;
+        break;
+    default:
+        return INVALID_UTF8_CODE_POINT;
+    }
+
+    /* Process remaining bytes of the UTF-8 sequence */
+    for (size_t k = 1; k < len; k++) {
+        if (((uint32_t)s[k] & 0xc0) != 0x80)
+            return INVALID_UTF8_CODE_POINT;
+        cp <<= 6;
+        cp |= (uint32_t)s[k] & 0x3f;
+    }
+
+    /* Check surrogates */
+    if (cp >= 0xd800 && cp <= 0xdfff)
+        return INVALID_UTF8_CODE_POINT;
+
+    *size_out = len;
+    return cp;
+}

--- a/src/utf8-decoding.h
+++ b/src/utf8-decoding.h
@@ -1,0 +1,20 @@
+
+#ifndef UTF8_DECODING_H
+#define UTF8_DECODING_H
+
+#include "config.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Check if a char is the start of a UTF-8 sequence */
+#define is_utf8_start(c) (((c) & 0xc0) != 0x80)
+#define INVALID_UTF8_CODE_POINT UINT32_MAX
+
+uint8_t
+utf8_sequence_length(const char *s);
+
+uint32_t
+utf8_next_code_point(const char *s, size_t max_size, size_t *size_out);
+
+#endif

--- a/tools/xkbcli-how-to-type.1
+++ b/tools/xkbcli-how-to-type.1
@@ -1,24 +1,78 @@
-.Dd June 4, 2024
+.Dd September 11, 2024
 .Dt XKBCLI\-HOW\-TO\-TYPE 1
 .Os
 .
 .Sh NAME
 .Nm "xkbcli\-how\-to\-type"
-.Nd query how to type a given Unicode codepoint
+.Nd query how to type a given Unicode code point or keysym
 .
 .Sh SYNOPSIS
 .Nm
 .Op options
-.Ar codepoint/keysym
+.Ar character/codepoint/keysym
 .
 .Sh DESCRIPTION
 .Nm
 prints the key combinations (keycode + modifiers) in the keymap's layouts which
-would produce the given Unicode codepoint.
+would produce the given Unicode code point or keysym.
 .
+.Pp
+.Ar codepoint/keysym
+is either:
+.
+.Bl -bullet -compact
+.It
+a single character (requires a terminal which uses UTF-8 character encoding);
+.It
+a Unicode code point, interpreted as hexadecimal if prefixed with
+.Li 0x
+or
+.Li U+
+else as decimal;
+.
+.It
+a keysym if
+.Fl \-keysym
+is used: either a \fInumeric\fP value (hexadecimal if prefixed with
+.Li 0x
+else decimal) or a keysym \fIname\fP.
+.El
+.
+.Sh EXAMPLES
+.Bl -tag -width Ds
+.It Nm Fl \-layout Ar us 97
+.It Nm Fl \-layout Ar us 0x61
+.It Nm Fl \-layout Ar us U+0061
+.It Nm Fl \-layout Ar us a
+Print the key combinations that produce the letter "a"
+.Po
+decimal code point:
+.Ar 97 ,
+hexadecimal code point:
+.Ar 61
+.Pc
+in the default
+.Ar us
+layout.
+.It Nm Fl \-layout Ar us Fl \-keysym Ar 97
+.It Nm Fl \-layout Ar us Fl \-keysym Ar 0x61
+.It Nm Fl \-layout Ar us Fl \-keysym Ar a
+Print the key combinations that produce the keysym "a"
+.Po
+decimal code:
+.Ar 97 ,
+hexadecimal code:
+.Ar 61
+.Pc
+in the default
+.Ar us
+layout.
+.Be
+.
+.Sh OPTIONS
 .Bl -tag -width Ds
 .It Fl \-keysym
-Treat the argument as a keysym, not a Unicode codepoint
+Treat the argument as a keysym, not a Unicode code point
 .
 .It Fl \-rules Ar rules
 The XKB ruleset


### PR DESCRIPTION
Currently the positional parameter of the CLI is either a Unicode code
point or a keysym. However their respective format is not documented.

It turns out that there are multiple issues due to the use of `strtol`:
- Code points can be parsed as octal, decimal and hexadecimal while
  keysyms can only be parsed as hexadecimal. Some programs outputs
  keysyms in their decimal form (e.g. `wev`) so it is worth to bring
  symmetry with code points.
- Octal format is unusual for both and is triggered by leading zeros,
  which is unintuitive in this context.
- `U+NNNN` format is the standard format for Unicode code points but is
  not supported.
- Plain characters are not supported, e.g.: a, é, ß, Æ, γ, 🦆, etc.
  Although this is probably the easiest format for most users.

Fixed the issues above:
- Allow the code point to be passed exactly in the following formats:
  - Literal character (requires UTF-8 character encoding of the terminal);
  - Decimal number;
  - Hexadecimal number: either `0xNNNN` or `U+NNNN`.
- Allow the keysym to be passed exactly in the following formats:
  - Decimal number;
  - Hexadecimal number: either `0xNNNN`;
  - Name.
- Improve both `--help` message and manual.
