### PR TITLE
Make keymap thread-safe

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -151,6 +151,12 @@ if not cc.has_header_symbol('limits.h', 'PATH_MAX', prefix: system_ext_define)
         configh_data.set('PATH_MAX', 4096)
     endif
 endif
+if cc.get_argument_syntax() == 'msvc'
+    add_project_arguments(
+        cc.get_supported_arguments(['/experimental:c11atomics']),
+        language: 'c'
+    )
+endif
 
 # Silence some security & deprecation warnings on MSVC
 # for some unix/C functions we use.

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -58,14 +58,14 @@
 XKB_EXPORT struct xkb_keymap *
 xkb_keymap_ref(struct xkb_keymap *keymap)
 {
-    keymap->refcnt++;
+    atomic_fetch_add(&keymap->refcnt, 1);
     return keymap;
 }
 
 XKB_EXPORT void
 xkb_keymap_unref(struct xkb_keymap *keymap)
 {
-    if (!keymap || --keymap->refcnt > 0)
+    if (!keymap || atomic_fetch_sub(&keymap->refcnt, 1) > 1)
         return;
 
     if (keymap->keys) {

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -83,6 +83,7 @@
 
  /* Don't use compat names in internal code. */
 #define _XKBCOMMON_COMPAT_H
+#include <stdatomic.h>
 #include "xkbcommon/xkbcommon.h"
 
 #include "utils.h"
@@ -388,7 +389,7 @@ struct xkb_mod_set {
 struct xkb_keymap {
     struct xkb_context *ctx;
 
-    int refcnt;
+    atomic_int refcnt;
     enum xkb_keymap_compile_flags flags;
     enum xkb_keymap_format format;
 


### PR DESCRIPTION
(WIP, to open discussion)

The only value that can be modified, once the keymap is compiled, is the reference counter. Use atomics to make it thread-safe.

WARNING: this alone does not make the keymap API thread-safe:
1. It depends on the atom table in the `xkb_context` for its strings values; this table is not thread-safe.
   However it is “safe” only if no other keymap is compiled using the same context.
2. Functions retrieving text may use the `xkb_context` internal string buffer, which is not thread safe.
   API not using this buffer should be “safe”.
3. Functions use the `xkb_context` log function, but modifying it is not thread-safe.
4. State API is not thread-safe.

Fixes #300