### PR TITLE
Tools: added --test option

### DIFF
--- a/changes/tools/+test-flag.feature.md
+++ b/changes/tools/+test-flag.feature.md
@@ -1,0 +1,2 @@
+Added `--test` option to `compile-keymap` and `compile-compose`, to enable testing
+compilation without printing the resulting file.

--- a/test/xkeyboard-config-test.py.in
+++ b/test/xkeyboard-config-test.py.in
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import gzip
 import itertools
 import multiprocessing
 import os
@@ -11,6 +12,7 @@ import sys
 import xml.etree.ElementTree as ET
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -124,12 +126,30 @@ class Invocation(RMLVO, metaclass=ABCMeta):
     def escape(s: str) -> str:
         return s.replace('"', '\\"')
 
-    @abstractmethod
-    def _run(self) -> Self: ...
+    def _write(self, fd: TextIO) -> None:
+        fd.write(f"// {self.to_yaml(self.rmlvo)}\n")
+        fd.write(self.keymap)
+
+    def _write_keymap(self, output_dir: Path, compress: int) -> None:
+        layout = self.layout
+        if self.variant:
+            layout += f"({self.variant})"
+        (output_dir / self.model).mkdir(exist_ok=True)
+        keymap_file = output_dir / self.model / layout
+        if compress:
+            keymap_file = keymap_file.with_suffix(".gz")
+            with gzip.open(
+                keymap_file, "wt", compresslevel=compress, encoding="utf-8"
+            ) as fd:
+                self._write(fd)
+                fd.close()
+        else:
+            with keymap_file.open("wt", encoding="utf-8") as fd:
+                self._write(fd)
 
     @classmethod
-    def run(cls, x: Self) -> Self:
-        return x._run()
+    @abstractmethod
+    def run(cls, i: Self, output_dir: Path | None, compress: int) -> Self: ...
 
     @classmethod
     def run_all(
@@ -141,6 +161,7 @@ class Invocation(RMLVO, metaclass=ABCMeta):
         verbose: bool,
         short: bool,
         progress_bar: ProgressBar[Iterable[Self]],
+        compress: int,
     ) -> bool:
         if keymap_output_dir:
             try:
@@ -149,12 +170,10 @@ class Invocation(RMLVO, metaclass=ABCMeta):
                 print(e, file=sys.stderr)
                 return False
 
-        keymap_file: Path | None = None
-        keymap_file_fd: TextIO | None = None
-
         failed = False
         with multiprocessing.Pool(njobs) as p:
-            results = p.imap_unordered(cls.run, combos)
+            f = partial(cls.run, output_dir=keymap_output_dir, compress=compress)
+            results = p.imap_unordered(f, combos)
             for invocation in progress_bar(
                 results, total=combos_count, file=sys.stdout
             ):
@@ -170,25 +189,6 @@ class Invocation(RMLVO, metaclass=ABCMeta):
                     else:
                         print(invocation, file=target)
 
-                if keymap_output_dir:
-                    # we're running through the layouts in a somewhat sorted manner,
-                    # so let's keep the fd open until we switch layouts
-                    layout = invocation.layout
-                    if invocation.variant:
-                        layout += f"({invocation.variant})"
-                    (keymap_output_dir / invocation.model).mkdir(exist_ok=True)
-                    fname = keymap_output_dir / invocation.model / layout
-                    if fname != keymap_file:
-                        keymap_file = fname
-                        if keymap_file_fd:
-                            keymap_file_fd.close()
-                        keymap_file_fd = open(keymap_file, "a")
-
-                    print(f"// {cls.to_yaml(invocation.rmlvo)}", file=keymap_file_fd)
-                    print(invocation.keymap, file=keymap_file_fd)
-                    assert keymap_file_fd
-                    keymap_file_fd.flush()
-
         return failed
 
 
@@ -196,7 +196,12 @@ class Invocation(RMLVO, metaclass=ABCMeta):
 class XkbCompInvocation(Invocation):
     xkbcomp_args: ClassVar[tuple[str, ...]] = ("xkbcomp", "-xkb", "-", "-")
 
-    def _run(self) -> Self:
+    @classmethod
+    def run(cls, i: Self, output_dir: Path | None, compress: int) -> Self:
+        i._run(output_dir, compress)
+        return i
+
+    def _run(self, output_dir: Path | None, compress: int) -> None:
         args = (
             "setxkbmap",
             "-print",
@@ -230,36 +235,48 @@ class XkbCompInvocation(Invocation):
             else:
                 self.keymap = stdout
                 self.exitstatus = 0
-        return self
+
+        if output_dir:
+            self._write_keymap(output_dir, compress)
 
 
 @dataclass
 class XkbcommonInvocation(Invocation):
     UNRECOGNIZED_KEYSYM_ERROR: ClassVar[str] = "XKB-107"
 
-    def _run(self) -> Self:
+    @classmethod
+    def run(cls, i: Self, output_dir: Path | None, compress: int) -> Self:
+        i._run(output_dir, compress)
+        return i
+
+    def _run(self, output_dir: Path | None, compress: int) -> None:
         args = (
             "xkbcli-compile-keymap",  # this is run in the builddir
             # Not needed, because we set XKB_LOG_LEVEL and XKB_LOG_VERBOSITY in env
             # "--verbose",
             *itertools.chain.from_iterable((f"--{k}", v) for k, v in self.rmlvo),
         )
+        if not output_dir:
+            args += ("--test",)
         self.command = " ".join(args)
         try:
             completed = subprocess.run(args, text=True, check=True, capture_output=True)
+        except subprocess.CalledProcessError as err:
+            self.error = "failed to compile keymap"
+            self.exitstatus = err.returncode
+        else:
             if self.UNRECOGNIZED_KEYSYM_ERROR in completed.stderr:
                 for line in completed.stderr.splitlines():
                     if self.UNRECOGNIZED_KEYSYM_ERROR in line:
                         self.error = line
-                        self.exitstatus = 99  # tool doesn't generate this one
                         break
+                self.exitstatus = 99  # tool doesn't generate this one
             else:
                 self.exitstatus = 0
                 self.keymap = completed.stdout
-        except subprocess.CalledProcessError as err:
-            self.error = "failed to compile keymap"
-            self.exitstatus = err.returncode
-        return self
+
+        if output_dir:
+            self._write_keymap(output_dir, compress)
 
 
 @dataclass
@@ -438,6 +455,9 @@ def main() -> NoReturn:
         help="Directory to print compiled keymaps to",
     )
     parser.add_argument(
+        "--compress", type=int, default=0, help="Compression level of keymaps files"
+    )
+    parser.add_argument(
         "--model", default="", type=str, help="Only test the given model"
     )
     parser.add_argument(
@@ -484,7 +504,14 @@ def main() -> NoReturn:
         )
 
     failed = tool.run_all(
-        iter_combos, count, args.jobs, keymapdir, verbose, short, progress_bar
+        iter_combos,
+        count,
+        args.jobs,
+        keymapdir,
+        verbose,
+        short,
+        progress_bar,
+        args.compress,
     )
     sys.exit(failed)
 

--- a/tools/compile-compose.c
+++ b/tools/compile-compose.c
@@ -37,7 +37,7 @@ static void
 usage(FILE *fp, char *progname)
 {
     fprintf(fp,
-            "Usage: %s [--help] [--file FILE] [--locale LOCALE]\n",
+            "Usage: %s [--help] [--file FILE] [--locale LOCALE] [--test]\n",
             progname);
     fprintf(fp,
             "\n"
@@ -50,7 +50,9 @@ usage(FILE *fp, char *progname)
             "    Specify a Compose file to load\n"
             " --locale LOCALE\n"
             "    Specify the locale directly, instead of relying on the environment variables\n"
-            "    LC_ALL, LC_TYPE and LANG.\n");
+            "    LC_ALL, LC_TYPE and LANG.\n"
+            " --test\n"
+            "    Test compilation but do not print the Compose file.\n");
 }
 
 int
@@ -62,14 +64,17 @@ main(int argc, char *argv[])
     const char *locale = NULL;
     const char *path = NULL;
     enum xkb_compose_format format = XKB_COMPOSE_FORMAT_TEXT_V1;
+    bool test = false;
     enum options {
         OPT_FILE,
         OPT_LOCALE,
+        OPT_TEST,
     };
     static struct option opts[] = {
         {"help",   no_argument,       0, 'h'},
         {"file",   required_argument, 0, OPT_FILE},
         {"locale", required_argument, 0, OPT_LOCALE},
+        {"test",   no_argument,       0, OPT_TEST},
         {0, 0, 0, 0},
     };
 
@@ -94,6 +99,9 @@ main(int argc, char *argv[])
             break;
         case OPT_LOCALE:
             locale = optarg;
+            break;
+        case OPT_TEST:
+            test = true;
             break;
         case 'h':
             usage(stdout, argv[0]);
@@ -139,6 +147,11 @@ main(int argc, char *argv[])
                     "Couldn't create compose from locale \"%s\"\n", locale);
             goto out;
         }
+    }
+
+    if (test) {
+        ret = EXIT_SUCCESS;
+        goto out;
     }
 
     ret = xkb_compose_table_dump(stdout, compose_table)

--- a/tools/compile-keymap.c
+++ b/tools/compile-keymap.c
@@ -49,6 +49,7 @@ static enum output_format {
 } output_format = FORMAT_KEYMAP;
 static const char *includes[64];
 static size_t num_includes = 0;
+static bool test = false;
 
 static void
 usage(char **argv)
@@ -62,6 +63,8 @@ usage(char **argv)
            "    Print this help and exit\n"
            " --verbose\n"
            "    Enable verbose debugging output\n"
+           " --test\n"
+           "    Test compilation but do not print the keymap.\n"
 #if ENABLE_PRIVATE_APIS
            " --kccgst\n"
            "    Print a keymap which only includes the KcCGST component names instead of the full keymap\n"
@@ -107,6 +110,7 @@ parse_options(int argc, char **argv, struct xkb_rule_names *names)
 {
     enum options {
         OPT_VERBOSE,
+        OPT_TEST,
         OPT_KCCGST,
         OPT_RMLVO,
         OPT_FROM_XKB,
@@ -121,6 +125,7 @@ parse_options(int argc, char **argv, struct xkb_rule_names *names)
     static struct option opts[] = {
         {"help",             no_argument,            0, 'h'},
         {"verbose",          no_argument,            0, OPT_VERBOSE},
+        {"test",             no_argument,            0, OPT_TEST},
 #if ENABLE_PRIVATE_APIS
         {"kccgst",           no_argument,            0, OPT_KCCGST},
 #endif
@@ -149,6 +154,9 @@ parse_options(int argc, char **argv, struct xkb_rule_names *names)
             exit(0);
         case OPT_VERBOSE:
             verbose = true;
+            break;
+        case OPT_TEST:
+            test = true;
             break;
         case OPT_KCCGST:
             output_format = FORMAT_KCCGST;
@@ -216,6 +224,8 @@ print_kccgst(struct xkb_context *ctx, const struct xkb_rule_names *rmlvo)
 
         if (!xkb_components_from_rules(ctx, rmlvo, &kccgst, NULL))
             return false;
+        if (test)
+            goto out;
 
         printf("xkb_keymap {\n"
                "  xkb_keycodes { include \"%s\" };\n"
@@ -224,6 +234,7 @@ print_kccgst(struct xkb_context *ctx, const struct xkb_rule_names *rmlvo)
                "  xkb_symbols { include \"%s\" };\n"
                "};\n",
                kccgst.keycodes, kccgst.types, kccgst.compat, kccgst.symbols);
+out:
         free(kccgst.keycodes);
         free(kccgst.types);
         free(kccgst.compat);
@@ -244,10 +255,14 @@ print_keymap(struct xkb_context *ctx, const struct xkb_rule_names *rmlvo)
     if (keymap == NULL)
         return false;
 
+    if (test)
+        goto out;
+
     char *buf = xkb_keymap_get_as_string(keymap, XKB_KEYMAP_FORMAT_TEXT_V1);
     printf("%s\n", buf);
     free(buf);
 
+out:
     xkb_keymap_unref(keymap);
     return true;
 }
@@ -290,6 +305,9 @@ print_keymap_from_file(struct xkb_context *ctx)
                                       XKB_KEYMAP_FORMAT_TEXT_V1, 0);
     if (!keymap) {
         fprintf(stderr, "Couldn't create xkb keymap\n");
+        goto out;
+    } else if (test) {
+        success = true;
         goto out;
     }
 

--- a/tools/xkbcli-compile-compose.1
+++ b/tools/xkbcli-compile-compose.1
@@ -24,6 +24,9 @@ Specify a Compose file to load
 .It Fl \-locale Ar LOCALE
 Specify the locale directly, instead of relying on the environment variables
 LC_ALL, LC_TYPE and LANG.
+.
+.It Fl \-test
+Test compilation but do not print the Compose file
 .El
 .
 .Sh SEE ALSO

--- a/tools/xkbcli-compile-keymap.1
+++ b/tools/xkbcli-compile-keymap.1
@@ -21,6 +21,9 @@ Print help and exit
 .It Fl \-verbose
 Enable verbose debugging output
 .
+.It Fl \-test
+Test compilation but do not print the keymap
+.
 .It Fl \-rmlvo
 Print the full RMLVO with the defaults filled in for missing elements
 .


### PR DESCRIPTION
- Added `--test` option to `xkbcli compile-{keymap,compose}` tool, to enable testing compilation without printing the resulting file.
- Improved `xkeyboard-config-test` script:
  - Make use of previous new option to speedup test (≈25% faster).
  - Refactored to make keymap writing in workers, not in the main process.
  - Added `--compress` option to enable keymap compression with gunzip.