### PR TITLE
registry: Restore default libxml2 error handler after parsing

### DIFF
--- a/changes/api/529.fix-xml-error-handler.bugfix.md
+++ b/changes/api/529.fix-xml-error-handler.bugfix.md
@@ -1,0 +1,4 @@
+registry: Fixed `libxml2` global error handler not reset after parsing, which
+could trigger a crash if the corresponding `rxkb_context` has been freed.
+
+Contributed by Sebastian Keller.

--- a/meson.build
+++ b/meson.build
@@ -879,7 +879,7 @@ if get_option('enable-xkbregistry')
         'registry',
         executable('test-registry', 'test/registry.c',
                    include_directories: include_directories('src'),
-                   dependencies: [dep_libxkbregistry, test_dep]),
+                   dependencies: [dep_libxkbregistry, dep_libxml, test_dep]),
         env: test_env,
     )
 endif


### PR DESCRIPTION
Leaving the custom error handler could have resulted in a crash after the context has been freed.

Closes: https://github.com/xkbcommon/libxkbcommon/issues/529