### PR TITLE
ci: upload only doxygen docs to pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,8 +25,6 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - name: Set up directory tree
-        run: mkdir -p public_html/doc/
       - name: Download doxygen from Linux build
         uses: dawidd6/action-download-artifact@v7
         with:
@@ -34,22 +32,15 @@ jobs:
           workflow_conclusion: success
           name: doxygen-docs
           path: doxygen/
-      - name: Move doxygen to target directory
-        run: mv doxygen/ public_html/doc/current/
-      - name: Check out the static website
-        uses: actions/checkout@v4
-        with:
-          repository: xkbcommon/website
-          persist-credentials: false
-          path: website
-      - name: Move static website to target directory
-        run: mv website/* public_html/
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
+
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: public_html/
+          path: doxygen/
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
We use the xkbcommon/website pages for the website, so here it's just for previewing and we only need to the docs, not the website.

Fix #561.