### PR TITLE
Fix warnings about empty variadic macros

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -115,8 +115,8 @@ xkb_context_sanitize_rule_names(struct xkb_context *ctx,
  * format is supplied without arguments. Not supplying it would still
  * result in an error, though.
  */
-#define xkb_log_with_code(ctx, level, verbosity, msg_id, fmt, ...) \
-    xkb_log(ctx, level, verbosity, PREPEND_MESSAGE_ID(msg_id, fmt), ##__VA_ARGS__)
+#define xkb_log_with_code(ctx, level, verbosity, msg_id, ...) \
+    xkb_log(ctx, level, verbosity, PREPEND_MESSAGE_ID(msg_id, __VA_ARGS__))
 #define log_dbg(ctx, id, ...) \
     xkb_log_with_code((ctx), XKB_LOG_LEVEL_DEBUG, 0, id, __VA_ARGS__)
 #define log_info(ctx, id, ...) \

--- a/src/messages-codes.h
+++ b/src/messages-codes.h
@@ -25,15 +25,36 @@
 #define JOIN_EXPAND(a, b)        a##b
 #define JOIN(a, b)               JOIN_EXPAND(a, b)
 
+/* Determine if we have one or more arguments (up to 24) */
+#define _ARGS_COUNT(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13,\
+                    _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, ...) _24
+#define ARGS_COUNT(...)          _ARGS_COUNT(__VA_ARGS__, \
+                                   MORE, MORE, MORE, MORE, MORE, MORE, MORE, \
+                                   MORE, MORE, MORE, MORE, MORE, MORE, MORE, \
+                                   MORE, MORE, MORE, MORE, MORE, MORE, MORE, \
+                                   MORE, MORE, ONE, unused)
+
+#define FIRST_ONE(a)             a
+#define FIRST_MORE(a, ...)       a
+#define FIRST(...)               JOIN(FIRST_, ARGS_COUNT(__VA_ARGS__))(__VA_ARGS__)
+
 #define SECOND_EXPAND(a, b, ...) b
 #define SECOND(...)              EXPAND(SECOND_EXPAND(__VA_ARGS__))
+
+#define LATER_ONE(a)
+#define LATER_MORE(a, ...)       , __VA_ARGS__
+#define LATER(...)               JOIN(LATER_, ARGS_COUNT(__VA_ARGS__))(__VA_ARGS__)
+
+#define SWAP_FIRST_TWO_ONE(a, b)       b, a
+#define SWAP_FIRST_TWO_MORE(a, b, ...) b, a, __VA_ARGS__
+#define SWAP_FIRST_TWO(a, ...)   JOIN(SWAP_FIRST_TWO_, ARGS_COUNT(__VA_ARGS__))(a, __VA_ARGS__)
 
 #define MATCH0                   unused,WITHOUT_ID
 #define CHECK_ID(value)          SECOND(JOIN(MATCH, value), WITH_ID, unused)
 
-#define FORMAT_MESSAGE_WITHOUT_ID(id, fmt) fmt
-#define FORMAT_MESSAGE_WITH_ID(id, fmt)    "[XKB-%03d] " fmt, id
-#define PREPEND_MESSAGE_ID(id, fmt) JOIN(FORMAT_MESSAGE_, CHECK_ID(id))(id, fmt)
+#define FORMAT_MESSAGE_WITHOUT_ID(id, ...) __VA_ARGS__
+#define FORMAT_MESSAGE_WITH_ID(id, ...)    "[XKB-%03d] " SWAP_FIRST_TWO(id, __VA_ARGS__)
+#define PREPEND_MESSAGE_ID(id, ...) JOIN(FORMAT_MESSAGE_, CHECK_ID(id))(id, __VA_ARGS__)
 
 /**
  * Special case when no message identifier is defined.

--- a/src/messages-codes.h.jinja
+++ b/src/messages-codes.h.jinja
@@ -25,15 +25,36 @@
 #define JOIN_EXPAND(a, b)        a##b
 #define JOIN(a, b)               JOIN_EXPAND(a, b)
 
+/* Determine if we have one or more arguments (up to 24) */
+#define _ARGS_COUNT(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13,\
+                    _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, ...) _24
+#define ARGS_COUNT(...)          _ARGS_COUNT(__VA_ARGS__, \
+                                   MORE, MORE, MORE, MORE, MORE, MORE, MORE, \
+                                   MORE, MORE, MORE, MORE, MORE, MORE, MORE, \
+                                   MORE, MORE, MORE, MORE, MORE, MORE, MORE, \
+                                   MORE, MORE, ONE, unused)
+
+#define FIRST_ONE(a)             a
+#define FIRST_MORE(a, ...)       a
+#define FIRST(...)               JOIN(FIRST_, ARGS_COUNT(__VA_ARGS__))(__VA_ARGS__)
+
 #define SECOND_EXPAND(a, b, ...) b
 #define SECOND(...)              EXPAND(SECOND_EXPAND(__VA_ARGS__))
+
+#define LATER_ONE(a)
+#define LATER_MORE(a, ...)       , __VA_ARGS__
+#define LATER(...)               JOIN(LATER_, ARGS_COUNT(__VA_ARGS__))(__VA_ARGS__)
+
+#define SWAP_FIRST_TWO_ONE(a, b)       b, a
+#define SWAP_FIRST_TWO_MORE(a, b, ...) b, a, __VA_ARGS__
+#define SWAP_FIRST_TWO(a, ...)   JOIN(SWAP_FIRST_TWO_, ARGS_COUNT(__VA_ARGS__))(a, __VA_ARGS__)
 
 #define MATCH0                   unused,WITHOUT_ID
 #define CHECK_ID(value)          SECOND(JOIN(MATCH, value), WITH_ID, unused)
 
-#define FORMAT_MESSAGE_WITHOUT_ID(id, fmt) fmt
-#define FORMAT_MESSAGE_WITH_ID(id, fmt)    "[XKB-%03d] " fmt, id
-#define PREPEND_MESSAGE_ID(id, fmt) JOIN(FORMAT_MESSAGE_, CHECK_ID(id))(id, fmt)
+#define FORMAT_MESSAGE_WITHOUT_ID(id, ...) __VA_ARGS__
+#define FORMAT_MESSAGE_WITH_ID(id, ...)    "[XKB-%03d] " SWAP_FIRST_TWO(id, __VA_ARGS__)
+#define PREPEND_MESSAGE_ID(id, ...) JOIN(FORMAT_MESSAGE_, CHECK_ID(id))(id, __VA_ARGS__)
 
 /**
  * Special case when no message identifier is defined.

--- a/src/registry.c
+++ b/src/registry.c
@@ -157,8 +157,8 @@ rxkb_log(struct rxkb_context *ctx, enum rxkb_log_level level,
  * format is supplied without arguments. Not supplying it would still
  * result in an error, though.
  */
-#define rxkb_log_with_code(ctx, level, msg_id, fmt, ...) \
-    rxkb_log(ctx, level, PREPEND_MESSAGE_ID(msg_id, fmt), ##__VA_ARGS__)
+#define rxkb_log_with_code(ctx, level, msg_id, ...) \
+    rxkb_log(ctx, level, PREPEND_MESSAGE_ID(msg_id, __VA_ARGS__))
 #define log_dbg(ctx, ...) \
     rxkb_log((ctx), RXKB_LOG_LEVEL_DEBUG, __VA_ARGS__)
 #define log_info(ctx, ...) \

--- a/src/scanner-utils.h
+++ b/src/scanner-utils.h
@@ -24,6 +24,8 @@
 #ifndef XKBCOMP_SCANNER_UTILS_H
 #define XKBCOMP_SCANNER_UTILS_H
 
+#include "messages-codes.h"
+
 /* Point to some substring in the file; used to avoid copying. */
 struct sval {
     const char *start;
@@ -57,24 +59,22 @@ struct scanner {
     void *priv;
 };
 
-#define scanner_log_with_code(scanner, level, verbosity, log_msg_id, fmt, ...) \
-    xkb_log_with_code((scanner)->ctx, (level), verbosity, log_msg_id,          \
-                      "%s:%zu:%zu: " fmt "\n",                                 \
-                      (scanner)->file_name,                                    \
-                      (scanner)->token_line,                                   \
-                      (scanner)->token_column, ##__VA_ARGS__)
+#define scanner_log_with_code(scanner, level, verbosity, log_msg_id, ...) \
+    xkb_log_with_code((scanner)->ctx, (level), verbosity, log_msg_id,     \
+                      "%s:%zu:%zu: " FIRST(__VA_ARGS__) "\n",             \
+                      (scanner)->file_name,                               \
+                      (scanner)->token_line,                              \
+                      (scanner)->token_column LATER(__VA_ARGS__))
 
-#define scanner_err(scanner, id, fmt, ...)                     \
-    scanner_log_with_code(scanner, XKB_LOG_LEVEL_ERROR, 0, id, \
-                          fmt, ##__VA_ARGS__)
+#define scanner_err(scanner, id, ...) \
+    scanner_log_with_code(scanner, XKB_LOG_LEVEL_ERROR, 0, id, __VA_ARGS__)
 
-#define scanner_warn(scanner, id, fmt, ...)                      \
-    scanner_log_with_code(scanner, XKB_LOG_LEVEL_WARNING, 0, id, \
-                          fmt, ##__VA_ARGS__)
+#define scanner_warn(scanner, id, ...) \
+    scanner_log_with_code(scanner, XKB_LOG_LEVEL_WARNING, 0, id, __VA_ARGS__)
 
-#define scanner_vrb(scanner, verbosity, id, fmt, ...)                    \
-    scanner_log_with_code(scanner, XKB_LOG_LEVEL_WARNING, verbosity, id, \
-                          fmt, ##__VA_ARGS__)
+#define scanner_vrb(scanner, verbosity, id, ...)          \
+    scanner_log_with_code(scanner, XKB_LOG_LEVEL_WARNING, \
+                          verbosity, id, __VA_ARGS__)
 
 static inline void
 scanner_init(struct scanner *s, struct xkb_context *ctx,

--- a/src/xkbcomp/parser.y
+++ b/src/xkbcomp/parser.y
@@ -46,11 +46,11 @@ struct parser_param {
     bool more_maps;
 };
 
-#define parser_err(param, error_id, fmt, ...) \
-    scanner_err((param)->scanner, error_id, fmt, ##__VA_ARGS__)
+#define parser_err(param, error_id, ...) \
+    scanner_err((param)->scanner, error_id, __VA_ARGS__)
 
-#define parser_warn(param, warning_id, fmt, ...) \
-    scanner_warn((param)->scanner, warning_id, fmt, ##__VA_ARGS__)
+#define parser_warn(param, warning_id, ...) \
+    scanner_warn((param)->scanner, warning_id, __VA_ARGS__)
 
 static void
 _xkbcommon_error(struct parser_param *param, const char *msg)


### PR DESCRIPTION
Avoid using the GNU extension for `, ##`.

I got a flood of warnings with `-Wpedantic`. 

Note that if we do not merge this, we should remove the following comments in the code:

> The format is not part of the argument list in order to avoid the "ISO C99 requires rest arguments to be used" warning when only the format is supplied without arguments.
