### PR TITLE
keysyms: Fix off-by-one XKB_KEYSYM_NAME_MAX_SIZE

### DIFF
--- a/changes/api/+fix-keysym-name-max-size.bugfix.md
+++ b/changes/api/+fix-keysym-name-max-size.bugfix.md
@@ -1,0 +1,1 @@
+Fixed `xkb_keymap_get_as_string` truncating the *4* longest keysyms names, such as `Greek_upsilonaccentdieresis`.

--- a/changes/tools/+fix-keysym-name-max-size.bugfix.md
+++ b/changes/tools/+fix-keysym-name-max-size.bugfix.md
@@ -1,0 +1,1 @@
+Fixed various tools truncating the *4* longest keysyms names, such as `Greek_upsilonaccentdieresis`.

--- a/src/keysym.h
+++ b/src/keysym.h
@@ -78,8 +78,12 @@
 #define XKB_KEYSYM_UNICODE_MAX    0x0110ffff
 /** Unicode version used for case mappings */
 #define XKB_KEYSYM_UNICODE_VERSION { 15, 1, 0, 0 }
-/** Maximum keysym name length */
-#define XKB_KEYSYM_NAME_MAX_SIZE  27
+/** Maximum keysym canonical name length, plus terminating NULL byte */
+#define XKB_KEYSYM_NAME_MAX_SIZE  28
+/** Longest keysym canonical name */
+#define XKB_KEYSYM_LONGEST_CANONICAL_NAME ISO_Discontinuous_Underline
+/** Longest keysym name */
+#define XKB_KEYSYM_LONGEST_NAME ISO_Discontinuous_Underline
 /** Maximum bytes to encode the Unicode representation of a keysym in UTF-8:
  * 4 bytes + NULL-terminating byte */
 #define XKB_KEYSYM_UTF8_MAX_SIZE  5

--- a/src/keysym.h.jinja
+++ b/src/keysym.h.jinja
@@ -78,8 +78,12 @@
 #define XKB_KEYSYM_UNICODE_MAX    0x0110ffff
 /** Unicode version used for case mappings */
 #define XKB_KEYSYM_UNICODE_VERSION { 15, 1, 0, 0 }
-/** Maximum keysym name length */
+/** Maximum keysym canonical name length, plus terminating NULL byte */
 #define XKB_KEYSYM_NAME_MAX_SIZE  {{ XKB_KEYSYM_NAME_MAX_SIZE }}
+/** Longest keysym canonical name */
+#define XKB_KEYSYM_LONGEST_CANONICAL_NAME {{ XKB_KEYSYM_LONGEST_CANONICAL_NAME }}
+/** Longest keysym name */
+#define XKB_KEYSYM_LONGEST_NAME {{ XKB_KEYSYM_LONGEST_NAME }}
 /** Maximum bytes to encode the Unicode representation of a keysym in UTF-8:
  * 4 bytes + NULL-terminating byte */
 #define XKB_KEYSYM_UTF8_MAX_SIZE  5

--- a/test/keysym.c
+++ b/test/keysym.c
@@ -474,10 +474,10 @@ main(void)
         char utf8[7];
         int needed = xkb_keysym_to_utf8(ks, utf8, sizeof(utf8));
         assert(0 <= needed && needed <= XKB_KEYSYM_UTF8_MAX_SIZE);
-        /* Check maximum name length */
+        /* Check maximum name length (`needed` does not include the ending NULL) */
         char name[XKB_KEYSYM_NAME_MAX_SIZE];
         needed = xkb_keysym_iterator_get_name(iter, name, sizeof(name));
-        assert(0 < needed && (size_t)needed <= sizeof(name));
+        assert(0 < needed && (size_t)needed <= sizeof(name) - 1);
         /* Test modifier keysyms */
         bool expected = test_modifier(ks);
         bool got = xkb_keysym_is_modifier(ks);
@@ -519,6 +519,12 @@ main(void)
     assert(test_string("thorn", 0x00fe));
     assert(test_string(" thorn", XKB_KEY_NoSymbol));
     assert(test_string("thorn ", XKB_KEY_NoSymbol));
+#define LONGEST_NAME STRINGIFY2(XKB_KEYSYM_LONGEST_NAME)
+#define XKB_KEY_LONGEST_NAME CONCAT2(XKB_KEY_, XKB_KEYSYM_LONGEST_NAME)
+    assert(test_string(LONGEST_NAME, XKB_KEY_LONGEST_NAME));
+#define LONGEST_CANONICAL_NAME STRINGIFY2(XKB_KEYSYM_LONGEST_CANONICAL_NAME)
+#define XKB_KEY_LONGEST_CANONICAL_NAME CONCAT2(XKB_KEY_, XKB_KEYSYM_LONGEST_CANONICAL_NAME)
+    assert(test_string(LONGEST_CANONICAL_NAME, XKB_KEY_LONGEST_CANONICAL_NAME));
 
     /* Decimal keysyms are not supported (digits are special cases) */
     assert(test_string("-1", XKB_KEY_NoSymbol));
@@ -586,6 +592,9 @@ main(void)
     assert(test_keysym(0x0, "NoSymbol"));
     assert(test_keysym(0x1008FE20, "XF86Ungrab"));
     assert(test_keysym(XKB_KEYSYM_UNICODE_OFFSET, "0x01000000"));
+    /* Longest names */
+    assert(test_keysym(XKB_KEY_LONGEST_NAME, LONGEST_NAME));
+    assert(test_keysym(XKB_KEY_LONGEST_CANONICAL_NAME, LONGEST_CANONICAL_NAME));
     /* Canonical names */
     assert(test_keysym(XKB_KEY_Henkan, "Henkan_Mode"));
     assert(test_keysym(XKB_KEY_ISO_Group_Shift, "Mode_switch"));


### PR DESCRIPTION
The constant did not account for the terminating `NULL` byte and this was sadly not caught by the tests.

Fixed the invalid value, the corresponding script and the tests.