### PR TITLE
symbols: Skip interprets only for groups with explicit actions

### DIFF
--- a/changes/api/511.explicit-interp-per-group.bugfix.md
+++ b/changes/api/511.explicit-interp-per-group.bugfix.md
@@ -1,0 +1,6 @@
+Previously, setting *explicit actions* for a group in symbols files made the parser
+skip compatibility interpretations for *all* the groups in the corresponding key,
+resulting in possibly broken groups with *no* explicit actions or missing key fields.
+
+Fixed by skipping interpretations only for groups with explicit actions when parsing
+a keymap and setting relevant fields explicitly when serializing a keymap to a string.

--- a/meson.build
+++ b/meson.build
@@ -738,7 +738,13 @@ test(
 )
 test(
     'stringcomp',
-    executable('test-stringcomp', 'test/stringcomp.c', dependencies: test_dep),
+    executable(
+        'test-stringcomp',
+        'test/stringcomp.c',
+        'test/utils-text.c',
+        'test/utils-text.h',
+        dependencies: test_dep
+    ),
     env: test_env,
 )
 test(
@@ -787,10 +793,10 @@ test(
     executable(
         'test-compose',
         'test/compose.c',
-        'test/utils-text.c',
-        'test/utils-text.h',
         'test/compose-iter.c',
         'test/compose-iter.h',
+        'test/utils-text.c',
+        'test/utils-text.h',
         'src/compose/dump.c',
         'src/compose/dump.h',
         'src/compose/escape.h',

--- a/meson.build
+++ b/meson.build
@@ -787,8 +787,8 @@ test(
     executable(
         'test-compose',
         'test/compose.c',
-        'test/shuffle-lines.c',
-        'test/shuffle-lines.h',
+        'test/utils-text.c',
+        'test/utils-text.h',
         'test/compose-iter.c',
         'test/compose-iter.h',
         'src/compose/dump.c',
@@ -800,7 +800,13 @@ test(
 )
 test(
     'utils',
-    executable('test-utils', 'test/utils.c', dependencies: test_dep),
+    executable(
+        'test-utils',
+        'test/utils.c',
+        'test/utils-text.c',
+        'test/utils-text.h',
+        dependencies: test_dep
+    ),
     env: test_env,
 )
 test(

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -324,11 +324,28 @@ struct xkb_level {
     } u;
 };
 
+/**
+ * Group in a key
+ */
 struct xkb_group {
-    bool explicit_type;
-    /* Points to a type in keymap->types. */
+    /**
+     * Flag that indicates whether a group has explicit actions. In case it has,
+     * compatibility interpretations will not be used on it.
+     * See also EXPLICIT_INTERP flag at key level.
+     */
+    bool explicit_actions:1;
+    /**
+     * Flag that indicates whether a group has an explicit key type. In case it
+     * has, type detection will not be used on it.
+     */
+    bool explicit_type:1;
+    /**
+     * Key type of the group. Points to an entry in keymap->types.
+     */
     const struct xkb_key_type *type;
-    /* Use XkbKeyNumLevels for the number of levels. */
+    /**
+     * Array of group levels. Use `XkbKeyNumLevels` for the number of levels.
+     */
     struct xkb_level *levels;
 };
 

--- a/src/x11/keymap.c
+++ b/src/x11/keymap.c
@@ -602,8 +602,13 @@ get_explicits(struct xkb_keymap *keymap, xcb_connection_t *conn,
         if ((wire->explicit & XCB_XKB_EXPLICIT_KEY_TYPE_4) &&
             key->num_groups > 3)
             key->groups[3].explicit_type = true;
-        if (wire->explicit & XCB_XKB_EXPLICIT_INTERPRET)
+        if (wire->explicit & XCB_XKB_EXPLICIT_INTERPRET) {
             key->explicit |= EXPLICIT_INTERP;
+            /* Make all key groups have explicit actions too */
+            for (xkb_layout_index_t l = 0; l < key->num_groups; l++) {
+                key->groups[l].explicit_actions = true;
+            }
+        }
         if (wire->explicit & XCB_XKB_EXPLICIT_AUTO_REPEAT)
             key->explicit |= EXPLICIT_REPEAT;
         if (wire->explicit & XCB_XKB_EXPLICIT_V_MOD_MAP)

--- a/src/xkbcomp/keymap.c
+++ b/src/xkbcomp/keymap.c
@@ -133,11 +133,11 @@ ApplyInterpsToKey(struct xkb_keymap *keymap, struct xkb_key *key)
     xkb_layout_index_t group;
     xkb_level_index_t level;
 
-    /* If we've been told not to bind interps to this key, then don't. */
-    if (key->explicit & EXPLICIT_INTERP)
-        return true;
-
     for (group = 0; group < key->num_groups; group++) {
+        /* Skip any interpretation for this group if it has explicit actions */
+        if (key->groups[group].explicit_actions)
+            continue;
+
         for (level = 0; level < XkbKeyNumLevels(key, group); level++) {
             const struct xkb_sym_interpret *interp;
 

--- a/src/xkbcomp/symbols.c
+++ b/src/xkbcomp/symbols.c
@@ -1494,8 +1494,13 @@ CopySymbolsDefToKeymap(struct xkb_keymap *keymap, SymbolsInfo *info,
     }
 
     /* Copy levels. */
-    darray_enumerate(i, groupi, keyi->groups)
+    darray_enumerate(i, groupi, keyi->groups) {
         darray_steal(groupi->levels, &key->groups[i].levels, NULL);
+        if (groupi->defined & GROUP_FIELD_ACTS) {
+            key->groups[i].explicit_actions = true;
+            key->explicit |= EXPLICIT_INTERP;
+        }
+    }
 
     key->out_of_range_group_number = keyi->out_of_range_group_number;
     key->out_of_range_group_action = keyi->out_of_range_group_action;
@@ -1508,13 +1513,6 @@ CopySymbolsDefToKeymap(struct xkb_keymap *keymap, SymbolsInfo *info,
     if (keyi->repeat != KEY_REPEAT_UNDEFINED) {
         key->repeats = (keyi->repeat == KEY_REPEAT_YES);
         key->explicit |= EXPLICIT_REPEAT;
-    }
-
-    darray_foreach(groupi, keyi->groups) {
-        if (groupi->defined & GROUP_FIELD_ACTS) {
-            key->explicit |= EXPLICIT_INTERP;
-            break;
-        }
     }
 
     return true;

--- a/test/compose.c
+++ b/test/compose.c
@@ -34,7 +34,7 @@
 #include "src/compose/parser.h"
 #include "src/compose/escape.h"
 #include "src/compose/dump.h"
-#include "test/shuffle-lines.h"
+#include "test/utils-text.h"
 #include "test/compose-iter.h"
 
 static const char *

--- a/test/compose.c
+++ b/test/compose.c
@@ -34,8 +34,8 @@
 #include "src/compose/parser.h"
 #include "src/compose/escape.h"
 #include "src/compose/dump.h"
-#include "test/utils-text.h"
 #include "test/compose-iter.h"
+#include "test/utils-text.h"
 
 static const char *
 compose_status_string(enum xkb_compose_status status)

--- a/test/data/keymaps/explicit-actions.xkb
+++ b/test/data/keymaps/explicit-actions.xkb
@@ -1,0 +1,368 @@
+xkb_keymap {
+xkb_keycodes "(unnamed)" {
+	minimum = 8;
+	maximum = 255;
+	<ESC>                = 9;
+	<AE01>               = 10;
+	<AE02>               = 11;
+	<AE03>               = 12;
+	<AE04>               = 13;
+	<AE05>               = 14;
+	<AE06>               = 15;
+	<AE07>               = 16;
+	<AE08>               = 17;
+	<AE09>               = 18;
+	<AE10>               = 19;
+	<AE11>               = 20;
+	<AE12>               = 21;
+	<BKSP>               = 22;
+	<TAB>                = 23;
+	<AD01>               = 24;
+	<AD02>               = 25;
+	<AD03>               = 26;
+	<AD04>               = 27;
+	<AD05>               = 28;
+	<AD06>               = 29;
+	<AD07>               = 30;
+	<AD08>               = 31;
+	<AD09>               = 32;
+	<AD10>               = 33;
+	<AD11>               = 34;
+	<AD12>               = 35;
+	<RTRN>               = 36;
+	<LCTL>               = 37;
+	<AC01>               = 38;
+	<AC02>               = 39;
+	<AC03>               = 40;
+	<AC04>               = 41;
+	<AC05>               = 42;
+	<AC06>               = 43;
+	<AC07>               = 44;
+	<AC08>               = 45;
+	<AC09>               = 46;
+	<AC10>               = 47;
+	<AC11>               = 48;
+	<TLDE>               = 49;
+	<LFSH>               = 50;
+	<BKSL>               = 51;
+	<AB01>               = 52;
+	<AB02>               = 53;
+	<AB03>               = 54;
+	<AB04>               = 55;
+	<AB05>               = 56;
+	<AB06>               = 57;
+	<AB07>               = 58;
+	<AB08>               = 59;
+	<AB09>               = 60;
+	<AB10>               = 61;
+	<RTSH>               = 62;
+	<KPMU>               = 63;
+	<LALT>               = 64;
+	<SPCE>               = 65;
+	<CAPS>               = 66;
+	<FK01>               = 67;
+	<FK02>               = 68;
+	<FK03>               = 69;
+	<FK04>               = 70;
+	<FK05>               = 71;
+	<FK06>               = 72;
+	<FK07>               = 73;
+	<FK08>               = 74;
+	<FK09>               = 75;
+	<FK10>               = 76;
+	<NMLK>               = 77;
+	<SCLK>               = 78;
+	<KP7>                = 79;
+	<KP8>                = 80;
+	<KP9>                = 81;
+	<KPSU>               = 82;
+	<KP4>                = 83;
+	<KP5>                = 84;
+	<KP6>                = 85;
+	<KPAD>               = 86;
+	<KP1>                = 87;
+	<KP2>                = 88;
+	<KP3>                = 89;
+	<KP0>                = 90;
+	<KPDL>               = 91;
+	<LVL3>               = 92;
+	<LSGT>               = 94;
+	<FK11>               = 95;
+	<FK12>               = 96;
+	<AB11>               = 97;
+	<RCTL>               = 105;
+	<RALT>               = 108;
+	<LWIN>               = 133;
+	<RWIN>               = 134;
+	<COMP>               = 135;
+	<MDSW>               = 203;
+	<ALT>                = 204;
+	<META>               = 205;
+	<SUPR>               = 206;
+	<HYPR>               = 207;
+};
+
+xkb_types "(unnamed)" {
+	virtual_modifiers NumLock,Alt,LevelThree,ScrollLock,LevelFive,Super,AltGr,Meta,Hyper;
+
+	type "ONE_LEVEL" {
+		modifiers= none;
+		level_name[1]= "Any";
+	};
+	type "TWO_LEVEL" {
+		modifiers= Shift;
+		map[Shift]= 2;
+		level_name[1]= "Base";
+		level_name[2]= "Shift";
+	};
+	type "ALPHABETIC" {
+		modifiers= Shift+Lock;
+		map[Shift]= 2;
+		map[Lock]= 2;
+		level_name[1]= "Base";
+		level_name[2]= "Caps";
+	};
+	type "FOUR_LEVEL" {
+		modifiers= Shift+LevelThree;
+		map[Shift]= 2;
+		map[LevelThree]= 3;
+		map[Shift+LevelThree]= 4;
+		level_name[1]= "Base";
+		level_name[2]= "Shift";
+		level_name[3]= "AltGr";
+		level_name[4]= "Shift AltGr";
+	};
+	type "EIGHT_LEVEL_ALPHABETIC_LEVEL_FIVE_LOCK" {
+		modifiers= Shift+Lock+NumLock+LevelThree+LevelFive;
+		map[Shift]= 2;
+		map[LevelThree]= 3;
+		map[Shift+LevelThree]= 4;
+		map[LevelFive]= 5;
+		map[Shift+LevelFive]= 6;
+		preserve[Shift+LevelFive]= Shift;
+		map[LevelThree+LevelFive]= 7;
+		map[Shift+LevelThree+LevelFive]= 8;
+		map[NumLock]= 5;
+		map[Shift+NumLock]= 6;
+		preserve[Shift+NumLock]= Shift;
+		map[NumLock+LevelThree]= 7;
+		map[Shift+NumLock+LevelThree]= 8;
+		map[Shift+NumLock+LevelFive]= 2;
+		map[NumLock+LevelThree+LevelFive]= 3;
+		map[Shift+NumLock+LevelThree+LevelFive]= 4;
+		map[Lock]= 2;
+		map[Lock+LevelThree]= 3;
+		map[Shift+Lock+LevelThree]= 4;
+		map[Lock+LevelFive]= 5;
+		map[Shift+Lock+LevelFive]= 6;
+		map[Lock+LevelThree+LevelFive]= 7;
+		map[Shift+Lock+LevelThree+LevelFive]= 8;
+		map[Lock+NumLock]= 5;
+		map[Shift+Lock+NumLock]= 6;
+		map[Lock+NumLock+LevelThree]= 7;
+		map[Shift+Lock+NumLock+LevelThree]= 8;
+		map[Lock+NumLock+LevelFive]= 2;
+		map[Lock+NumLock+LevelThree+LevelFive]= 4;
+		map[Shift+Lock+NumLock+LevelThree+LevelFive]= 3;
+		level_name[1]= "Base";
+		level_name[2]= "Shift";
+		level_name[3]= "Alt Base";
+		level_name[4]= "Shift Alt";
+		level_name[5]= "X";
+		level_name[6]= "X Shift";
+		level_name[7]= "X Alt Base";
+		level_name[8]= "X Shift Alt";
+	};
+	type "FOUR_LEVEL_SEMIALPHABETIC" {
+		modifiers= Shift+Lock+LevelThree;
+		map[Shift]= 2;
+		map[Lock]= 2;
+		map[LevelThree]= 3;
+		map[Shift+LevelThree]= 4;
+		map[Lock+LevelThree]= 3;
+		preserve[Lock+LevelThree]= Lock;
+		map[Shift+Lock+LevelThree]= 4;
+		preserve[Shift+Lock+LevelThree]= Lock;
+		level_name[1]= "Base";
+		level_name[2]= "Shift";
+		level_name[3]= "AltGr";
+		level_name[4]= "Shift AltGr";
+	};
+};
+
+xkb_compatibility "(unnamed)" {
+	virtual_modifiers NumLock,Alt,LevelThree,ScrollLock,LevelFive,Super,AltGr,Meta,Hyper;
+
+	interpret.useModMapMods= AnyLevel;
+	interpret.repeat= False;
+	interpret ISO_Level2_Latch+Exactly(Shift) {
+		useModMapMods=level1;
+		action= LatchMods(modifiers=Shift,clearLocks,latchToLock);
+	};
+	interpret Shift_Lock+AnyOf(Shift+Lock) {
+		action= LockMods(modifiers=Shift);
+	};
+	interpret Num_Lock+AnyOf(all) {
+		virtualModifier= NumLock;
+		action= LockMods(modifiers=NumLock);
+	};
+	interpret ISO_Level3_Shift+AnyOf(all) {
+		virtualModifier= LevelThree;
+		useModMapMods=level1;
+		action= SetMods(modifiers=LevelThree,clearLocks);
+	};
+	interpret ISO_Level3_Latch+AnyOf(all) {
+		virtualModifier= LevelThree;
+		useModMapMods=level1;
+		action= LatchMods(modifiers=LevelThree,clearLocks,latchToLock);
+	};
+	interpret ISO_Level3_Lock+AnyOf(all) {
+		virtualModifier= LevelThree;
+		useModMapMods=level1;
+		action= LockMods(modifiers=LevelThree);
+	};
+	interpret Alt_L+AnyOf(all) {
+		virtualModifier= Alt;
+		action= SetMods(modifiers=modMapMods,clearLocks);
+	};
+	interpret Alt_R+AnyOf(all) {
+		virtualModifier= Alt;
+		action= SetMods(modifiers=modMapMods,clearLocks);
+	};
+	interpret ISO_Level5_Shift+AnyOf(all) {
+		virtualModifier= LevelFive;
+		useModMapMods=level1;
+		action= SetMods(modifiers=LevelFive,clearLocks);
+	};
+	interpret Mode_switch+AnyOfOrNone(all) {
+		virtualModifier= AltGr;
+		useModMapMods=level1;
+		action= SetGroup(group=+1);
+	};
+	interpret ISO_Level3_Shift+AnyOfOrNone(all) {
+		action= SetMods(modifiers=LevelThree,clearLocks);
+	};
+	interpret ISO_Next_Group+AnyOfOrNone(all) {
+		virtualModifier= AltGr;
+		useModMapMods=level1;
+		action= LockGroup(group=+1);
+	};
+	interpret ISO_Prev_Group+AnyOfOrNone(all) {
+		virtualModifier= AltGr;
+		useModMapMods=level1;
+		action= LockGroup(group=-1);
+	};
+	interpret Alt_L+AnyOfOrNone(all) {
+		action= SetMods(modifiers=Alt,clearLocks);
+	};
+	interpret Alt_R+AnyOfOrNone(all) {
+		action= SetMods(modifiers=Alt,clearLocks);
+	};
+	interpret Shift_L+AnyOfOrNone(all) {
+		action= SetMods(modifiers=Shift,clearLocks);
+	};
+	interpret Shift_R+AnyOfOrNone(all) {
+		action= SetMods(modifiers=Shift,clearLocks);
+	};
+	interpret ISO_Level5_Shift+AnyOfOrNone(all) {
+		action= SetMods(modifiers=LevelFive,clearLocks);
+	};
+	interpret ISO_Level5_Latch+AnyOfOrNone(all) {
+		action= LatchMods(modifiers=LevelFive,clearLocks,latchToLock);
+	};
+	interpret ISO_Level5_Lock+AnyOfOrNone(all) {
+		action= LockMods(modifiers=LevelFive);
+	};
+	interpret Any+AnyOf(all) {
+		action= SetMods(modifiers=modMapMods,clearLocks);
+	};
+};
+
+xkb_symbols "(unnamed)" {
+	name[Group1]="English (US)";
+	name[Group2]="Czech";
+	name[Group3]="German (Neo 2)";
+
+	key <AD05>               {
+		//// repeat=Yes is set with the default *interpretation*, but
+		//// using explicit actions makes the key keep the initial value,
+		//// i.e. repeat=No.
+		//repeat= Yes,
+		symbols[Group1]= [               t,               T ],
+		//actions[Group1]= [ NoAction(), NoAction() ],
+		symbols[Group2]= [     Cyrillic_ie,     Cyrillic_IE ],
+		actions[Group2]= [ NoAction(), NoAction() ],
+		symbols[Group3]= [               w,               W ]//,
+		//actions[Group3]= [ NoAction(), NoAction() ]
+	};
+	key <AD06>               {
+		type[Group3]= "EIGHT_LEVEL_ALPHABETIC_LEVEL_FIVE_LOCK",
+		symbols[Group1]= [               y,               Y ],
+		symbols[Group2]= [               z,               Z,       leftarrow,             yen ],
+		symbols[Group3]= [               k,               K,          exclam,     Greek_kappa,      exclamdown,        NoSymbol,        multiply,        NoSymbol ]
+	};
+	key <LFSH>               {
+		type[Group3]= "TWO_LEVEL",
+		symbols[Group1]= [         Shift_L ],
+		symbols[Group2]= [         Shift_L ],
+		symbols[Group3]= [         Shift_L,       Caps_Lock ]
+	};
+	//// This should set the key’s EXPLICIT_INTERP explicit flag and
+	//// the group 2 explicit_actions, but it should still allow to
+	//// interpret the keysyms in groups 1 and 3.
+	key <LALT>               {
+		type[Group1]= "ONE_LEVEL",
+		type[Group2]= "TWO_LEVEL",
+		type[Group3]= "TWO_LEVEL",
+		//repeat= No,
+		symbols[Group1]= [         Shift_L ],
+		//actions[Group1]= [ SetMods(modifiers=Shift,clearLocks) ],
+		symbols[Group2]= [ ISO_Level3_Shift,       Multi_key ],
+		actions[Group2]= [ SetMods(modifiers=LevelThree), NoAction() ],
+		symbols[Group3]= [ ISO_Level5_Shift, ISO_Level3_Shift ]//,
+		//actions[Group3]= [ SetMods(modifiers=LevelFive,clearLocks), SetMods(modifiers=LevelThree,clearLocks) ]
+	};
+	key <LVL3>               {
+		type= "ONE_LEVEL",
+		//// The following fields are added, because they are set via
+		//// compatibility interpretations, but using explicit actions
+		//// disable them.
+		//repeat= No,
+		//virtualMods= LevelThree,
+		symbols[Group1]= [ ISO_Level3_Shift ],
+		//actions[Group1]= [ SetMods(modifiers=LevelThree,clearLocks) ],
+		symbols[Group2]= [ ISO_Level3_Shift ],
+		actions[Group2]= [ SetMods(modifiers=LevelThree) ],
+		symbols[Group3]= [ ISO_Level3_Shift ]//,
+		//actions[Group3]= [ SetMods(modifiers=LevelThree,clearLocks) ]
+	};
+	key <LSGT>               {
+		symbols[Group1]= [            less,         greater,             bar,       brokenbar ],
+		symbols[Group2]= [       backslash,             bar,           slash,        NoSymbol ],
+		symbols[Group3]= [ ISO_Level5_Shift ]
+	};
+	key <RALT>               {
+		type[Group1]= "TWO_LEVEL",
+		type[Group2]= "ONE_LEVEL",
+		type[Group3]= "ONE_LEVEL",
+		symbols[Group1]= [           Alt_R,          Meta_R ],
+		symbols[Group2]= [ ISO_Level3_Shift ],
+		symbols[Group3]= [ ISO_Level5_Shift ]
+	};
+	key <COMP>               {	[  ISO_Next_Group,            Menu ] };
+	key <MDSW>               {
+		type= "ONE_LEVEL",
+		symbols[Group1]= [ ISO_Level5_Shift ],
+		symbols[Group2]= [ ISO_Level5_Shift ],
+		symbols[Group3]= [ ISO_Level5_Shift ]
+	};
+	key <ALT>                {	[        NoSymbol,           Alt_L ] };
+	key <META>               {	[        NoSymbol,          Meta_L ] };
+	key <SUPR>               {	[        NoSymbol,         Super_L ] };
+	modifier_map Shift { <LFSH>, <RTSH> };
+	modifier_map Mod1 { <RALT>, <ALT>, <META> };
+	modifier_map Mod3 { <MDSW> };
+	modifier_map Mod5 { <LVL3> };
+};
+
+};

--- a/test/utils-text.h
+++ b/test/utils-text.h
@@ -1,5 +1,11 @@
 #include <stdint.h>
 
+char *
+strip_lines(const char *input, size_t input_length, const char *prefix);
+
+char *
+uncomment(const char *input, size_t input_length, const char *prefix);
+
 struct text_line {
     const char *start;
     size_t length;
@@ -8,6 +14,10 @@ struct text_line {
 size_t
 split_lines(const char *input, size_t input_length,
             struct text_line *output, size_t output_length);
+
+size_t
+concat_lines(struct text_line *lines, size_t length,
+             const char *sep, char *output);
 
 size_t
 shuffle_lines(struct text_line *lines, size_t length, char *output);

--- a/test/utils.c
+++ b/test/utils.c
@@ -31,6 +31,7 @@
 #include "test.h"
 #include "utils.h"
 #include "utils-paths.h"
+#include "test/utils-text.h"
 
 static void
 test_string_functions(void)
@@ -52,6 +53,41 @@ test_string_functions(void)
     assert(!streq_null("foobar", NULL));
     assert(!streq_null(NULL, "foobar"));
     assert(streq_null(NULL, NULL));
+
+    const char text[] =
+        "123; // abc\n"
+        "  // def\n"
+        "456 // ghi // jkl\n"
+        "// mno\n"
+        "//\n"
+        "ok; // pqr\n"
+        "foo\n";
+
+    char *out;
+    out = strip_lines(text, ARRAY_SIZE(text), "//");
+    assert_streq_not_null(
+        "strip_lines",
+        "123; \n"
+        "456 \n"
+        "ok; \n"
+        "foo\n",
+        out
+    );
+    free(out);
+
+    out = uncomment(text, ARRAY_SIZE(text), "//");
+    assert_streq_not_null(
+        "uncomment",
+        "123;  abc\n"
+        "   def\n"
+        "456  ghi // jkl\n"
+        " mno\n"
+        "\n"
+        "ok;  pqr\n"
+        "foo\n",
+        out
+    );
+    free(out);
 }
 
 static void


### PR DESCRIPTION
Previously setting explicit actions for a group in symbols files made the parser skip compatibility interpretations for the corresponding *whole* key, so the other groups with *no* explicit actions could result broken on some levels.

In the following example, `<RALT>` would have an action on group 2, because it is explicit, but none on group 1 because interpretation are also skipped there as a side effect:

```c
key <RALT> {
	symbols[1]= [              ISO_Level3_Shift ],
	symbols[2]= [              ISO_Level3_Shift ],
	actions[2]= [ SetMods(modifiers=LevelThree) ]
};
```

Fixed by skipping interpretations *only* for groups with explicit actions.

We still set `key->explicit |= EXPLICIT_INTERP` if at least one group has explicit actions. In such case, when dumping a keymap, we will write explicit actions for *all* groups, in order to ensure that X11 and previous versions of libxkbcommon can parse the keymap as intended. One side effect is that no interpretation will be run on this key anymore, so we may have to set some extra fields explicitly: repeat, virtualMods. Thus the previous example would be bumped as:

```c
key <RALT> {
	repeat= No,
	symbols[1]= [              ISO_Level3_Shift ],
	actions[1]= [ SetMods(modifiers=LevelThree,clearLocks) ],
	symbols[2]= [              ISO_Level3_Shift ],
	actions[2]= [ SetMods(modifiers=LevelThree) ]
};
```

Fixes #511