### PR TITLE
Allow only the first group in symbols sections when using RMLVO

### DIFF
--- a/bench/rules.c
+++ b/bench/rules.c
@@ -53,7 +53,7 @@ main(int argc, char *argv[])
     for (i = 0; i < BENCHMARK_ITERATIONS; i++) {
         struct xkb_component_names kccgst;
 
-        assert(xkb_components_from_rules(ctx, &rmlvo, &kccgst));
+        assert(xkb_components_from_rules(ctx, &rmlvo, &kccgst, NULL));
         free(kccgst.keycodes);
         free(kccgst.types);
         free(kccgst.compat);

--- a/changes/api/262.only-one-group-per-key.bugfix.md
+++ b/changes/api/262.only-one-group-per-key.bugfix.md
@@ -1,0 +1,6 @@
+`xkb_keymap_new_from_names`: Allow only one group per key in symbols sections.
+While the original issue was [fixed in `xkeyboard-config`](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/merge_requests/253)
+project, the previous handling in `libxkbcommon` of extra key groups was deemed unintuitive.
+
+Note: rules resolution may still produce more groups than the input layouts.
+This is currently true for some [legacy rules in `xkeyboard-config`](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/blob/6a2eb9e63bcb3c52584580570d31cd91110d1f2e/rules/0013-modellayout_symbols.part#L2).

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -404,7 +404,9 @@ struct xkb_keymap {
 
     struct xkb_mod_set mods;
 
-    /* Number of groups in the key with the most groups. */
+    /* This field has 2 uses:
+     * • During parsing: Expected layouts count after RMLVO resolution, if any;
+     * • After parsing: Number of groups in the key with the most groups. */
     xkb_layout_index_t num_groups;
     /* Not all groups must have names. */
     xkb_layout_index_t num_group_names;

--- a/src/xkbcomp/rules.h
+++ b/src/xkbcomp/rules.h
@@ -27,7 +27,8 @@
 bool
 xkb_components_from_rules(struct xkb_context *ctx,
                           const struct xkb_rule_names *rmlvo,
-                          struct xkb_component_names *out);
+                          struct xkb_component_names *out,
+                          xkb_layout_index_t *explicit_layouts);
 
 /* Maximum length of a layout index string:
  * [NOTE] Currently XKB_MAX_GROUPS is 4, but the following code is

--- a/src/xkbcomp/xkbcomp.c
+++ b/src/xkbcomp/xkbcomp.c
@@ -65,7 +65,10 @@ text_v1_keymap_new_from_names(struct xkb_keymap *keymap,
             rmlvo->rules, rmlvo->model, rmlvo->layout, rmlvo->variant,
             rmlvo->options);
 
-    ok = xkb_components_from_rules(keymap->ctx, rmlvo, &kccgst);
+    /* Resolve the RMLVO component to KcCGST components and get the
+     * expected number of layouts */
+    ok = xkb_components_from_rules(keymap->ctx, rmlvo, &kccgst,
+                                   &keymap->num_groups);
     if (!ok) {
         log_err(keymap->ctx, XKB_ERROR_KEYMAP_COMPILATION_FAILED,
                 "Couldn't look up rules '%s', model '%s', layout '%s', "

--- a/test/data/rules/multiple-groups
+++ b/test/data/rules/multiple-groups
@@ -1,0 +1,9 @@
+// Insert US layout before a single layout
+! model layout = symbols
+  *     us     = pc+%l%(v)
+  *     *      = pc+us+%l%(v):2
+
+! option          = symbols
+  multiple-groups = +multiple-groups
+
+! include evdev

--- a/test/data/symbols/multiple-groups
+++ b/test/data/symbols/multiple-groups
@@ -1,0 +1,30 @@
+// Define a key with various groups at the same time.
+// Use RALT because the option `lv3:ralt_alt` used to have a similar
+// (buggy) implementation, that triggered an unexpected result
+// for `xkb_keymap_num_layouts` and `xkb_keymap_num_layouts_for_key`.
+default partial modifier_keys
+xkb_symbols "1" {
+  key <RALT> {
+    type[Group1]="ONE_LEVEL",
+    type[Group2]="ONE_LEVEL",
+    type[Group3]="ONE_LEVEL",
+    type[Group4]="ONE_LEVEL",
+    symbols[Group1] = [ a ],
+    symbols[Group2] = [ b ],
+    symbols[Group3] = [ c ],
+    symbols[Group4] = [ d ]
+  };
+};
+
+xkb_symbols "2" {
+	key <RALT> {
+	  type[Group1]="ONE_LEVEL",
+	  type[Group2]="ONE_LEVEL",
+	  type[Group3]="ONE_LEVEL",
+	  type[Group4]="ONE_LEVEL",
+	  symbols[Group1] = [ a ],
+	  symbols[Group2] = [ B ],
+	  symbols[Group3] = [ C ],
+	  symbols[Group4] = [ D ]
+	};
+      };

--- a/test/rules-file-includes.c
+++ b/test/rules-file-includes.c
@@ -67,7 +67,7 @@ test_rules(struct xkb_context *ctx, struct test_data *data)
         fprintf(stderr, "Expecting: %s\t%s\t%s\t%s\n",
                 data->keycodes, data->types, data->compat, data->symbols);
 
-    if (!xkb_components_from_rules(ctx, &rmlvo, &kccgst)) {
+    if (!xkb_components_from_rules(ctx, &rmlvo, &kccgst, NULL)) {
         fprintf(stderr, "Received : FAILURE\n");
         return data->should_fail;
     }

--- a/test/rules-file.c
+++ b/test/rules-file.c
@@ -42,6 +42,7 @@ struct test_data {
     const char *types;
     const char *compat;
     const char *symbols;
+    xkb_layout_index_t explicit_layouts;
 
     /* Or set this if xkb_components_from_rules() should fail. */
     bool should_fail;
@@ -62,21 +63,25 @@ test_rules(struct xkb_context *ctx, struct test_data *data)
     if (data->should_fail)
         fprintf(stderr, "Expecting: FAILURE\n");
     else
-        fprintf(stderr, "Expecting: %s\t%s\t%s\t%s\n",
-                data->keycodes, data->types, data->compat, data->symbols);
+        fprintf(stderr, "Expecting: %s\t%s\t%s\t%s\t%u\n",
+                data->keycodes, data->types, data->compat, data->symbols,
+                data->explicit_layouts);
 
-    if (!xkb_components_from_rules(ctx, &rmlvo, &kccgst)) {
+    xkb_layout_index_t explicit_layouts;
+    if (!xkb_components_from_rules(ctx, &rmlvo, &kccgst, &explicit_layouts)) {
         fprintf(stderr, "Received : FAILURE\n");
         return data->should_fail;
     }
 
-    fprintf(stderr, "Received : %s\t%s\t%s\t%s\n",
-            kccgst.keycodes, kccgst.types, kccgst.compat, kccgst.symbols);
+    fprintf(stderr, "Received : %s\t%s\t%s\t%s\t%u\n",
+            kccgst.keycodes, kccgst.types, kccgst.compat, kccgst.symbols,
+            explicit_layouts);
 
     passed = streq_not_null(kccgst.keycodes, data->keycodes) &&
              streq_not_null(kccgst.types, data->types) &&
              streq_not_null(kccgst.compat, data->compat) &&
-             streq_not_null(kccgst.symbols, data->symbols);
+             streq_not_null(kccgst.symbols, data->symbols) &&
+             explicit_layouts == data->explicit_layouts;
 
     free(kccgst.keycodes);
     free(kccgst.types);
@@ -105,6 +110,7 @@ main(int argc, char *argv[])
         .keycodes = "my_keycodes", .types = "my_types",
         .compat = "my_compat|some:compat",
         .symbols = "my_symbols+extra_variant",
+        .explicit_layouts = 1,
     };
     assert(test_rules(ctx, &test_utf_8_with_bom));
 
@@ -117,6 +123,7 @@ main(int argc, char *argv[])
         .keycodes = "my_keycodes", .types = "my_types",
         .compat = "my_compat|some:compat",
         .symbols = "my_symbols+extra_variant",
+        .explicit_layouts = 1,
     };
     assert(!test_rules(ctx, &test_utf_16le_with_bom));
 
@@ -129,6 +136,7 @@ main(int argc, char *argv[])
         .keycodes = "my_keycodes", .types = "my_types",
         .compat = "my_compat|some:compat",
         .symbols = "my_symbols+extra_variant",
+        .explicit_layouts = 1,
     };
     assert(!test_rules(ctx, &test_utf_16be_with_bom));
 
@@ -141,6 +149,7 @@ main(int argc, char *argv[])
         .keycodes = "my_keycodes", .types = "my_types",
         .compat = "my_compat|some:compat",
         .symbols = "my_symbols+extra_variant",
+        .explicit_layouts = 1,
     };
     assert(!test_rules(ctx, &test_utf_32be));
 
@@ -153,6 +162,7 @@ main(int argc, char *argv[])
         .keycodes = "my_keycodes", .types = "my_types",
         .compat = "my_compat|some:compat",
         .symbols = "my_symbols+extra_variant",
+        .explicit_layouts = 1,
     };
     assert(test_rules(ctx, &test1));
 
@@ -163,6 +173,7 @@ main(int argc, char *argv[])
 
         .keycodes = "default_keycodes", .types = "default_types",
         .compat = "default_compat", .symbols = "default_symbols",
+        .explicit_layouts = 1,
     };
     assert(test_rules(ctx, &test2));
 
@@ -173,6 +184,7 @@ main(int argc, char *argv[])
 
         .keycodes = "something(pc104)", .types = "default_types",
         .compat = "default_compat", .symbols = "default_symbols",
+        .explicit_layouts = 1,
     };
     assert(test_rules(ctx, &test3));
 
@@ -183,6 +195,7 @@ main(int argc, char *argv[])
 
         .keycodes = "default_keycodes", .types = "default_types",
         .compat = "default_compat", .symbols = "my_symbols+(bar)",
+        .explicit_layouts = 1,
     };
     assert(test_rules(ctx, &test4));
 
@@ -205,6 +218,7 @@ main(int argc, char *argv[])
         .keycodes = "default_keycodes", .types = "default_types",
         .compat = "default_compat",
         .symbols = "default_symbols+extra:1+extra:2+extra:3+extra:4",
+        .explicit_layouts = 4,
     };
     assert(test_rules(ctx, &test6));
 
@@ -217,34 +231,35 @@ main(int argc, char *argv[])
         .keycodes = "my_keycodes", .types = "my_types",
         .compat = "my_compat+some:compat+group(bla)",
         .symbols = "my_symbols+extra_variant+compose(foo)+keypad(bar)+altwin(menu)",
+        .explicit_layouts = 1,
     };
     assert(test_rules(ctx, &test7));
 
     /* Wild card does not match empty entries for layouts and variants */
-#define ENTRY(_model, _layout, _variant, _options, _symbols, _should_fail) \
-    { .rules = "wildcard", .model = _model,                                \
-      .layout = _layout, .variant = _variant, .options = _options,         \
-      .keycodes = "evdev", .types = "complete", .compat = "complete",      \
-      .symbols = _symbols , .should_fail = _should_fail }
+#define ENTRY(_model, _layout, _variant, _options, _symbols, _layouts, _fail) \
+    { .rules = "wildcard", .model = _model,                                   \
+      .layout = _layout, .variant = _variant, .options = _options,            \
+      .keycodes = "evdev", .types = "complete", .compat = "complete",         \
+      .symbols = _symbols , .explicit_layouts = _layouts, .should_fail = _fail }
     struct test_data wildcard_data[] = {
         /* OK: empty model and options and at least one layout+variant combo */
-        ENTRY(NULL, "a"  , "1"  , NULL, "pc+a(1)", false),
-        ENTRY(""  , "a"  , "1"  , ""  , "pc+a(1)", false),
-        ENTRY(""  , "a," , "1," , ""  , "pc+a(1)", false),
-        ENTRY(""  , ",b" , ",2" , ""  , "+b(2):2", false),
-        ENTRY(""  , "a,b", "1," , ""  , "pc+a(1)", false),
-        ENTRY(""  , "a,b", ",2" , ""  , "+b(2):2", false),
+        ENTRY(NULL, "a"  , "1"  , NULL, "pc+a(1)", 1, false),
+        ENTRY(""  , "a"  , "1"  , ""  , "pc+a(1)", 1, false),
+        ENTRY(""  , "a," , "1," , ""  , "pc+a(1)", 1, false),
+        ENTRY(""  , ",b" , ",2" , ""  , "+b(2):2", 2, false),
+        ENTRY(""  , "a,b", "1," , ""  , "pc+a(1)", 1, false),
+        ENTRY(""  , "a,b", ",2" , ""  , "+b(2):2", 2, false),
         /* Fails: empty layout or variant */
-        ENTRY(NULL, NULL , NULL , NULL, "", true),
-        ENTRY(NULL, ""   , ""   , NULL, "", true),
-        ENTRY(NULL, NULL , "1"  , NULL, "", true),
-        ENTRY(NULL, ""   , "1"  , NULL, "", true),
-        ENTRY(NULL, ","  , "1,2", NULL, "", true),
-        ENTRY(NULL, "a"  , NULL , NULL, "", true),
-        ENTRY(NULL, "a"  , ""   , NULL, "", true),
-        ENTRY(NULL, "a,b", NULL , NULL, "", true),
-        ENTRY(NULL, "a,b", ""   , NULL, "", true),
-        ENTRY(NULL, "a,b", ","  , NULL, "", true)
+        ENTRY(NULL, NULL , NULL , NULL, "", 1, true),
+        ENTRY(NULL, ""   , ""   , NULL, "", 1, true),
+        ENTRY(NULL, NULL , "1"  , NULL, "", 1, true),
+        ENTRY(NULL, ""   , "1"  , NULL, "", 1, true),
+        ENTRY(NULL, ","  , "1,2", NULL, "", 2, true),
+        ENTRY(NULL, "a"  , NULL , NULL, "", 1, true),
+        ENTRY(NULL, "a"  , ""   , NULL, "", 1, true),
+        ENTRY(NULL, "a,b", NULL , NULL, "", 2, true),
+        ENTRY(NULL, "a,b", ""   , NULL, "", 2, true),
+        ENTRY(NULL, "a,b", ","  , NULL, "", 2, true)
     };
 #undef ENTRY
     for (size_t k = 0; k < ARRAY_SIZE(wildcard_data); k++) {
@@ -267,93 +282,93 @@ main(int argc, char *argv[])
     }
     too_much_symbols[--i] = '\0';
 
-#define ENTRY2(_rules, _model, _layout, _variant, _options,                 \
-               _keycodes, _types, _compat, _symbols, _should_fail)          \
-    { .rules = _rules, .model = _model,                                     \
-      .layout = _layout, .variant = _variant, .options = _options,          \
-      .keycodes = _keycodes,                                                \
-      .types = _types,                                                      \
-      .compat = _compat,                                                    \
-      .symbols = _symbols , .should_fail = _should_fail }
-#define ENTRY(layout, variant, options, symbols, should_fail)                  \
+#define ENTRY2(_rules, _model, _layout, _variant, _options,                \
+               _keycodes, _types, _compat, _symbols, _count, _should_fail) \
+    { .rules = _rules, .model = _model,                                    \
+      .layout = _layout, .variant = _variant, .options = _options,         \
+      .keycodes = _keycodes, .types = _types, .compat = _compat,           \
+      .symbols = _symbols , .explicit_layouts = _count,                    \
+      .should_fail = _should_fail }
+#define ENTRY(layout, variant, options, symbols, count, should_fail)           \
         ENTRY2("special_indexes", NULL, layout, variant, options,              \
                "default_keycodes", "default_types", "default_compat", symbols, \
-               should_fail)
+               count, should_fail)
     struct test_data special_indexes_first_data[] = {
         /* Test index ranges: layout vs layout[first] */
-        ENTRY("layout_a", NULL, NULL, "symbols_A", false),
-        ENTRY("layout_e", NULL, NULL, "symbols_E+layout_e", false),
-        ENTRY("a", NULL, NULL, "a", false),
-        ENTRY("a", "1", NULL, "a(1)", false),
+        ENTRY("layout_a", NULL, NULL, "symbols_A", 1, false),
+        ENTRY("layout_e", NULL, NULL, "symbols_E+layout_e", 1, false),
+        ENTRY("a", NULL, NULL, "a", 1, false),
+        ENTRY("a", "1", NULL, "a(1)", 1, false),
         /* Test index ranges: invalid layout qualifier */
-        ENTRY("layout_c", NULL, NULL, "symbols_C:1+symbols_z:1", false),
+        ENTRY("layout_c", NULL, NULL, "symbols_C:1+symbols_z:1", 1, false),
         /* Test index ranges: invalid layout[first] qualifier */
-        ENTRY("layout_d", NULL, NULL, "symbols_D", false),
+        ENTRY("layout_d", NULL, NULL, "symbols_D", 1, false),
         /* Test index ranges: multiple layouts */
-        ENTRY("a,b", NULL, NULL, "a+b:2", false),
-        ENTRY("a,b", ",c", NULL, "a+b(c):2", false),
-        ENTRY("layout_e,layout_a", NULL, NULL, "symbols_e:1+symbols_x:2", false),
+        ENTRY("a,b", NULL, NULL, "a+b:2", 2, false),
+        ENTRY("a,b", ",c", NULL, "a+b(c):2", 2, false),
+        ENTRY("layout_e,layout_a", NULL, NULL, "symbols_e:1+symbols_x:2", 2, false),
         ENTRY("layout_a,layout_b,layout_c,layout_d", NULL, NULL,
-              "symbols_a:1+symbols_y:2+layout_c:3+layout_d:4+symbols_z:3", false),
+              "symbols_a:1+symbols_y:2+layout_c:3+layout_d:4+symbols_z:3", 4, false),
         ENTRY("layout_a,layout_b,layout_c,layout_d",
               "extra,,,extra", NULL,
               "symbols_a:1+symbols_y:2+layout_c:3+layout_d(extra):4+symbols_z:3"
-              "+foo:1|bar:1+foo:4|bar:4", false),
+              "+foo:1|bar:1+foo:4|bar:4", 4, false),
         /* NOTE: 5 layouts is intentional;
          * will require update when raising XKB_MAX_LAYOUTS */
         ENTRY("layout_a,layout_b,layout_c,layout_d,layout_e", NULL, NULL,
-              "symbols_a:1+symbols_y:2+layout_c:3+layout_d:4+symbols_z:3", false),
+              "symbols_a:1+symbols_y:2+layout_c:3+layout_d:4+symbols_z:3", 4, false),
 #undef ENTRY
         /* Test index ranges: too much layouts */
         ENTRY2("special_indexes-limit", NULL, too_much_layouts, NULL, NULL,
-               "default_keycodes", "default_types", "default_compat", too_much_symbols, false),
-#define ENTRY(model, layout, variant, options, compat, symbols, should_fail) \
-        ENTRY2("evdev-modern", model, layout, variant, options,      \
-               "evdev+aliases(qwerty)", "complete", compat, symbols, should_fail)
+               "default_keycodes", "default_types", "default_compat", too_much_symbols,
+               XKB_MAX_GROUPS, false),
+#define ENTRY(model, layout, variant, options, compat, symbols, count, should_fail) \
+        ENTRY2("evdev-modern", model, layout, variant, options,                     \
+               "evdev+aliases(qwerty)", "complete", compat, symbols, count, should_fail)
         /* evdev-modern: 1 layout */
-        ENTRY("whatever", "ar", NULL, NULL, "complete", "pc+ara+inet(evdev)", false),
-        ENTRY("whatever", "ben", "probhat", NULL, "complete", "pc+in(ben_probhat)+inet(evdev)", false),
-        ENTRY("ataritt", "es", NULL, NULL, "complete", "xfree68_vndr/ataritt(us)+es+inet(evdev)", false),
-        ENTRY("ataritt", "jp", NULL, NULL, "complete+japan", "xfree68_vndr/ataritt(us)+jp+inet(evdev)", false),
+        ENTRY("whatever", "ar", NULL, NULL, "complete", "pc+ara+inet(evdev)", 1, false),
+        ENTRY("whatever", "ben", "probhat", NULL, "complete", "pc+in(ben_probhat)+inet(evdev)", 1, false),
+        ENTRY("ataritt", "es", NULL, NULL, "complete", "xfree68_vndr/ataritt(us)+es+inet(evdev)", 1, false),
+        ENTRY("ataritt", "jp", NULL, NULL, "complete+japan", "xfree68_vndr/ataritt(us)+jp+inet(evdev)", 1, false),
         ENTRY2("evdev-modern", "olpc", "us", NULL, NULL,
-               "evdev+olpc(olpc)+aliases(qwerty)", "complete", "olpc", "olpc+us(olpc)+inet(evdev)", false),
+               "evdev+olpc(olpc)+aliases(qwerty)", "complete", "olpc", "olpc+us(olpc)+inet(evdev)", 1, false),
         ENTRY2("evdev-modern", "olpc", "jp", NULL, NULL,
-               "evdev+olpc(olpc)+aliases(qwerty)", "complete", "complete+japan", "olpc+jp+inet(evdev)", false),
-        ENTRY("pc104", "jp", NULL, NULL, "complete+japan", "pc+jp+inet(evdev)", false),
-        ENTRY("pc104", "jp", "xxx", NULL, "complete+japan", "pc+jp(xxx)+inet(evdev)", false),
-        ENTRY("pc104", "es", NULL, NULL, "complete", "pc+es+inet(evdev)", false),
-        ENTRY("pc104", "es", "xxx", NULL, "complete", "pc+es(xxx)+inet(evdev)", false),
+               "evdev+olpc(olpc)+aliases(qwerty)", "complete", "complete+japan", "olpc+jp+inet(evdev)", 1, false),
+        ENTRY("pc104", "jp", NULL, NULL, "complete+japan", "pc+jp+inet(evdev)", 1, false),
+        ENTRY("pc104", "jp", "xxx", NULL, "complete+japan", "pc+jp(xxx)+inet(evdev)", 1, false),
+        ENTRY("pc104", "es", NULL, NULL, "complete", "pc+es+inet(evdev)", 1, false),
+        ENTRY("pc104", "es", "xxx", NULL, "complete", "pc+es(xxx)+inet(evdev)", 1, false),
         ENTRY2("evdev-modern", "pc104", "de", "neo", NULL,
                "evdev+aliases(qwertz)", "complete",
                "complete+caps(caps_lock):1+misc(assign_shift_left_action):1+level5(level5_lock):1",
-               "pc+de(neo)+inet(evdev)", false),
+               "pc+de(neo)+inet(evdev)", 1, false),
         ENTRY("pc104", "br", NULL, "misc:typo,misc:apl", "complete",
-              "pc+br+inet(evdev)+apl(level3):1+typo(base):1", false),
+              "pc+br+inet(evdev)+apl(level3):1+typo(base):1", 1, false),
         /* evdev-modern: 2 layouts */
-        ENTRY("whatever", "ar,pt", NULL, NULL, "complete", "pc+ara+pt:2+inet(evdev)", false),
-        ENTRY("whatever", "pt,ar", NULL, NULL, "complete", "pc+pt+ara:2+inet(evdev)", false),
+        ENTRY("whatever", "ar,pt", NULL, NULL, "complete", "pc+ara+pt:2+inet(evdev)", 2, false),
+        ENTRY("whatever", "pt,ar", NULL, NULL, "complete", "pc+pt+ara:2+inet(evdev)", 2, false),
         ENTRY("whatever", "ben,gb", "probhat,", NULL, "complete",
-              "pc+in(ben_probhat)+gb:2+inet(evdev)", false),
+              "pc+in(ben_probhat)+gb:2+inet(evdev)", 2, false),
         ENTRY("whatever", "gb,ben", ",probhat", NULL, "complete",
-              "pc+gb+in(ben):2+in(ben_probhat):2+inet(evdev)", false),
+              "pc+gb+in(ben):2+in(ben_probhat):2+inet(evdev)", 2, false),
         ENTRY("whatever", "ben,ar", "probhat,", NULL, "complete",
-              "pc+in(ben_probhat)+ara:2+inet(evdev)", false),
-        ENTRY("ataritt", "jp,es", NULL, NULL, "complete", "pc+jp+es:2+inet(evdev)", false),
-        ENTRY("ataritt", "es,jp", NULL, NULL, "complete", "pc+es+jp:2+inet(evdev)", false),
+              "pc+in(ben_probhat)+ara:2+inet(evdev)", 2, false),
+        ENTRY("ataritt", "jp,es", NULL, NULL, "complete", "pc+jp+es:2+inet(evdev)", 2, false),
+        ENTRY("ataritt", "es,jp", NULL, NULL, "complete", "pc+es+jp:2+inet(evdev)", 2, false),
         ENTRY2("evdev-modern", "olpc", "jp,es", NULL, NULL,
-               "evdev+olpc(olpc)+aliases(qwerty)", "complete", "complete", "pc+jp+es:2+inet(evdev)", false),
+               "evdev+olpc(olpc)+aliases(qwerty)", "complete", "complete", "pc+jp+es:2+inet(evdev)", 2, false),
         ENTRY2("evdev-modern", "olpc", "es,jp", NULL, NULL,
-               "evdev+olpc(olpc)+aliases(qwerty)", "complete", "complete", "pc+es+jp:2+inet(evdev)", false),
-        ENTRY("pc104", "jp,es", NULL, NULL, "complete", "pc+jp+es:2+inet(evdev)", false),
-        ENTRY("pc104", "jp,es", "xxx,yyy", NULL, "complete", "pc+jp(xxx)+es(yyy):2+inet(evdev)", false),
-        ENTRY("pc104", "latin,jp", NULL, NULL, "complete", "pc+latin+jp:2+inet(evdev)", false),
-        ENTRY("pc104", "latin,jp", "xxx,yyy", NULL, "complete", "pc+latin(xxx)+jp(yyy):2+inet(evdev)", false),
+               "evdev+olpc(olpc)+aliases(qwerty)", "complete", "complete", "pc+es+jp:2+inet(evdev)", 2, false),
+        ENTRY("pc104", "jp,es", NULL, NULL, "complete", "pc+jp+es:2+inet(evdev)", 2, false),
+        ENTRY("pc104", "jp,es", "xxx,yyy", NULL, "complete", "pc+jp(xxx)+es(yyy):2+inet(evdev)", 2, false),
+        ENTRY("pc104", "latin,jp", NULL, NULL, "complete", "pc+latin+jp:2+inet(evdev)", 2, false),
+        ENTRY("pc104", "latin,jp", "xxx,yyy", NULL, "complete", "pc+latin(xxx)+jp(yyy):2+inet(evdev)", 2, false),
         ENTRY2("evdev-modern", "pc104", "gb,de", ",neo", NULL,
                "evdev+aliases(qwerty)", "complete",
                "complete+caps(caps_lock):2+misc(assign_shift_left_action):2+level5(level5_lock):2",
-               "pc+gb+de(neo):2+inet(evdev)", false),
+               "pc+gb+de(neo):2+inet(evdev)", 2, false),
         ENTRY("pc104", "ca,br", NULL, "misc:typo,misc:apl", "complete",
-              "pc+ca+br:2+inet(evdev)+apl(level3):1+apl(level3):2+typo(base):1+typo(base):2", false),
+              "pc+ca+br:2+inet(evdev)+apl(level3):1+apl(level3):2+typo(base):1+typo(base):2", 2, false),
 #undef ENTRY
     };
     for (size_t k = 0; k < ARRAY_SIZE(special_indexes_first_data); k++) {
@@ -375,6 +390,7 @@ main(int argc, char *argv[])
         .compat = "my_compat",
         .symbols = "symbols_a:1+symbols_b:2+symbols_a:3+symbols_b:4+extra_option:1"
                    "+extra_option:2+extra_option:3+extra_option:4",
+        .explicit_layouts = 4,
     };
     assert(test_rules(ctx, &all_qualified_alone1));
 
@@ -393,6 +409,7 @@ main(int argc, char *argv[])
         .compat = "my_compat",
         .symbols = "base:1+base:2+base:3+base:4"
                    "+symbols_a:2+symbols_b:3+default_symbols:4",
+        .explicit_layouts = 4,
     };
     assert(test_rules(ctx, &all_qualified_alone2));
 
@@ -408,6 +425,7 @@ main(int argc, char *argv[])
         .keycodes = "default_keycodes", .types = "default_types",
         .compat = "default_compat",
         .symbols = too_much_symbols,
+        .explicit_layouts = XKB_MAX_GROUPS,
     };
     assert(test_rules(ctx, &all_qualified_invalid_layouts));
 
@@ -427,6 +445,7 @@ main(int argc, char *argv[])
         .symbols = "symbols_a:1+symbols_b:2+symbols_a:3+symbols_b:4"
                    "+extra_symbols:1+extra_symbols:2+extra_symbols:3+extra_symbols:4"
                    "+extra_option:1+extra_option:2+extra_option:3+extra_option:4",
+        .explicit_layouts = 4,
     };
     assert(test_rules(ctx, &all_qualified_with_special_indexes1));
 
@@ -451,6 +470,7 @@ main(int argc, char *argv[])
                    "+extra_symbols1:3"
                    "+extra_option:1"
                    "+extra_option:2+extra_option:3+extra_option:4",
+        .explicit_layouts = 4,
     };
     assert(test_rules(ctx, &all_qualified_with_special_indexes2));
 

--- a/tools/compile-keymap.c
+++ b/tools/compile-keymap.c
@@ -214,7 +214,7 @@ print_kccgst(struct xkb_context *ctx, const struct xkb_rule_names *rmlvo)
 #if ENABLE_PRIVATE_APIS
         struct xkb_component_names kccgst;
 
-        if (!xkb_components_from_rules(ctx, rmlvo, &kccgst))
+        if (!xkb_components_from_rules(ctx, rmlvo, &kccgst, NULL))
             return false;
 
         printf("xkb_keymap {\n"


### PR DESCRIPTION
Currently `xkb_keymap_num_layouts` may return a greater number than the number of layouts configured using RMLVO, because we allow symbols sections to define various groups per key.

This is unintuitive and kind of buggy: groups should be added via rules by setting an explicit `:n` modifier.

Fix: when parsing a keymap using RMLVO resolution:
- Get the expected layouts count from the resulting KcCGST.
- Drop the groups after the first one in included symbols sections. This will ensure that a symbol section can only define one group per key.

Notes:
- Compiling a keymap string directly is unaffected.
- RMLVO resolution may still produce more groups than the input layouts. Indeed, some legacy rules in xkeyboard-config rely on this to insert automatically a US layout before to the given non-Latin one, resulting in two layouts while only one was given.

Fixes #262