### PR TITLE
Registry: use safe libxml2 API

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -383,6 +383,13 @@ endif
 # libxkbregistry
 if get_option('enable-xkbregistry')
     dep_libxml = dependency('libxml-2.0')
+    if cc.has_header_symbol(
+        'libxml/xmlerror.h',
+        'xmlCtxtSetErrorHandler',
+        prefix: system_ext_define
+    )
+        configh_data.set10('HAVE_XML_CTXT_SET_ERRORHANDLER', true)
+    endif
     deps_libxkbregistry = [dep_libxml]
     libxkbregistry_sources = [
         'src/registry.c',

--- a/src/registry.c
+++ b/src/registry.c
@@ -1264,6 +1264,13 @@ parse(struct rxkb_context *ctx, const char *path,
     if (!xmlCtxt)
         return false;
 
+#ifdef XML_PARSE_NO_XXE
+#define _XML_OPTIONS (XML_PARSE_NONET | XML_PARSE_NOENT | XML_PARSE_NO_XXE)
+#else
+#define _XML_OPTIONS (XML_PARSE_NONET)
+#endif
+    xmlCtxtUseOptions(xmlCtxt, _XML_OPTIONS);
+
 #ifdef HAVE_XML_CTXT_SET_ERRORHANDLER
     /* Prefer contextual handler whenever possible. It takes precedence over
      * the global generic handler. */


### PR DESCRIPTION
See: #529 and the related comment in the [original Gnome issue](https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/7974#note_2245926).