### PR TITLE
Fix explicit vmod dump

### DIFF
--- a/changes/api/+dump-explicit-vmod-mappings.bugfix.md
+++ b/changes/api/+dump-explicit-vmod-mappings.bugfix.md
@@ -1,0 +1,1 @@
+Fixed missing explicit virtual modifier mappings when export the keymap as a string.

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -438,6 +438,12 @@ struct xkb_keymap {
          (iter) < (mods_)->mods + (mods_)->num_mods; \
          (iter)++)
 
+#define xkb_mods_mask_foreach(mask, iter, mods_) \
+    for ((iter) = (mods_)->mods; \
+         mask && (iter) < (mods_)->mods + (mods_)->num_mods; \
+         (iter)++, mask >>= 1) \
+        if (mask & 0x1)
+
 #define xkb_mods_enumerate(idx, iter, mods_) \
     for ((idx) = 0, (iter) = (mods_)->mods; \
          (idx) < (mods_)->num_mods; \

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -382,6 +382,7 @@ struct xkb_mod {
 struct xkb_mod_set {
     struct xkb_mod mods[XKB_MAX_MODS];
     unsigned int num_mods;
+    xkb_mod_mask_t explicit_vmods;
 };
 
 /* Common keyboard description structure */

--- a/src/xkbcomp/vmod.c
+++ b/src/xkbcomp/vmod.c
@@ -39,8 +39,6 @@ HandleVModDef(struct xkb_context *ctx, struct xkb_mod_set *mods,
     struct xkb_mod *mod;
     xkb_mod_mask_t mapping;
 
-    merge = (merge == MERGE_DEFAULT ? stmt->merge : merge);
-
     if (stmt->value) {
         /*
          * This is a statement such as 'virtualModifiers NumLock = Mod1';
@@ -58,6 +56,8 @@ HandleVModDef(struct xkb_context *ctx, struct xkb_mod_set *mods,
         mapping = 0;
     }
 
+    merge = (merge == MERGE_DEFAULT ? stmt->merge : merge);
+
     xkb_mods_enumerate(i, mod, mods) {
         if (mod->name == stmt->name) {
             if (mod->type != MOD_VIRT) {
@@ -68,14 +68,22 @@ HandleVModDef(struct xkb_context *ctx, struct xkb_mod_set *mods,
                 return false;
             }
 
-            if (mod->mapping == mapping)
+            if (mod->mapping == mapping || !stmt->value) {
+                /*
+                 * Same definition or no new explicit mapping: do nothing.
+                 * Note that we must test the statement value and not the mapping
+                 * in order to allow resetting it: e.g. `VMod=none`.
+                 */
                 return true;
+            }
 
-            if (mod->mapping != 0) {
-                xkb_mod_mask_t use, ignore;
-
-                use = (merge == MERGE_OVERRIDE ? mapping : mod->mapping);
-                ignore = (merge == MERGE_OVERRIDE ? mod->mapping : mapping);
+            const xkb_mod_mask_t vmod = UINT32_C(1) << i;
+            if (mods->explicit_vmods & vmod) {
+                /* Handle conflicting mappings */
+                assert(mod->mapping != 0);
+                const bool clobber = (merge != MERGE_AUGMENT);
+                const xkb_mod_mask_t use = (clobber ? mapping : mod->mapping);
+                const xkb_mod_mask_t ignore = (clobber ? mod->mapping : mapping);
 
                 log_warn(ctx, XKB_LOG_MESSAGE_NO_ID,
                          "Virtual modifier %s defined multiple times; "
@@ -88,6 +96,12 @@ HandleVModDef(struct xkb_context *ctx, struct xkb_mod_set *mods,
             }
 
             mod->mapping = mapping;
+            if (mapping) {
+                mods->explicit_vmods |= vmod;
+            } else {
+                mods->explicit_vmods &= ~vmod;
+            }
+
             return true;
         }
     }
@@ -102,6 +116,8 @@ HandleVModDef(struct xkb_context *ctx, struct xkb_mod_set *mods,
     mods->mods[mods->num_mods].name = stmt->name;
     mods->mods[mods->num_mods].type = MOD_VIRT;
     mods->mods[mods->num_mods].mapping = mapping;
+    if (mapping)
+        mods->explicit_vmods |= UINT32_C(1) << mods->num_mods;
     mods->num_mods++;
     return true;
 }

--- a/test/data/keymaps/stringcomp.data
+++ b/test/data/keymaps/stringcomp.data
@@ -296,7 +296,7 @@ xkb_keycodes "evdev_aliases(qwerty)" {
 };
 
 xkb_types "complete" {
-	virtual_modifiers NumLock,Alt,LevelThree,LAlt,RAlt,RControl,LControl,ScrollLock,LevelFive,AltGr,Meta,Super,Hyper;
+	virtual_modifiers NumLock,Alt,LevelThree,LAlt=Mod1,RAlt=0x100,RControl=0x210001,LControl,ScrollLock,LevelFive,AltGr,Meta,Super,Hyper;
 
 	type "ONE_LEVEL" {
 		modifiers= none;
@@ -590,7 +590,7 @@ xkb_types "complete" {
 };
 
 xkb_compatibility "complete_caps(caps_lock)_4_misc(assign_shift_left_action)_4_level5(level5_lock)_4" {
-	virtual_modifiers NumLock,Alt,LevelThree,LAlt,RAlt,RControl,LControl,ScrollLock,LevelFive,AltGr,Meta,Super,Hyper;
+	virtual_modifiers NumLock,Alt,LevelThree,LAlt=Mod1,RAlt=0x100,RControl=0x210001,LControl,ScrollLock,LevelFive,AltGr,Meta,Super,Hyper;
 
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;


### PR DESCRIPTION
xkbcommon already allow pure virtual modifiers (see #450) via explicit mapping (see @mahkoh [comment](https://github.com/xkbcommon/libxkbcommon/pull/450#issuecomment-2575248313)). But it does not roundtrip, because we do not dump the virtual modifier mappings.

This PR enable dumping the *explicit* mappings. The following issue may be dealt with in a follow-up MR:

> The assignment of pure virtual modifiers to bits is implicit. If both parties don't agree on the order in which virtual modifiers are assigned, they cannot communicate. With the mapping explicitly spelled out, it is at least possible for a client to detect the desired bit offset.