### PR TITLE
Use test map for checking --version-script, instead of full map

### DIFF
--- a/changes/build/481.bugfix.md
+++ b/changes/build/481.bugfix.md
@@ -1,2 +1,1 @@
-Gated the use of `--undefined-version` in the linker because it breaks on older
-GNU `ld`.
+Make the test of `-Wl,--version-script` more robust.

--- a/meson.build
+++ b/meson.build
@@ -164,14 +164,10 @@ configh_data.set('WIN32_LEAN_AND_MEAN', 1)
 xkbcommon_map = meson.current_source_dir() / 'xkbcommon.map'
 
 # Supports -Wl,--version-script?
-if cc.has_link_argument('-Wl,--undefined-version')
-    extra_linker_args = ',--undefined-version'
-else
-    extra_linker_args = ''
-endif
+meson_test_map = meson.current_source_dir() / 'test/meson_test.map'
 have_version_script = cc.links(
-    'int main(){}',
-    args: f'-Wl,--version-script=@xkbcommon_map@@extra_linker_args@',
+    'int main() { return 0; }',
+    args: f'-Wl,--version-script=@meson_test_map@',
     name: '-Wl,--version-script',
 )
 

--- a/test/meson_test.map
+++ b/test/meson_test.map
@@ -1,0 +1,6 @@
+VERSION_1 {
+    global:
+        main;
+    local:
+        *;
+};


### PR DESCRIPTION
Various problems can occur when using the full `xkbcommon.map` file when checking whether the `--version-script` linker option works in `meson.build`. See https://lists.freebsd.org/archives/freebsd-current/2025-January/006888.html for an example.

For instance, newer linkers typically complain about non-existing symbols, so in commit ebe4157 `--undefined-version` was added to work around that. But then in commit 1d8a25d6 another workaround needed to be added for older linkers.

It is better to use a minimalistic linker script for testing instead. The other workarounds can then be removed.