### PR TITLE
tools: Add xkbcli dump-keymap-{wayland,x11}

### DIFF
--- a/changes/tools/+dump-keymap.feature.md
+++ b/changes/tools/+dump-keymap.feature.md
@@ -1,0 +1,3 @@
+Added `xkbcli dump-keymap-wayland` and `xkbcli dump-keymap-x11` debugging tools
+to dump a keymap from a Wayland compositor or a X server, similar to what
+`xkbcomp -xkb $DISPLAY -` does for X servers.

--- a/meson.build
+++ b/meson.build
@@ -544,7 +544,7 @@ if build_tools
                 install: false)
     endif
 
-    # Tool: interactive-x11
+    # Tools: interactive-x11
     if get_option('enable-x11')
         x11_tools_dep = declare_dependency(
             link_with: libxkbcommon_x11,
@@ -561,9 +561,18 @@ if build_tools
                    install_dir: dir_libexec)
         install_man('tools/xkbcli-interactive-x11.1')
         configh_data.set10('HAVE_XKBCLI_INTERACTIVE_X11', true)
+
+        executable('xkbcli-dump-keymap-x11',
+                   'tools/interactive-x11.c',
+                   dependencies: x11_tools_dep,
+                   c_args: ['-DKEYMAP_DUMP'],
+                   install: true,
+                   install_dir: dir_libexec)
+        install_man('tools/xkbcli-dump-keymap-x11.1')
+        configh_data.set10('HAVE_XKBCLI_DUMP_KEYMAP_X11', true)
     endif
 
-    # Tool: interactive-wayland
+    # Tools: interactive-wayland
     if get_option('enable-wayland')
         wayland_client_dep = dependency('wayland-client', version: '>=1.2.0', required: false)
         wayland_protocols_dep = dependency('wayland-protocols', version: '>=1.12', required: false)
@@ -598,6 +607,16 @@ You can disable the Wayland xkbcli programs with -Denable-wayland=false.''')
                    install_dir: dir_libexec)
         install_man('tools/xkbcli-interactive-wayland.1')
         configh_data.set10('HAVE_XKBCLI_INTERACTIVE_WAYLAND', true)
+
+        executable('xkbcli-dump-keymap-wayland',
+                   'tools/interactive-wayland.c',
+                   xdg_shell_sources,
+                   dependencies: [tools_dep, wayland_client_dep],
+                   c_args: ['-DKEYMAP_DUMP'],
+                   install: true,
+                   install_dir: dir_libexec)
+        install_man('tools/xkbcli-dump-keymap-wayland.1')
+        configh_data.set10('HAVE_XKBCLI_DUMP_KEYMAP_WAYLAND', true)
     endif
 
     # Tool: list

--- a/tools/xkbcli-dump-keymap-wayland.1
+++ b/tools/xkbcli-dump-keymap-wayland.1
@@ -1,0 +1,35 @@
+.Dd September 20, 2024
+.Dt XKBCLI\-DUMP\-KEYMAP\-WAYLAND 1
+.Os
+.
+.Sh NAME
+.Nm "xkbcli\-dump\-keymap\-wayland"
+.Nd Debugger for XKB keyboard keymaps on Wayland
+.
+.Sh SYNOPSIS
+.Nm
+.Op Ar options
+.
+.Sh DESCRIPTION
+.Nm
+is a commandline tool to dump XKB keymaps from Wayland compositor.
+.
+.Pp
+This requires a Wayland compositor to be running.
+.
+.Pp
+This is a debugging tool, its behavior or output is not guaranteed to be stable.
+.
+.Bl -tag -width Ds
+.It Fl \-help
+Print help and exit
+.
+.It Fl \-raw
+Print the raw keymap, without parsing it.
+.El
+.
+.Sh SEE ALSO
+.Xr xkbcli 1 ,
+.Xr xkbcli\-interactive\-wayland 1 ,
+.Xr xkbcli\-dump\-keymap\-x11 1 ,
+.Lk https://xkbcommon.org "The libxkbcommon online documentation"

--- a/tools/xkbcli-dump-keymap-x11.1
+++ b/tools/xkbcli-dump-keymap-x11.1
@@ -1,0 +1,32 @@
+.Dd September 20, 2024
+.Dt XKBCLI\-DUMP\-KEYMAP\-X11 1
+.Os
+.
+.Sh NAME
+.Nm "xkbcli\-dump\-keymap\-x11"
+.Nd Debugger for XKB keyboard keymaps on X11
+.
+.Sh SYNOPSIS
+.Nm
+.Op Ar options
+.
+.Sh DESCRIPTION
+.Nm
+is a commandline tool to dump XKB keymaps from X servers.
+.
+.Pp
+This requires an X server to be running.
+.
+.Pp
+This is a debugging tool, its behavior or output is not guaranteed to be stable.
+.
+.Bl -tag -width Ds
+.It Fl \-help
+Print help and exit
+.El
+.
+.Sh SEE ALSO
+.Xr xkbcli 1 ,
+.Xr xkbcli\-interactive\-x11 1 ,
+.Xr xkbcli\-dump\-keymap\-wayland 1 ,
+.Lk https://xkbcommon.org "The libxkbcommon online documentation"

--- a/tools/xkbcli-interactive-wayland.1
+++ b/tools/xkbcli-interactive-wayland.1
@@ -4,7 +4,7 @@
 .
 .Sh NAME
 .Nm "xkbcli\-interactive\-wayland"
-.Nd interactive debugger for X Keyboard keymaps
+.Nd interactive debugger for Wayland keyboard keymaps
 .
 .Sh SYNOPSIS
 .Nm

--- a/tools/xkbcli.c
+++ b/tools/xkbcli.c
@@ -61,6 +61,16 @@ usage(void)
            "    Interactive debugger for XKB keymaps for evdev\n"
            "\n"
 #endif
+#if HAVE_XKBCLI_DUMP_KEYMAP_WAYLAND
+           "  dump-keymap-wayland\n"
+           "    Dump a XKB keymap from a Wayland compositor\n"
+           "\n"
+#endif
+#if HAVE_XKBCLI_DUMP_KEYMAP_X11
+           "  dump-keymap-x11\n"
+           "    Dump a XKB keymap from an X server\n"
+           "\n"
+#endif
 #if HAVE_XKBCLI_COMPILE_KEYMAP
            "  compile-keymap\n"
            "    Compile an XKB keymap\n"


### PR DESCRIPTION
There is currently no easy way to dump a keymap from a Wayland compositor, such as `xkbcomp -xkb $DISPLAY -` could do for X servers.

As `xkbcomp` may not be intuitive, a corresponding tool for X servers would also be useful.

Add the tools `xkbcli-dump-keymap-{wayland,x11}` by tweaking the existing `xkbcli-interactive-{wayland,x11}` tools.

Commands names subject to bikeshedding.