### PR TITLE
changelog: Fix release title format

### DIFF
--- a/towncrier.toml
+++ b/towncrier.toml
@@ -6,8 +6,10 @@ start_string = "<!-- towncrier release notes start -->\n"
 all_bullets = true
 single_file = true
 orphan_prefix = "+"
-underlines = ["=", "-", ""]
-title_format = "{name} [{version}](https://github.com/xkbcommon/libxkbcommon/tree/xkbcommon-{version}) - {project_date}"
+title_format = """\
+{name} [{version}](https://github.com/xkbcommon/libxkbcommon/tree/xkbcommon-{version}) - {project_date}
+=============================================================================================\
+"""
 issue_format = "[#{issue}](https://github.com/xkbcommon/libxkbcommon/issues/{issue})"
 
 # Sections configuration


### PR DESCRIPTION
Towncrier doc states that the `underlines` setting is not used with Markdown files, so let’s apply the tag ourselves.