### PR TITLE
ci: fix upload artifact conflict

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -76,7 +76,7 @@ jobs:
             fi
       - name: Store doxygen docs for use by the pages workflow
         uses: actions/upload-artifact@v4
-        if: success()
+        if: success() && matrix.compiler == 'gcc'
         with:
           name: doxygen-docs
           path: |


### PR DESCRIPTION
Doesn't like it when two jobs from the same run upload the same name.