### PR TITLE
Overlays

### DIFF
--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -1438,7 +1438,15 @@ enum xkb_state_component {
      *  Use this unless you explicitly care how the state came about. */
     XKB_STATE_LAYOUT_EFFECTIVE = (1 << 7),
     /** LEDs (derived from the other state components). */
-    XKB_STATE_LEDS = (1 << 8)
+    XKB_STATE_LEDS = (1 << 8),
+    /** TODO: doc */
+    XKB_STATE_OVERLAYS_SET = (1 << 9),
+    /** TODO: doc */
+    XKB_STATE_OVERLAYS_LOCKED = (1 << 10),
+    /** TODO: doc */
+    XKB_STATE_OVERLAYS_EFFECTIVE = (1 << 11),
+    /** TODO: doc */
+    XKB_STATE_OVERLAID_KEYS = (1 << 12),
 };
 
 /**
@@ -1501,6 +1509,9 @@ xkb_state_update_mask(struct xkb_state *state,
                       xkb_layout_index_t depressed_layout,
                       xkb_layout_index_t latched_layout,
                       xkb_layout_index_t locked_layout);
+
+xkb_keycode_t
+xkb_state_key_get_overlay_keycode(struct xkb_state *state, xkb_keycode_t kc);
 
 /**
  * Get the keysyms obtained from pressing a particular key in a given

--- a/meson.build
+++ b/meson.build
@@ -251,6 +251,7 @@ libxkbcommon_sources = [
     'src/messages-codes.h',
     'src/scanner-utils.h',
     'src/state.c',
+    'src/state.h',
     'src/text.c',
     'src/text.h',
     'src/utf8.c',

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -82,6 +82,9 @@ xkb_keymap_unref(struct xkb_keymap *keymap)
                 }
                 free(key->groups);
             }
+            if (key->overlays) {
+                free(key->overlays);
+            }
         }
         free(keymap->keys);
     }
@@ -92,6 +95,7 @@ xkb_keymap_unref(struct xkb_keymap *keymap)
         }
         free(keymap->types);
     }
+    free(keymap->incompatible_overlays);
     free(keymap->sym_interprets);
     free(keymap->key_aliases);
     free(keymap->group_names);

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -120,6 +120,15 @@ enum mod_type {
 };
 #define MOD_REAL_MASK_ALL ((xkb_mod_mask_t) 0x000000ff)
 
+/* TODO: doc */
+#define XKB_MAX_OVERLAYS 8
+
+#if XKB_MAX_OVERLAYS > 8
+    #error "Cannot store overlays indexes"
+#endif
+typedef uint8_t xkb_overlay_index_t;
+typedef uint8_t xkb_overlay_mask_t;
+
 enum xkb_action_type {
     ACTION_TYPE_NONE = 0,
     ACTION_TYPE_MOD_SET,
@@ -165,11 +174,15 @@ enum xkb_action_controls {
     CONTROL_AX_FEEDBACK = (1 << 8),
     CONTROL_BELL = (1 << 9),
     CONTROL_IGNORE_GROUP_LOCK = (1 << 10),
+#define _CONTROL_OVERLAY1_LOG2 11
+#define CONTROL_OVERLAYS (CONTROL_OVERLAY1 | CONTROL_OVERLAY2)
+    CONTROL_OVERLAY1 = (1 << 11),
+    CONTROL_OVERLAY2 = (1 << 12),
     CONTROL_ALL = \
         (CONTROL_REPEAT | CONTROL_SLOW | CONTROL_DEBOUNCE | CONTROL_STICKY | \
          CONTROL_MOUSEKEYS | CONTROL_MOUSEKEYS_ACCEL | CONTROL_AX | \
          CONTROL_AX_TIMEOUT | CONTROL_AX_FEEDBACK | CONTROL_BELL | \
-         CONTROL_IGNORE_GROUP_LOCK)
+         CONTROL_IGNORE_GROUP_LOCK | CONTROL_OVERLAY1 | CONTROL_OVERLAY2)
 };
 
 enum xkb_match_operation {
@@ -201,6 +214,7 @@ struct xkb_controls_action {
     enum xkb_action_type type;
     enum xkb_action_flags flags;
     enum xkb_action_controls ctrls;
+    xkb_overlay_mask_t overlays;
 };
 
 struct xkb_pointer_default_action {
@@ -336,6 +350,9 @@ struct xkb_key {
     xkb_keycode_t keycode;
     xkb_atom_t name;
 
+    xkb_overlay_mask_t overlays_mask;
+    xkb_keycode_t *overlays;
+
     enum xkb_explicit_components explicit;
 
     xkb_mod_mask_t modmap;
@@ -370,6 +387,8 @@ struct xkb_keymap {
     enum xkb_keymap_format format;
 
     enum xkb_action_controls enabled_ctrls;
+    xkb_overlay_index_t num_overlays;
+    xkb_overlay_mask_t *incompatible_overlays;
 
     xkb_keycode_t min_key_code;
     xkb_keycode_t max_key_code;

--- a/src/state.h
+++ b/src/state.h
@@ -1,0 +1,10 @@
+#ifndef STATE_H
+#define STATE_H
+
+#include "keymap.h"
+
+xkb_overlay_mask_t
+xkb_state_serialize_overlays(struct xkb_state *state,
+                             enum xkb_state_component type);
+
+#endif

--- a/src/text.c
+++ b/src/text.c
@@ -71,10 +71,10 @@ const LookupEntry ctrlMaskNames[] = {
     { "AccessXFeedback", CONTROL_AX_FEEDBACK },
     { "AudibleBell", CONTROL_BELL },
     { "IgnoreGroupLock", CONTROL_IGNORE_GROUP_LOCK },
+    { "Overlay1", CONTROL_OVERLAY1 },
+    { "Overlay2", CONTROL_OVERLAY2 },
     { "all", CONTROL_ALL },
     { "none", 0 },
-    { "Overlay1", 0 },
-    { "Overlay2", 0 },
     { NULL, 0 }
 };
 
@@ -348,5 +348,36 @@ ControlMaskText(struct xkb_context *ctx, enum xkb_action_controls mask)
             pos += ret;
     }
 
+    return strcpy(xkb_context_get_buffer(ctx, pos + 1), buf);
+}
+
+const char *
+ControlMaskText2(struct xkb_context *ctx, enum xkb_action_controls mask,
+                 xkb_overlay_mask_t overlays)
+{
+    char buf[1024];
+    size_t pos = 0;
+    int ret;
+    if (mask) {
+        ret = snprintf(buf, sizeof(buf), "%s", ControlMaskText(ctx, mask));
+        if (ret <= 0 || pos + ret >= sizeof(buf))
+            goto error;
+        else
+            pos += ret;
+    }
+    /* Only deal with Overlay3+ */
+    xkb_overlay_index_t i = 2;
+    overlays >>= i;
+    for (; overlays && i < XKB_MAX_OVERLAYS; i++, overlays >>= 1) {
+        if (overlays & 1) {
+            ret = snprintf(buf + pos, sizeof(buf) - pos, "%sOverlay%u",
+                           pos == 0 ? "" : "+", i + 1);
+            if (ret <= 0 || pos + ret >= sizeof(buf))
+                break;
+            else
+                pos += ret;
+        }
+    }
+error:
     return strcpy(xkb_context_get_buffer(ctx, pos + 1), buf);
 }

--- a/src/text.h
+++ b/src/text.h
@@ -73,4 +73,8 @@ LedStateMaskText(struct xkb_context *ctx, enum xkb_state_component mask);
 const char *
 ControlMaskText(struct xkb_context *ctx, enum xkb_action_controls mask);
 
+const char *
+ControlMaskText2(struct xkb_context *ctx, enum xkb_action_controls mask,
+                 xkb_overlay_mask_t overlays);
+
 #endif /* TEXT_H */

--- a/src/x11/keymap.c
+++ b/src/x11/keymap.c
@@ -152,6 +152,10 @@ translate_controls_mask(uint32_t wire)
         ret |= CONTROL_BELL;
     if (wire & XCB_XKB_BOOL_CTRL_IGNORE_GROUP_LOCK_MASK)
         ret |= CONTROL_IGNORE_GROUP_LOCK;
+    if (wire & XCB_XKB_BOOL_CTRL_OVERLAY_1_MASK)
+        ret |= CONTROL_OVERLAY1;
+    if (wire & XCB_XKB_BOOL_CTRL_OVERLAY_2_MASK)
+        ret |= CONTROL_OVERLAY2;
     /* Some controls are not supported and don't appear here. */
     return ret;
 }

--- a/src/xkbcomp/action.c
+++ b/src/xkbcomp/action.c
@@ -630,15 +630,23 @@ HandleSetLockControls(struct xkb_context *ctx, const struct xkb_mod_set *mods,
 
     if (field == ACTION_FIELD_CONTROLS) {
         enum xkb_action_controls mask;
+        xkb_overlay_mask_t overlays;
 
         if (array_ndx)
             return ReportActionNotArray(ctx, action->type, field);
 
-        if (!ExprResolveMask(ctx, value, &mask, ctrlMaskNames))
+        if (!ExprResolveControlsMask(ctx, value, &mask, &overlays))
             return ReportMismatch(ctx, XKB_ERROR_WRONG_FIELD_TYPE, action->type,
                                   field, "controls mask");
 
         act->ctrls = mask;
+        act->overlays = overlays;
+
+        /* FIXME: remove debug */
+        fprintf(stderr,
+                "HandleSetLockControls: ctrls: %u, overlays: %u (%u)\n",
+                act->ctrls, act->overlays, overlays);
+
         return true;
     }
     else if (field == ACTION_FIELD_AFFECT) {

--- a/src/xkbcomp/expr.h
+++ b/src/xkbcomp/expr.h
@@ -79,6 +79,11 @@ ExprResolveMask(struct xkb_context *ctx, const ExprDef *expr,
                 unsigned int *mask_rtrn, const LookupEntry *values);
 
 bool
+ExprResolveControlsMask(struct xkb_context *ctx, const ExprDef *expr,
+                        enum xkb_action_controls *mask_rtrn,
+                        xkb_overlay_mask_t *overlays);
+
+bool
 ExprResolveKeySym(struct xkb_context *ctx, const ExprDef *expr,
                   xkb_keysym_t *sym_rtrn);
 

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -52,6 +52,10 @@
 #include "src/keysym.h"
 #include "src/compose/parser.h"
 
+#ifdef ENABLE_PRIVATE_APIS
+#include "src/state.h"
+#endif
+
 static void
 print_keycode(struct xkb_keymap *keymap, const char* prefix,
               xkb_keycode_t keycode, const char *suffix) {
@@ -246,6 +250,11 @@ tools_print_keycode_state(const char *prefix,
     }
     printf("] ");
 
+#ifdef ENABLE_PRIVATE_APIS
+    printf("overlays [ %d ] ",
+           xkb_state_serialize_overlays(state, XKB_STATE_OVERLAYS_EFFECTIVE));
+#endif
+
     printf("leds [ ");
     for (xkb_led_index_t led = 0; led < xkb_keymap_num_leds(keymap); led++) {
         if (xkb_state_led_index_is_active(state, led) <= 0)
@@ -282,6 +291,7 @@ tools_print_state_changes(enum xkb_state_component changed)
         printf("locked-mods ");
     if (changed & XKB_STATE_LEDS)
         printf("leds ");
+    /* FIXME: overlays */
     printf("]\n");
 }
 

--- a/xkbcommon.map
+++ b/xkbcommon.map
@@ -119,3 +119,8 @@ global:
     xkb_compose_table_iterator_free;
     xkb_compose_table_iterator_next;
 } V_1.0.0;
+
+V_1.8.0 {
+global:
+    xkb_state_key_get_overlay_keycode;
+} V_1.6.0;


### PR DESCRIPTION
Very rough implementation of overlays. It works but requires more tests.

However, I am not sure what API to propose. This is messing with the keycodes and thus requires extreme rigor for the compositor. We *could* try to make it completely internal and then provide no keycode redirection in the API.

I think *permanent* overlays could be however really useful and completely internal: we would just copy the target key into the source key, thus making easy to permute keys. Not exactly the implementation in X11, but same effect apart the keycodes changes.

I am not planning to work further on *general* overlays ATM, but I share this to open discussion.

Fixes #124