### PR TITLE
x11: Keep level when the keysym is undefined but not the action

### DIFF
--- a/changes/api/+fix-x11-action-only-handling.bugfix.md
+++ b/changes/api/+fix-x11-action-only-handling.bugfix.md
@@ -1,0 +1,1 @@
+x11: Do not drop a level when the keysym is undefined but not the action.

--- a/test/data/keymaps/host.xkb
+++ b/test/data/keymaps/host.xkb
@@ -1657,6 +1657,11 @@ xkb_symbols "pc_us_pt_2_us_3_inet(evdev)_group(shift_caps_toggle)_compose(ralt)"
 	key <I244>               {	[     XF86Battery ] };
 	key <I245>               {	[   XF86Bluetooth ] };
 	key <I246>               {	[        XF86WLAN ] };
+	key <I247>               {
+		repeat= Yes,
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [       SetMods(modifiers=Shift) ]
+	};
 	modifier_map Shift { <LFSH>, <RTSH> };
 	modifier_map Lock { <CAPS> };
 	modifier_map Control { <LCTL>, <RCTL> };


### PR DESCRIPTION
When getting the keymap from X11, the following:

```
key <AD01> { actions=[SetGroup(2)] };
```

is currently converted to:

```
key <AD01> { };
```

This commit fixes dropping a defined action when the keysym is undefined