### PR TITLE
Add "How to make a libxkbcommon release"

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,74 @@
+# How to make a libxkbcommon release
+
+### Prerequisites
+
+- Have write access to xkbcommon Git repositories.
+- Be subscribed to the [wayland-devel](https://lists.freedesktop.org/mailman/listinfo/wayland-devel) mailing list.
+
+### Steps
+
+#### Prepare the release
+
+- [ ] Ensure there is no issue in the tracker blocking the release. Make sure
+  they have their milestone set to the relevant release and the relevant tag
+  “critical”.
+
+- [ ] Ensure all items in the current milestone are processed. Remaining items
+  must be *explicitly* postponed by changing their milestone.
+
+- [ ] Create a release branch: `git checkout -b release/vMAJOR.MINOR.PATCH master`
+
+- [ ] Update the `NEWS.md` file for the release, following [the corresponding instructions](changes/README.md).
+
+- [ ] Bump the `version` in `meson.build`.
+
+- [ ] Run `meson dist -C build` to make sure the release is good to go.
+
+- [ ] Commit `git commit -m 'Bump version to MAJOR.MINOR.PATCH'`.
+
+- [ ] Create a pull request using this template and ensure *all* CI is green.
+
+- [ ] Merge the pull request.
+
+- [ ] Tag `git pull && git tag --annotate -m xkbcommon-<MAJOR.MINOR.PATCH> xkbcommon-<MAJOR.MINOR.PATCH>`.
+
+- [ ] Push the tag `git push xkbcommon-<MAJOR.MINOR.PATCH>`.
+
+#### Send announcement email to wayland-devel
+
+- [ ] Send an email to the wayland-devel@lists.freedesktop.org mailing list, using this template:
+
+```
+Subject: [ANNOUNCE] libxkbcommon MAJOR.MINOR.PATCH
+
+<NEWS & comments for this release>
+
+Git tag:
+--------
+
+git tag: xkbcommon-<MAJOR.MINOR.PATCH>
+git commit: <git commit sha>
+
+<YOUR NAME>
+```
+
+#### Update website
+
+- [ ] Pull the latest [website repository](https://github.com/xkbcommon/website).
+
+- [ ] Add the doc for the release: `cp -r <xkbommon>/build/html doc/<MAJOR.MINOR.PATCH>`.
+  Check carefully that there is no warning during generation with Doxygen.
+  It may be necessary to use another version of Doxygen to get a clean build.
+  Building from source using the main branch is also a good option.
+
+- [ ] Update the `current` symlink: `ln -nsrf doc/<MAJOR.MINOR.PATCH> doc/current`.
+
+- [ ] Grab a link to the announcement mail from the [wayland-devel archives](https://lists.freedesktop.org/archives/wayland-devel/).
+
+- [ ] Update the `index.html`:
+    - "Our latest API- and ABI-stable release ..."
+    - Add entry to the `releases` HTML list.
+
+- [ ] Commit `git commit -m MAJOR.MINOR.PATCH`.
+
+- [ ] Push `git push`. This automatically publishes the website after a few seconds.


### PR DESCRIPTION
I hope I didn't forget anything. We can certainly automate some of this, but this is documenting what I am currently doing.

Note that I explicitly decided to remove publishing a tarball. Given what happened with [xz backdoor](https://en.wikipedia.org/wiki/XZ_Utils_backdoor), I think we are better off without them. I'm pretty sure most distros build directly from git these days. We should make a prominent note of this change in the announcement email. Old tarballs will not be removed.

Let me know if you have any comments.