### PR TITLE
meson: Enable linker garbage collection

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -48,6 +48,15 @@ cflags = [
     '-Wwrite-strings',
     '-Wno-documentation-deprecated-sync',
 ]
+if get_option('buildtype') != 'debug'
+    cflags += [
+            '-ffunction-sections',
+            '-fdata-sections',
+    ]
+    base_link_args = ['-Wl,--gc-sections']
+else
+    base_link_args = []
+endif
 add_project_arguments(cc.get_supported_arguments(cflags), language: 'c')
 
 
@@ -259,7 +268,7 @@ libxkbcommon_sources = [
     'src/utils.c',
     'src/utils.h',
 ]
-libxkbcommon_link_args = []
+libxkbcommon_link_args = base_link_args
 libxkbcommon_link_deps = []
 if have_version_script
     libxkbcommon_link_args += f'-Wl,--version-script=@xkbcommon_map@'
@@ -328,7 +337,7 @@ You can disable X11 support with -Denable-x11=false.''')
         'src/atom.h',
         'src/atom.c',
     ]
-    libxkbcommon_x11_link_args = []
+    libxkbcommon_x11_link_args = base_link_args
     libxkbcommon_x11_link_deps = []
     if have_version_script
         libxkbcommon_x11_link_args += '-Wl,--version-script=' + meson.current_source_dir()/'xkbcommon-x11.map'
@@ -390,7 +399,7 @@ if get_option('enable-xkbregistry')
         'src/util-list.c',
         'src/util-mem.h',
     ]
-    libxkbregistry_link_args = []
+    libxkbregistry_link_args = base_link_args
     libxkbregistry_link_deps = []
     if have_version_script
         libxkbregistry_link_args += '-Wl,--version-script=' + meson.current_source_dir()/'xkbregistry.map'


### PR DESCRIPTION
Alternative to #427 [suggested](https://github.com/xkbcommon/libxkbcommon/pull/427#issuecomment-2336828098) by @bluetech.

Adapted from [systemd](https://github.com/systemd/systemd/blob/978e7d166c362302ce2302ac36efe9717d642d90/meson.build#L482-L489).

I am not an expert on the topic but got curious. From [gcc doc](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-ffunction-sections):

> Only use these options when there are significant benefits from doing so. When you specify these options, the assembler and linker create larger object and executable files and are also slower. These options affect code generation. **They prevent optimizations by the compiler and assembler** using relative locations inside a translation unit since the locations are unknown until link time. An example of such an optimization is relaxing calls to short call instructions.

How can we tell accurately if this is interesting for us and not affecting perf?