### PR TITLE
Fix integer literal suffixes

### DIFF
--- a/src/atom.c
+++ b/src/atom.c
@@ -85,7 +85,7 @@
 static inline uint32_t
 hash_buf(const char *string, size_t len)
 {
-    uint32_t hash = 2166136261u;
+    uint32_t hash = UINT32_C(2166136261);
     for (size_t i = 0; i < (len + 1) / 2; i++) {
         hash ^= (uint8_t) string[i];
         hash *= 0x01000193;

--- a/src/compose/parser.c
+++ b/src/compose/parser.c
@@ -472,7 +472,7 @@ add_production(struct xkb_compose_table *table, struct scanner *s,
 }
 
 /* Should match resolve_modifier(). */
-#define ALL_MODS_MASK ((1 << 0) | (1 << 1) | (1 << 2) | (1 << 3))
+#define ALL_MODS_MASK ((1u << 0) | (1u << 1) | (1u << 2) | (1u << 3))
 
 static xkb_mod_index_t
 resolve_modifier(const char *name)
@@ -705,11 +705,11 @@ lhs_mod_list_tok: {
             goto error;
         }
 
-        production.modmask |= 1 << mod;
+        production.modmask |= UINT32_C(1) << mod;
         if (tilde)
-            production.mods &= ~(1 << mod);
+            production.mods &= ~(UINT32_C(1) << mod);
         else
-            production.mods |= 1 << mod;
+            production.mods |= UINT32_C(1) << mod;
 
         goto lhs_mod_list;
     }

--- a/src/compose/table.h
+++ b/src/compose/table.h
@@ -78,7 +78,7 @@
 /* 7 nodes for every potential Unicode character and then some should be
  * enough for all purposes. */
 #define MAX_COMPOSE_NODES_LOG2 23
-#define MAX_COMPOSE_NODES (1 << MAX_COMPOSE_NODES_LOG2)
+#define MAX_COMPOSE_NODES (1u << MAX_COMPOSE_NODES_LOG2)
 
 struct compose_node {
     xkb_keysym_t keysym;

--- a/src/keymap-priv.c
+++ b/src/keymap-priv.c
@@ -122,7 +122,7 @@ XkbEscapeMapName(char *name)
 
     while (*name) {
         unsigned char c = *name;
-        if (!(legal[c / 8] & (1 << (c % 8))))
+        if (!(legal[c / 8] & (1u << (c % 8))))
             *name = '_';
         name++;
     }

--- a/src/state.c
+++ b/src/state.c
@@ -754,7 +754,7 @@ xkb_state_led_update_all(struct xkb_state *state)
                 mod_mask |= state->components.locked_mods;
 
             if (led->mods.mask & mod_mask) {
-                state->components.leds |= (1u << idx);
+                state->components.leds |= (UINT32_C(1) << idx);
                 continue;
             }
         }
@@ -768,9 +768,9 @@ xkb_state_led_update_all(struct xkb_state *state)
                        state->components.locked_group < XKB_MAX_GROUPS);
                 /* Effective and locked groups are used as mask */
                 if (led->which_groups & XKB_STATE_LAYOUT_EFFECTIVE)
-                    group_mask |= (1u << state->components.group);
+                    group_mask |= (UINT32_C(1) << state->components.group);
                 if (led->which_groups & XKB_STATE_LAYOUT_LOCKED)
-                    group_mask |= (1u << state->components.locked_group);
+                    group_mask |= (UINT32_C(1) << state->components.locked_group);
                 /* Base and latched groups only have to be non-zero */
                 if ((led->which_groups & XKB_STATE_LAYOUT_DEPRESSED) &&
                     state->components.base_group != 0)
@@ -780,7 +780,7 @@ xkb_state_led_update_all(struct xkb_state *state)
                     group_mask |= led->groups;
 
                 if (led->groups & group_mask) {
-                    state->components.leds |= (1u << idx);
+                    state->components.leds |= (UINT32_C(1) << idx);
                     continue;
                 }
             } else {
@@ -789,14 +789,14 @@ xkb_state_led_update_all(struct xkb_state *state)
                      state->components.base_group == 0) ||
                     ((led->which_groups & XKB_STATE_LAYOUT_LATCHED) &&
                      state->components.latched_group == 0)) {
-                    state->components.leds |= (1u << idx);
+                    state->components.leds |= (UINT32_C(1) << idx);
                     continue;
                 }
             }
         }
 
         if (led->ctrls & state->keymap->enabled_ctrls) {
-            state->components.leds |= (1u << idx);
+            state->components.leds |= (UINT32_C(1) << idx);
             continue;
         }
     }
@@ -933,7 +933,8 @@ xkb_state_update_mask(struct xkb_state *state,
     prev_components = state->components;
 
     /* Only include modifiers which exist in the keymap. */
-    mask = (xkb_mod_mask_t) ((1ull << xkb_keymap_num_mods(state->keymap)) - 1u);
+    mask = (xkb_mod_mask_t) ((UINT64_C(1) << xkb_keymap_num_mods(state->keymap))
+         - UINT64_C(1));
 
     state->components.base_mods = base_mods & mask;
     state->components.latched_mods = latched_mods & mask;
@@ -1276,7 +1277,7 @@ mod_mask_get_effective(struct xkb_keymap *keymap, xkb_mod_mask_t mods)
     mask = mods & MOD_REAL_MASK_ALL;
 
     xkb_mods_enumerate(i, mod, &keymap->mods)
-        if (mods & (1u << i))
+        if (mods & (UINT32_C(1) << i))
             mask |= mod->mapping;
 
     return mask;
@@ -1290,7 +1291,7 @@ mod_mapping(struct xkb_mod *mod, xkb_mod_index_t idx)
      * We cannot use `mod->mapping` directly, because it is
      * not set for real modifiers.
      */
-    return (mod->type & MOD_REAL) ? (1u << idx) : mod->mapping;
+    return (mod->type & MOD_REAL) ? (UINT32_C(1) << idx) : mod->mapping;
 }
 
 /**
@@ -1482,7 +1483,7 @@ xkb_state_led_index_is_active(struct xkb_state *state, xkb_led_index_t idx)
         state->keymap->leds[idx].name == XKB_ATOM_NONE)
         return -1;
 
-    return !!(state->components.leds & (1u << idx));
+    return !!(state->components.leds & (UINT32_C(1) << idx));
 }
 
 /**

--- a/src/text.c
+++ b/src/text.c
@@ -275,7 +275,7 @@ ModMaskText(struct xkb_context *ctx, const struct xkb_mod_set *mods,
     xkb_mods_enumerate(i, mod, mods) {
         int ret;
 
-        if (!(mask & (1u << i)))
+        if (!(mask & (UINT32_C(1) << i)))
             continue;
 
         ret = snprintf(buf + pos, sizeof(buf) - pos, "%s%s",

--- a/src/x11/keymap.c
+++ b/src/x11/keymap.c
@@ -736,7 +736,7 @@ get_indicators(struct xkb_keymap *keymap, xcb_connection_t *conn,
     keymap->num_leds = msb_pos(reply->which);
 
     for (unsigned i = 0; i < NUM_INDICATORS; i++) {
-        if (reply->which & (1u << i)) {
+        if (reply->which & (UINT32_C(1) << i)) {
             xcb_xkb_indicator_map_t *wire = iter.data;
             struct xkb_led *led = &keymap->leds[i];
 
@@ -934,7 +934,7 @@ get_indicator_names(struct xkb_keymap *keymap,
     FAIL_UNLESS(msb_pos(reply->indicators) <= keymap->num_leds);
 
     for (unsigned i = 0; i < NUM_INDICATORS; i++) {
-        if (reply->indicators & (1u << i)) {
+        if (reply->indicators & (UINT32_C(1) << i)) {
             xcb_atom_t wire = *iter;
             struct xkb_led *led = &keymap->leds[i];
 
@@ -1137,7 +1137,7 @@ get_controls(struct xkb_keymap *keymap, xcb_connection_t *conn,
     FAIL_UNLESS(keymap->max_key_code < XCB_XKB_CONST_PER_KEY_BIT_ARRAY_SIZE * 8);
 
     for (xkb_keycode_t i = keymap->min_key_code; i <= keymap->max_key_code; i++)
-        keymap->keys[i].repeats = (reply->perKeyRepeat[i / 8] & (1 << (i % 8)));
+        keymap->keys[i].repeats = (reply->perKeyRepeat[i / 8] & (1u << (i % 8)));
 
     free(reply);
     return true;

--- a/src/xkbcomp/expr.c
+++ b/src/xkbcomp/expr.c
@@ -127,7 +127,7 @@ LookupModMask(struct xkb_context *ctx, const void *priv, xkb_atom_t field,
     if (ndx == XKB_MOD_INVALID)
         return false;
 
-    *val_rtrn = (1u << ndx);
+    *val_rtrn = (UINT32_C(1) << ndx);
     return true;
 }
 

--- a/src/xkbcomp/keymap-dump.c
+++ b/src/xkbcomp/keymap-dump.c
@@ -699,7 +699,7 @@ write_symbols(struct xkb_keymap *keymap, struct buf *buf)
     xkb_mods_enumerate(i, mod, &keymap->mods) {
         bool had_any = false;
         xkb_keys_foreach(key, keymap) {
-            if (key->modmap & (1u << i)) {
+            if (key->modmap & (UINT32_C(1) << i)) {
                 if (!had_any)
                     write_buf(buf, "\tmodifier_map %s { ",
                               xkb_atom_text(keymap->ctx, mod->name));

--- a/src/xkbcomp/keymap.c
+++ b/src/xkbcomp/keymap.c
@@ -190,7 +190,7 @@ ApplyInterpsToKey(struct xkb_keymap *keymap, struct xkb_key *key)
 
                 if ((group == 0 && level == 0) || !interp->level_one_only)
                     if (interp->virtual_mod != XKB_MOD_INVALID)
-                        vmodmap |= (1u << interp->virtual_mod);
+                        vmodmap |= (UINT32_C(1) << interp->virtual_mod);
 
                 if (interp->action.type != ACTION_TYPE_NONE) {
                     if (darray_size(interprets) == 1) {
@@ -289,7 +289,7 @@ UpdateDerivedKeymapFields(struct xkb_keymap *keymap)
     /* Update keymap->mods, the virtual -> real mod mapping. */
     xkb_keys_foreach(key, keymap)
         xkb_mods_enumerate(i, mod, &keymap->mods)
-            if (key->vmodmap & (1u << i))
+            if (key->vmodmap & (UINT32_C(1) << i))
                 mod->mapping |= key->modmap;
 
     /* Now update the level masks for all the types to reflect the vmods. */

--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -717,7 +717,7 @@ matcher_mapping_set_layout_bounds(struct matcher *m)
             m->mapping.has_layout_idx_range = false;
             m->mapping.layout_idx_min = idx;
             m->mapping.layout_idx_max = idx + 1;
-            m->mapping.layouts_candidates_mask = 1u << idx;
+            m->mapping.layouts_candidates_mask = UINT32_C(1) << idx;
     }
 }
 
@@ -1242,7 +1242,7 @@ matcher_rule_apply_if_matches(struct matcher *m, struct scanner *s)
                      idx++)                                                  \
                 {                                                            \
                     /* Process only if index not skipped */                  \
-                    xkb_layout_mask_t mask = 1u << idx;                      \
+                    xkb_layout_mask_t mask = UINT32_C(1) << idx;             \
                     if (candidate_layouts & mask) {                          \
                         to = &darray_item(m->rmlvo._component, idx);         \
                         if (match_value_and_mark(m, value, to, match_type,   \
@@ -1290,7 +1290,7 @@ matcher_rule_apply_if_matches(struct matcher *m, struct scanner *s)
              idx < m->mapping.layout_idx_max;
              idx++)
         {
-            if (candidate_layouts & (1u << idx)) {
+            if (candidate_layouts & (UINT32_C(1) << idx)) {
                 for (unsigned i = 0; i < m->mapping.num_kccgst; i++) {
                     enum rules_kccgst kccgst = m->mapping.kccgst_at_pos[i];
                     struct sval value = m->rule.kccgst_value_at_pos[i];

--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -695,7 +695,8 @@ matcher_mapping_set_layout_bounds(struct matcher *m)
                                             darray_size(m->rmlvo.layouts));
             m->mapping.layouts_candidates_mask =
                 /* All but the first layout */
-                ((1u << m->mapping.layout_idx_max) - 1) & ~1;
+                ((UINT64_C(1) << m->mapping.layout_idx_max) - UINT64_C(1)) &
+                ~UINT64_C(1);
             break;
         case LAYOUT_INDEX_ANY:
             m->mapping.has_layout_idx_range = true;
@@ -704,7 +705,7 @@ matcher_mapping_set_layout_bounds(struct matcher *m)
                                             darray_size(m->rmlvo.layouts));
             m->mapping.layouts_candidates_mask =
                 /* All layouts */
-                (1u << m->mapping.layout_idx_max) - 1;
+                (UINT64_C(1) << m->mapping.layout_idx_max) - UINT64_C(1);
             break;
         case LAYOUT_INDEX_FIRST:
         case XKB_LAYOUT_INVALID:

--- a/src/xkbcomp/symbols.c
+++ b/src/xkbcomp/symbols.c
@@ -1751,7 +1751,7 @@ CopyModMapDefToKeymap(struct xkb_keymap *keymap, SymbolsInfo *info,
     // Handle modMap None
     if (entry->modifier != XKB_MOD_NONE) {
         // Convert modifier index to modifier mask
-        key->modmap |= (1u << entry->modifier);
+        key->modmap |= (UINT32_C(1) << entry->modifier);
     }
 
     return true;

--- a/test/common.c
+++ b/test/common.c
@@ -80,7 +80,7 @@ print_detailed_state(struct xkb_state *state)
     xkb_led_mask_t leds = 0;
     for (xkb_led_index_t led = 0; led < xkb_keymap_num_leds(keymap); led++) {
         if (xkb_state_led_index_is_active(state, led) > 0)
-            leds |= 1u << led;
+            leds |= UINT32_C(1) << led;
     }
     fprintf(stderr, "  LEDs: 0x%x\n", leds);
 }

--- a/test/keymap.c
+++ b/test/keymap.c
@@ -120,9 +120,9 @@ test_keymap(void)
     assert(mask_count == 1);
     assert(masks_out[0] == 0);
 
-    shift_mask = 1 << xkb_keymap_mod_get_index(keymap, XKB_MOD_NAME_SHIFT);
-    lock_mask = 1 << xkb_keymap_mod_get_index(keymap, XKB_MOD_NAME_CAPS);
-    mod2_mask = 1 << xkb_keymap_mod_get_index(keymap, XKB_MOD_NAME_MOD2);
+    shift_mask = UINT32_C(1) << xkb_keymap_mod_get_index(keymap, XKB_MOD_NAME_SHIFT);
+    lock_mask = UINT32_C(1) << xkb_keymap_mod_get_index(keymap, XKB_MOD_NAME_CAPS);
+    mod2_mask = UINT32_C(1) << xkb_keymap_mod_get_index(keymap, XKB_MOD_NAME_MOD2);
 
     // AC01 level 1 ('A') requires either Shift or Lock modifiers on us-pc104
     mask_count = xkb_keymap_key_get_mods_for_level(keymap, kc, 0, 1, masks_out, 4);
@@ -239,9 +239,9 @@ test_no_extra_groups(void)
     xkb_context_unref(context);
 }
 
-#define Mod1Mask (1 << 3)
-#define Mod2Mask (1 << 4)
-#define Mod3Mask (1 << 5)
+#define Mod1Mask (UINT32_C(1) << 3)
+#define Mod2Mask (UINT32_C(1) << 4)
+#define Mod3Mask (UINT32_C(1) << 5)
 
 static void
 test_numeric_keysyms(void)

--- a/test/keymap.c
+++ b/test/keymap.c
@@ -349,7 +349,7 @@ test_multiple_actions_per_level(void)
     assert(layout == 0);
     xkb_state_update_key(state, KEY_LEFTCTRL + EVDEV_OFFSET, XKB_KEY_DOWN);
     base_mods = xkb_state_serialize_mods(state, XKB_STATE_MODS_DEPRESSED);
-    assert(base_mods == (1U << ctrl));
+    assert(base_mods == (UINT32_C(1) << ctrl));
     layout = xkb_state_serialize_layout(state, XKB_STATE_LAYOUT_DEPRESSED);
     assert(layout == 1);
     layout = xkb_state_serialize_layout(state, XKB_STATE_LAYOUT_LATCHED);
@@ -371,7 +371,7 @@ test_multiple_actions_per_level(void)
     assert(layout == 0);
     xkb_state_update_key(state, KEY_LVL3 + EVDEV_OFFSET, XKB_KEY_DOWN);
     base_mods = xkb_state_serialize_mods(state, XKB_STATE_MODS_DEPRESSED);
-    assert(base_mods == (1U << level3));
+    assert(base_mods == (UINT32_C(1) << level3));
     layout = xkb_state_serialize_layout(state, XKB_STATE_LAYOUT_DEPRESSED);
     assert(layout == 1);
     layout = xkb_state_serialize_layout(state, XKB_STATE_LAYOUT_LATCHED);
@@ -490,7 +490,7 @@ test_multiple_actions_per_level(void)
     assert(layout == 0);
     xkb_state_update_key(state, KEY_LEFTCTRL + EVDEV_OFFSET, XKB_KEY_DOWN);
     base_mods = xkb_state_serialize_mods(state, XKB_STATE_MODS_DEPRESSED);
-    assert(base_mods == (1U << ctrl));
+    assert(base_mods == (UINT32_C(1) << ctrl));
     layout = xkb_state_key_get_layout(state, XKB_KEY_2 + EVDEV_OFFSET);
     assert(layout == 1);
     xkb_state_update_key(state, KEY_LEFTCTRL + EVDEV_OFFSET, XKB_KEY_UP);
@@ -504,7 +504,7 @@ test_multiple_actions_per_level(void)
     assert(layout == 1);
     xkb_state_update_key(state, KEY_LEFTCTRL + EVDEV_OFFSET, XKB_KEY_DOWN);
     base_mods = xkb_state_serialize_mods(state, XKB_STATE_MODS_DEPRESSED);
-    assert(base_mods == (1U << ctrl));
+    assert(base_mods == (UINT32_C(1) << ctrl));
     layout = xkb_state_key_get_layout(state, XKB_KEY_2 + EVDEV_OFFSET);
     assert(layout == 0);
     xkb_state_update_key(state, KEY_LEFTCTRL + EVDEV_OFFSET, XKB_KEY_UP);

--- a/test/keyseq.c
+++ b/test/keyseq.c
@@ -334,11 +334,11 @@ test_explicit_actions(struct xkb_context *ctx)
          * explicit actions as well as repeat=Yes.
          */
         const struct key_properties keys[] = {
-            { .name = "LALT", .repeats = false, .vmodmap = 0        },
-            { .name = "LVL3", .repeats = false, .vmodmap = 1u << 10 },
-            { .name = "AD05", .repeats = true , .vmodmap = 0        },
+            { .name = "LALT", .repeats = false, .vmodmap = 0 },
+            { .name = "LVL3", .repeats = false, .vmodmap = UINT32_C(1) << 10 },
+            { .name = "AD05", .repeats = true , .vmodmap = 0 },
             /* No explicit actions, check defaults */
-            { .name = "AD06", .repeats = true , .vmodmap = 0        },
+            { .name = "AD06", .repeats = true , .vmodmap = 0 },
         };
         for (unsigned i = 0; i < ARRAY_SIZE(keys); i++) {
             xkb_keycode_t kc = xkb_keymap_key_by_name(keymaps[k], keys[i].name);

--- a/test/modifiers.c
+++ b/test/modifiers.c
@@ -41,14 +41,14 @@
 #define Mod5Index    7
 
 /* Standard real modifier masks */
-#define ShiftMask   (1 << ShiftIndex)
-#define LockMask    (1 << LockIndex)
-#define ControlMask (1 << ControlIndex)
-#define Mod1Mask    (1 << Mod1Index)
-#define Mod2Mask    (1 << Mod2Index)
-#define Mod3Mask    (1 << Mod3Index)
-#define Mod4Mask    (1 << Mod4Index)
-#define Mod5Mask    (1 << Mod5Index)
+#define ShiftMask   (UINT32_C(1) << ShiftIndex)
+#define LockMask    (UINT32_C(1) << LockIndex)
+#define ControlMask (UINT32_C(1) << ControlIndex)
+#define Mod1Mask    (UINT32_C(1) << Mod1Index)
+#define Mod2Mask    (UINT32_C(1) << Mod2Index)
+#define Mod3Mask    (UINT32_C(1) << Mod3Index)
+#define Mod4Mask    (UINT32_C(1) << Mod4Index)
+#define Mod5Mask    (UINT32_C(1) << Mod5Index)
 #define NoModifier  0
 
 static bool
@@ -57,7 +57,7 @@ test_real_mod(struct xkb_keymap *keymap, const char* name,
 {
     return xkb_keymap_mod_get_index(keymap, name) == idx &&
            (keymap->mods.mods[idx].type == MOD_REAL) &&
-           mapping == (1u << idx);
+           mapping == (UINT32_C(1) << idx);
 }
 
 static bool

--- a/test/state.c
+++ b/test/state.c
@@ -347,21 +347,21 @@ test_serialisation(struct xkb_keymap *keymap)
     xkb_mod_index_t numIdx    = _xkb_keymap_mod_get_index(keymap, XKB_VMOD_NAME_NUM);
     xkb_mod_index_t level3Idx = _xkb_keymap_mod_get_index(keymap, XKB_VMOD_NAME_LEVEL3);
     xkb_mod_index_t altGrIdx  = _xkb_keymap_mod_get_index(keymap, "AltGr");
-    xkb_mod_mask_t shift  = (1u << shiftIdx);
-    xkb_mod_mask_t caps   = (1u << capsIdx);
-    xkb_mod_mask_t ctrl   = (1u << ctrlIdx);
-    xkb_mod_mask_t mod1   = (1u << mod1Idx);
-    xkb_mod_mask_t mod2   = (1u << mod2Idx);
-    xkb_mod_mask_t mod3   = (1u << mod3Idx);
-    xkb_mod_mask_t mod4   = (1u << mod4Idx);
-    xkb_mod_mask_t mod5   = (1u << mod5Idx);
-    xkb_mod_mask_t alt    = (1u << altIdx);
-    xkb_mod_mask_t meta   = (1u << metaIdx);
-    xkb_mod_mask_t super  = (1u << superIdx);
-    xkb_mod_mask_t hyper  = (1u << hyperIdx);
-    xkb_mod_mask_t num    = (1u << numIdx);
-    xkb_mod_mask_t level3 = (1u << level3Idx);
-    xkb_mod_mask_t altGr  = (1u << altGrIdx);
+    xkb_mod_mask_t shift  = (UINT32_C(1) << shiftIdx);
+    xkb_mod_mask_t caps   = (UINT32_C(1) << capsIdx);
+    xkb_mod_mask_t ctrl   = (UINT32_C(1) << ctrlIdx);
+    xkb_mod_mask_t mod1   = (UINT32_C(1) << mod1Idx);
+    xkb_mod_mask_t mod2   = (UINT32_C(1) << mod2Idx);
+    xkb_mod_mask_t mod3   = (UINT32_C(1) << mod3Idx);
+    xkb_mod_mask_t mod4   = (UINT32_C(1) << mod4Idx);
+    xkb_mod_mask_t mod5   = (UINT32_C(1) << mod5Idx);
+    xkb_mod_mask_t alt    = (UINT32_C(1) << altIdx);
+    xkb_mod_mask_t meta   = (UINT32_C(1) << metaIdx);
+    xkb_mod_mask_t super  = (UINT32_C(1) << superIdx);
+    xkb_mod_mask_t hyper  = (UINT32_C(1) << hyperIdx);
+    xkb_mod_mask_t num    = (UINT32_C(1) << numIdx);
+    xkb_mod_mask_t level3 = (UINT32_C(1) << level3Idx);
+    xkb_mod_mask_t altGr  = (UINT32_C(1) << altGrIdx);
 
     xkb_state_update_key(state, KEY_CAPSLOCK + EVDEV_OFFSET, XKB_KEY_DOWN);
     xkb_state_update_key(state, KEY_CAPSLOCK + EVDEV_OFFSET, XKB_KEY_UP);
@@ -409,7 +409,7 @@ test_serialisation(struct xkb_keymap *keymap)
         const struct test_active_mods_entry *entry = &test_data[k];
 #define check_mods(keymap, state, entry, type)                                      \
         for (xkb_mod_index_t idx = 0; idx < xkb_keymap_num_mods(keymap); idx++) {   \
-            xkb_mod_mask_t mask = 1u << idx;                                        \
+            xkb_mod_mask_t mask = UINT32_C(1) << idx;                                        \
             bool expected = !!(mask & entry->active);                               \
             bool got = !!xkb_state_mod_index_is_active(state, idx, type);           \
             fprintf(stderr, "#%u State 0x%x, mod: %u: expected %u, got: %u\n",      \
@@ -458,13 +458,13 @@ test_update_mask_mods(struct xkb_keymap *keymap)
     xkb_mod_index_t altIdx   = _xkb_keymap_mod_get_index(keymap, XKB_VMOD_NAME_ALT);
     xkb_mod_index_t metaIdx  = _xkb_keymap_mod_get_index(keymap, XKB_VMOD_NAME_META);
     xkb_mod_index_t numIdx   = _xkb_keymap_mod_get_index(keymap, XKB_VMOD_NAME_NUM);
-    xkb_mod_mask_t caps  = (1u << capsIdx);
-    xkb_mod_mask_t shift = (1u << shiftIdx);
-    xkb_mod_mask_t mod1  = (1u << mod1Idx);
-    xkb_mod_mask_t mod2  = (1u << mod2Idx);
-    xkb_mod_mask_t alt   = (1u << altIdx);
-    xkb_mod_mask_t meta  = (1u << metaIdx);
-    xkb_mod_mask_t num   = (1u << numIdx);
+    xkb_mod_mask_t caps  = (UINT32_C(1) << capsIdx);
+    xkb_mod_mask_t shift = (UINT32_C(1) << shiftIdx);
+    xkb_mod_mask_t mod1  = (UINT32_C(1) << mod1Idx);
+    xkb_mod_mask_t mod2  = (UINT32_C(1) << mod2Idx);
+    xkb_mod_mask_t alt   = (UINT32_C(1) << altIdx);
+    xkb_mod_mask_t meta  = (UINT32_C(1) << metaIdx);
+    xkb_mod_mask_t num   = (UINT32_C(1) << numIdx);
 
     changed = xkb_state_update_mask(state, caps, 0, 0, 0, 0, 0);
     assert(changed == (XKB_STATE_MODS_DEPRESSED | XKB_STATE_MODS_EFFECTIVE));
@@ -549,14 +549,14 @@ test_consume(struct xkb_keymap *keymap)
     print_state(state);
 
     mask = xkb_state_serialize_mods(state, XKB_STATE_MODS_EFFECTIVE);
-    assert(mask == ((1U << mod1) | (1U << shift)));
+    assert(mask == ((UINT32_C(1) << mod1) | (UINT32_C(1) << shift)));
     mask = xkb_state_mod_mask_remove_consumed(state, KEY_EQUAL + EVDEV_OFFSET,
                                               mask);
-    assert(mask == (1U << mod1));
+    assert(mask == (UINT32_C(1) << mod1));
 
     /* Test get_consumed_mods() */
     mask = xkb_state_key_get_consumed_mods(state, KEY_EQUAL + EVDEV_OFFSET);
-    assert(mask == (1U << shift));
+    assert(mask == (UINT32_C(1) << shift));
 
     mask = xkb_state_key_get_consumed_mods(state, KEY_ESC + EVDEV_OFFSET);
     assert(mask == 0);
@@ -573,7 +573,7 @@ test_consume(struct xkb_keymap *keymap)
     assert(state);
 
     mask = xkb_state_key_get_consumed_mods(state, KEY_A + EVDEV_OFFSET);
-    assert(mask == ((1U << shift) | (1U << caps)));
+    assert(mask == ((UINT32_C(1) << shift) | (UINT32_C(1) << caps)));
 
     assert(xkb_state_mod_index_is_consumed(state, KEY_A + EVDEV_OFFSET, caps) > 0);
     assert(xkb_state_mod_index_is_consumed(state, KEY_A + EVDEV_OFFSET, shift) > 0);
@@ -597,16 +597,19 @@ test_consume(struct xkb_keymap *keymap)
     assert(state);
 
     mask = xkb_state_key_get_consumed_mods(state, KEY_F1 + EVDEV_OFFSET);
-    assert(mask == ((1U << shift) | (1U << mod1) | (1U << ctrl) | (1U << mod5)));
+    assert(mask == ((UINT32_C(1) << shift) | (UINT32_C(1) << mod1) |
+                    (UINT32_C(1) << ctrl) | (UINT32_C(1) << mod5)));
 
     /* Shift is preserved. */
     xkb_state_update_key(state, KEY_LEFTSHIFT + EVDEV_OFFSET, XKB_KEY_DOWN);
     mask = xkb_state_key_get_consumed_mods(state, KEY_F1 + EVDEV_OFFSET);
-    assert(mask == ((1U << mod1) | (1U << ctrl) | (1U << mod5)));
+    assert(mask == ((UINT32_C(1) << mod1) | (UINT32_C(1) << ctrl) |
+                    (UINT32_C(1) << mod5)));
     xkb_state_update_key(state, KEY_LEFTSHIFT + EVDEV_OFFSET, XKB_KEY_UP);
 
     mask = xkb_state_key_get_consumed_mods(state, KEY_F1 + EVDEV_OFFSET);
-    assert(mask == ((1U << shift) | (1U << mod1) | (1U << ctrl) | (1U << mod5)));
+    assert(mask == ((UINT32_C(1) << shift) | (UINT32_C(1) << mod1) |
+                    (UINT32_C(1) << ctrl) | (UINT32_C(1) << mod5)));
 
     xkb_state_unref(state);
 
@@ -626,18 +629,19 @@ test_consume(struct xkb_keymap *keymap)
     xkb_state_update_key(state, KEY_LEFTALT + EVDEV_OFFSET, XKB_KEY_DOWN);
     mask = xkb_state_key_get_consumed_mods2(state, KEY_F1 + EVDEV_OFFSET,
                                             XKB_CONSUMED_MODE_GTK);
-    assert(mask == ((1U << mod1) | (1U << ctrl)));
+    assert(mask == ((UINT32_C(1) << mod1) | (UINT32_C(1) << ctrl)));
     assert(xkb_state_mod_index_is_consumed(state, KEY_F1 + EVDEV_OFFSET, shift) > 0);
     assert(xkb_state_mod_index_is_consumed(state, KEY_F1 + EVDEV_OFFSET, ctrl) > 0);
     assert(xkb_state_mod_index_is_consumed(state, KEY_F1 + EVDEV_OFFSET, mod1) > 0);
     assert(xkb_state_mod_index_is_consumed(state, KEY_F1 + EVDEV_OFFSET, alt) > 0);
     assert(xkb_state_mod_index_is_consumed(state, KEY_F1 + EVDEV_OFFSET, meta) > 0);
-    mask = (1U << ctrl) | (1U << mod1) | (1U << mod2);
+    mask = (UINT32_C(1) << ctrl) | (UINT32_C(1) << mod1) | (UINT32_C(1) << mod2);
     mask = xkb_state_mod_mask_remove_consumed(state, KEY_F1 + EVDEV_OFFSET, mask);
-    assert(mask == (1U << mod2));
-    mask = (1U << ctrl) | (1U << alt) | (1U << meta) | (1U << mod2);
+    assert(mask == (UINT32_C(1) << mod2));
+    mask = (UINT32_C(1) << ctrl) | (UINT32_C(1) << alt) | (UINT32_C(1) << meta) |
+           (UINT32_C(1) << mod2);
     mask = xkb_state_mod_mask_remove_consumed(state, KEY_F1 + EVDEV_OFFSET, mask);
-    assert(mask == (1U << mod2));
+    assert(mask == (UINT32_C(1) << mod2));
 
     xkb_state_unref(state);
 
@@ -647,12 +651,12 @@ test_consume(struct xkb_keymap *keymap)
 
     mask = xkb_state_key_get_consumed_mods2(state, KEY_A + EVDEV_OFFSET,
                                             XKB_CONSUMED_MODE_GTK);
-    assert(mask == ((1U << shift) | (1U << caps)));
+    assert(mask == ((UINT32_C(1) << shift) | (UINT32_C(1) << caps)));
 
     xkb_state_update_key(state, KEY_LEFTALT + EVDEV_OFFSET, XKB_KEY_DOWN);
     mask = xkb_state_key_get_consumed_mods2(state, KEY_A + EVDEV_OFFSET,
                                             XKB_CONSUMED_MODE_GTK);
-    assert(mask == ((1U << shift) | (1U << caps)));
+    assert(mask == ((UINT32_C(1) << shift) | (UINT32_C(1) << caps)));
 
     xkb_state_unref(state);
 }
@@ -681,16 +685,16 @@ test_overlapping_mods(struct xkb_context *context)
     xkb_mod_index_t hyperIdx = _xkb_keymap_mod_get_index(keymap, XKB_VMOD_NAME_HYPER);
     /* Note: not mapped */
     xkb_mod_index_t scrollIdx = _xkb_keymap_mod_get_index(keymap, XKB_VMOD_NAME_SCROLL);
-    xkb_mod_mask_t shift = (1u << shiftIdx);
-    xkb_mod_mask_t ctrl  = (1u << ctrlIdx);
-    xkb_mod_mask_t mod1  = (1u << mod1Idx);
-    xkb_mod_mask_t mod3  = (1u << mod3Idx);
-    xkb_mod_mask_t mod4  = (1u << mod4Idx);
-    xkb_mod_mask_t mod5  = (1u << mod5Idx);
-    xkb_mod_mask_t alt   = (1u << altIdx);
-    xkb_mod_mask_t meta  = (1u << metaIdx);
-    xkb_mod_mask_t super = (1u << superIdx);
-    xkb_mod_mask_t hyper = (1u << hyperIdx);
+    xkb_mod_mask_t shift = (UINT32_C(1) << shiftIdx);
+    xkb_mod_mask_t ctrl  = (UINT32_C(1) << ctrlIdx);
+    xkb_mod_mask_t mod1  = (UINT32_C(1) << mod1Idx);
+    xkb_mod_mask_t mod3  = (UINT32_C(1) << mod3Idx);
+    xkb_mod_mask_t mod4  = (UINT32_C(1) << mod4Idx);
+    xkb_mod_mask_t mod5  = (UINT32_C(1) << mod5Idx);
+    xkb_mod_mask_t alt   = (UINT32_C(1) << altIdx);
+    xkb_mod_mask_t meta  = (UINT32_C(1) << metaIdx);
+    xkb_mod_mask_t super = (UINT32_C(1) << superIdx);
+    xkb_mod_mask_t hyper = (UINT32_C(1) << hyperIdx);
     state = xkb_state_new(keymap);
     assert(state);
 
@@ -771,10 +775,10 @@ test_overlapping_mods(struct xkb_context *context)
     metaIdx  = _xkb_keymap_mod_get_index(keymap, XKB_VMOD_NAME_META);
     superIdx = _xkb_keymap_mod_get_index(keymap, XKB_VMOD_NAME_SUPER);
     hyperIdx = _xkb_keymap_mod_get_index(keymap, XKB_VMOD_NAME_HYPER);
-    alt   = (1u << altIdx);
-    meta  = (1u << metaIdx);
-    super = (1u << superIdx);
-    hyper = (1u << hyperIdx);
+    alt   = (UINT32_C(1) << altIdx);
+    meta  = (UINT32_C(1) << metaIdx);
+    super = (UINT32_C(1) << superIdx);
+    hyper = (UINT32_C(1) << hyperIdx);
     state = xkb_state_new(keymap);
     assert(state);
 
@@ -864,10 +868,10 @@ test_overlapping_mods(struct xkb_context *context)
     metaIdx  = _xkb_keymap_mod_get_index(keymap, XKB_VMOD_NAME_META);
     superIdx = _xkb_keymap_mod_get_index(keymap, XKB_VMOD_NAME_SUPER);
     hyperIdx = _xkb_keymap_mod_get_index(keymap, XKB_VMOD_NAME_HYPER);
-    alt   = (1u << altIdx);
-    meta  = (1u << metaIdx);
-    super = (1u << superIdx);
-    hyper = (1u << hyperIdx);
+    alt   = (UINT32_C(1) << altIdx);
+    meta  = (UINT32_C(1) << metaIdx);
+    super = (UINT32_C(1) << superIdx);
+    hyper = (UINT32_C(1) << hyperIdx);
     state = xkb_state_new(keymap);
     assert(state);
 
@@ -1159,7 +1163,7 @@ test_active_leds(struct xkb_state *state, xkb_led_mask_t leds_expected)
         const int status = xkb_state_led_index_is_active(state, led);
         if (status < 0)
             continue;
-        const xkb_led_mask_t mask = (1u << led);
+        const xkb_led_mask_t mask = (UINT32_C(1) << led);
         const bool expected = !!(leds_expected & mask);
         if (status)
             leds_got |= mask;
@@ -1210,15 +1214,15 @@ test_leds(struct xkb_context *ctx)
     const xkb_led_index_t mail_idx = _xkb_keymap_led_get_index(keymap, "Mail");
     const xkb_led_index_t charging_idx = _xkb_keymap_led_get_index(keymap, "Charging");
 
-    const xkb_led_mask_t caps = 1u << caps_idx;
-    const xkb_led_mask_t num = 1u << num_idx;
-    const xkb_led_mask_t scroll = 1u << scroll_idx;
-    const xkb_led_mask_t compose = 1u << compose_idx;
-    const xkb_led_mask_t sleep = 1u << sleep_idx;
-    const xkb_led_mask_t mute = 1u << mute_idx;
-    const xkb_led_mask_t misc = 1u << misc_idx;
-    const xkb_led_mask_t mail = 1u << mail_idx;
-    const xkb_led_mask_t charging = 1u << charging_idx;
+    const xkb_led_mask_t caps = UINT32_C(1) << caps_idx;
+    const xkb_led_mask_t num = UINT32_C(1) << num_idx;
+    const xkb_led_mask_t scroll = UINT32_C(1) << scroll_idx;
+    const xkb_led_mask_t compose = UINT32_C(1) << compose_idx;
+    const xkb_led_mask_t sleep = UINT32_C(1) << sleep_idx;
+    const xkb_led_mask_t mute = UINT32_C(1) << mute_idx;
+    const xkb_led_mask_t misc = UINT32_C(1) << misc_idx;
+    const xkb_led_mask_t mail = UINT32_C(1) << mail_idx;
+    const xkb_led_mask_t charging = UINT32_C(1) << charging_idx;
 
     struct xkb_state *state = xkb_state_new(keymap);
     assert(state);

--- a/tools/how-to-type.c
+++ b/tools/how-to-type.c
@@ -301,7 +301,7 @@ main(int argc, char *argv[])
                     printf("%-8u %-9s %-8u %-20s %-7u [ ",
                            keycode, key_name, layout + 1, layout_name, level + 1);
                     for (xkb_mod_index_t mod = 0; mod < num_mods; mod++) {
-                        if ((mask & (1 << mod)) == 0) {
+                        if ((mask & (UINT32_C(1) << mod)) == 0) {
                             continue;
                         }
                         printf("%s ", xkb_keymap_mod_get_name(keymap, mod));

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -76,7 +76,7 @@ print_keymap_modmaps(struct xkb_keymap *keymap) {
         if (keymap->mods.mods[vmod].mapping) {
             bool first = true;
             for (xkb_mod_index_t mod = 0; mod < xkb_keymap_num_mods(keymap); mod++) {
-                if (keymap->mods.mods[vmod].mapping & (1u << mod)) {
+                if (keymap->mods.mods[vmod].mapping & (UINT32_C(1) << mod)) {
                     if (first) {
                         first = false;
                         printf("%s", xkb_keymap_mod_get_name(keymap, mod));
@@ -103,7 +103,7 @@ print_key_modmaps(struct xkb_keymap *keymap, xkb_keycode_t keycode) {
         printf("modmap [ ");
         if (key->modmap) {
             for (mod = 0; mod < xkb_keymap_num_mods(keymap); mod++) {
-                if (key->modmap & (1u << mod)) {
+                if (key->modmap & (UINT32_C(1) << mod)) {
                     printf("%-*s", (int) MODMAP_PADDING,
                            xkb_keymap_mod_get_name(keymap, mod));
                     break;
@@ -117,7 +117,7 @@ print_key_modmaps(struct xkb_keymap *keymap, xkb_keycode_t keycode) {
         int length = 0;
         const char *mod_name;
         for (mod = 0; mod < xkb_keymap_num_mods(keymap); mod++) {
-            if (key->vmodmap & (1u << mod)) {
+            if (key->vmodmap & (UINT32_C(1) << mod)) {
                 mod_name = xkb_keymap_mod_get_name(keymap, mod);
                 length += strlen(mod_name) + 1;
                 printf("%s ", mod_name);


### PR DESCRIPTION
Fix a few of them and make the rest portable using `UINTn_C` macros.

@whot @bluetech 