### PR TITLE
Always retain later Compose sequence in case of conflict

### DIFF
--- a/changes/api/+compose-new-overrides-old.breaking.md
+++ b/changes/api/+compose-new-overrides-old.breaking.md
@@ -1,0 +1,2 @@
+Changed Compose behavior so that sequences defined later always override
+ones defined earlier, even if the new sequence is shorter.

--- a/include/xkbcommon/xkbcommon-compose.h
+++ b/include/xkbcommon/xkbcommon-compose.h
@@ -84,11 +84,7 @@ extern "C" {
  * @parblock
  *
  * To avoid ambiguity, a sequence is not allowed to be a prefix of another.
- * In such a case, the conflict is resolved thus:
- *
- * 1. A longer sequence overrides a shorter one.
- * 2. An equal sequence overrides an existing one.
- * 3. A shorter sequence does not override a longer one.
+ * When such a conflict occurs, the sequence defined last is the one retained.
  *
  * Sequences of length 1 are allowed.
  *

--- a/src/compose/parser.c
+++ b/src/compose/parser.c
@@ -454,8 +454,8 @@ add_production(struct xkb_compose_table *table, struct scanner *s,
             } else if (node->internal.eqkid != 0) {
                 scanner_warn(s, XKB_LOG_MESSAGE_NO_ID,
                              "this compose sequence is a prefix of another; "
-                             "skipping line");
-                return;
+                             "overriding");
+                node->internal.eqkid = 0;
             }
             node->is_leaf = true;
             if (production->has_string) {

--- a/test/compose.c
+++ b/test/compose.c
@@ -392,8 +392,8 @@ test_conflicting(struct xkb_context *ctx)
         "<A> <B> <C>  :  \"foo\"  A \n"
         "<A> <B>      :  \"bar\"  B \n",
         XKB_KEY_A,              XKB_COMPOSE_FEED_ACCEPTED,  XKB_COMPOSE_COMPOSING,  "",     XKB_KEY_NoSymbol,
-        XKB_KEY_B,              XKB_COMPOSE_FEED_ACCEPTED,  XKB_COMPOSE_COMPOSING,  "",     XKB_KEY_NoSymbol,
-        XKB_KEY_C,              XKB_COMPOSE_FEED_ACCEPTED,  XKB_COMPOSE_COMPOSED,   "foo",  XKB_KEY_A,
+        XKB_KEY_B,              XKB_COMPOSE_FEED_ACCEPTED,  XKB_COMPOSE_COMPOSED,   "bar",  XKB_KEY_B,
+        XKB_KEY_C,              XKB_COMPOSE_FEED_ACCEPTED,  XKB_COMPOSE_NOTHING,    "",     XKB_KEY_NoSymbol,
         XKB_KEY_NoSymbol));
 
     // old is a prefix of new


### PR DESCRIPTION
This ensures that it is always possible to override previous definitions, for example when `include`ing the system Compose file.

Fixes #395, as a stopgap while waiting for #398.