### PR TITLE
compose/paths: fix `false` <-> `NULL` confusion, errors on C23

### DIFF
--- a/src/compose/paths.c
+++ b/src/compose/paths.c
@@ -68,16 +68,16 @@ resolve_name(struct xkb_context *ctx, const char *filename,
 
     ret = snprintf(path, sizeof(path), "%s/%s", xlocaledir, filename);
     if (ret < 0 || (size_t) ret >= sizeof(path))
-        return false;
+        return NULL;
 
     file = fopen(path, "rb");
     if (!file)
-        return false;
+        return NULL;
 
     ok = map_file(file, &string, &string_size);
     fclose(file);
     if (!ok)
-        return false;
+        return NULL;
 
     s = string;
     end = string + string_size;


### PR DESCRIPTION
Patch authored by Jeffrey Cliff, send by email:

i don't have access to github but this patch enabled me to compile libxkbcommon with -std=gnu23

otherwise the following compilation error will result :

    ../src/compose/paths.c:70:16: error: incompatible types when returning type ‘_Bool’ but ‘char *’ was expected

( gcc (GCC) 15.0.0 20240509 (experimental) )