### PR TITLE
Clear mods properly with `|=`

### DIFF
--- a/changes/api/583.bugfix.md
+++ b/changes/api/583.bugfix.md
@@ -1,0 +1,1 @@
+Fixed modifiers not properly unset when multiple latches are used simultaneously.

--- a/src/state.c
+++ b/src/state.c
@@ -454,7 +454,7 @@ xkb_filter_group_latch_func(struct xkb_state *state,
 static void
 xkb_filter_mod_set_new(struct xkb_state *state, struct xkb_filter *filter)
 {
-    state->set_mods = filter->action.mods.mods.mask;
+    state->set_mods |= filter->action.mods.mods.mask;
 }
 
 static bool
@@ -476,7 +476,7 @@ xkb_filter_mod_set_func(struct xkb_state *state,
         return XKB_FILTER_CONSUME;
     }
 
-    state->clear_mods = filter->action.mods.mods.mask;
+    state->clear_mods |= filter->action.mods.mods.mask;
     if (filter->action.mods.flags & ACTION_LOCK_CLEAR)
         state->components.locked_mods &= ~filter->action.mods.mods.mask;
 
@@ -522,7 +522,7 @@ static void
 xkb_filter_mod_latch_new(struct xkb_state *state, struct xkb_filter *filter)
 {
     filter->priv = LATCH_KEY_DOWN;
-    state->set_mods = filter->action.mods.mods.mask;
+    state->set_mods |= filter->action.mods.mods.mask;
 }
 
 static bool
@@ -553,7 +553,7 @@ xkb_filter_mod_latch_func(struct xkb_state *state,
                 else {
                     filter->action.type = ACTION_TYPE_MOD_SET;
                     filter->func = xkb_filter_mod_set_func;
-                    state->set_mods = filter->action.mods.mods.mask;
+                    state->set_mods |= filter->action.mods.mods.mask;
                 }
                 filter->key = key;
                 state->components.latched_mods &= ~filter->action.mods.mods.mask;
@@ -585,13 +585,13 @@ xkb_filter_mod_latch_func(struct xkb_state *state,
                 state->components.latched_mods &=
                     ~filter->action.mods.mods.mask;
             else
-                state->clear_mods = filter->action.mods.mods.mask;
+                state->clear_mods |= filter->action.mods.mods.mask;
             state->components.locked_mods &= ~filter->action.mods.mods.mask;
             filter->func = NULL;
         }
         else {
             latch = LATCH_PENDING;
-            state->clear_mods = filter->action.mods.mods.mask;
+            state->clear_mods |= filter->action.mods.mods.mask;
             state->components.latched_mods |= filter->action.mods.mods.mask;
             /* XXX beep beep! */
         }

--- a/test/data/symbols/simultaneous-mods-latches
+++ b/test/data/symbols/simultaneous-mods-latches
@@ -1,0 +1,16 @@
+default partial alphanumeric_keys
+xkb_symbols "base" {
+	name[Group1] = "Test issue #583";
+
+	key <AB01> { [ z, Z, y, Y, ezh, EZH, ydiaeresis, Ydiaeresis ], type[Group1] = "EIGHT_LEVEL" };
+	key <AB02> { [ x, X ], type[Group1] = "PC_CONTROL_LEVEL2" };
+
+	key <RALT> { [ ISO_Level3_Latch, ISO_Level5_Latch ], type[Group1] = "PC_CONTROL_LEVEL2" };
+	key <RCTL> { [ Control_R ], [LatchMods(modifiers=Control)] };
+	key <LWIN> { [ ISO_Level3_Latch ], type[Group1] = "ONE_LEVEL" };
+	key <RWIN> { [ ISO_Level5_Latch ], type[Group1] = "ONE_LEVEL" };
+
+	modifier_map None { <RALT> };
+	modifier_map Mod3 { <RWIN> };
+	modifier_map Mod5 { <LWIN> };
+};


### PR DESCRIPTION
Fixes #583