### PR TITLE
meson: Make building benchmarks & fuzzers optional

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -54,6 +54,7 @@ jobs:
           # -gdwarf-4 - see https://github.com/llvm/llvm-project/issues/56550.
           CFLAGS='-gdwarf-4 -fno-omit-frame-pointer' \
               meson setup -Denable-docs=true -Denable-cool-uris=true \
+                          -Denable-benchmarks=true -Denable-fuzzers=true \
                           $MESON_EXTRA_FLAGS \
                           build
         env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -39,6 +39,8 @@ jobs:
             meson setup \
               -Denable-wayland=false \
               -Denable-x11=true \
+              -Denable-benchmarks=true \
+              -Denable-fuzzers=true \
               -Dxkb-config-root="$(brew --prefix xkeyboardconfig)/share/X11/xkb" \
               -Dx-locale-root="$(brew --prefix xorg-server)/share/X11/locale" \
               build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,7 +32,10 @@ jobs:
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-          meson setup --backend=vs -Denable-wayland=false -Denable-x11=false -Denable-docs=false -Denable-xkbregistry=false build
+          meson setup --backend=vs -Denable-wayland=false -Denable-x11=false ^
+                      -Denable-docs=false -Denable-xkbregistry=false ^
+                      -Denable-benchmarks=true -Denable-fuzzers=true ^
+                      build
       - name: Build
         shell: cmd
         run: |

--- a/changes/build/+make-bench-fuzz-optional.breaking.md
+++ b/changes/build/+make-bench-fuzz-optional.breaking.md
@@ -1,0 +1,2 @@
+Make building the benchmarks and the fuzzers optional via the new build options
+`enable-benchmarks` and `enable-fuzzers`.

--- a/meson.build
+++ b/meson.build
@@ -945,87 +945,91 @@ endif
 
 
 # Fuzzing target programs.
-executable('fuzz-keymap', 'fuzz/keymap/target.c', dependencies: test_dep)
-executable('fuzz-compose', 'fuzz/compose/target.c', dependencies: test_dep)
+if get_option('enable-fuzzers')
+    executable('fuzz-keymap', 'fuzz/keymap/target.c', dependencies: test_dep)
+    executable('fuzz-compose', 'fuzz/compose/target.c', dependencies: test_dep)
+endif
 
 
 # Benchmarks.
-bench_env = environment()
-bench_env.set('top_srcdir', meson.current_source_dir())
-benchmark(
-    'key-proc',
-    executable('bench-key-proc', 'bench/key-proc.c', dependencies: test_dep),
-    env: bench_env,
-)
-benchmark(
-    'keysym-case-mappings',
-    executable(
-        'bench-keysym-case-mappings',
-        'bench/keysym-case-mappings.c',
-        dependencies: test_dep,
-        c_args: ['-DENABLE_PRIVATE_APIS'],
-    ),
-)
-benchmark(
-    'rules',
-    executable('bench-rules', 'bench/rules.c', dependencies: test_dep),
-    env: bench_env,
-)
-benchmark(
-    'rulescomp',
-    executable('bench-rulescomp', 'bench/rulescomp.c', dependencies: test_dep),
-    env: bench_env,
-)
-if cc.has_header_symbol('getopt.h', 'getopt_long', prefix: '#define _GNU_SOURCE')
+if get_option('enable-benchmarks')
+    bench_env = environment()
+    bench_env.set('top_srcdir', meson.current_source_dir())
     benchmark(
-        'compile-keymap',
+        'key-proc',
+        executable('bench-key-proc', 'bench/key-proc.c', dependencies: test_dep),
+        env: bench_env,
+    )
+    benchmark(
+        'keysym-case-mappings',
         executable(
-            'bench-compile-keymap',
-            'bench/compile-keymap.c',
+            'bench-keysym-case-mappings',
+            'bench/keysym-case-mappings.c',
+            dependencies: test_dep,
+            c_args: ['-DENABLE_PRIVATE_APIS'],
+        ),
+    )
+    benchmark(
+        'rules',
+        executable('bench-rules', 'bench/rules.c', dependencies: test_dep),
+        env: bench_env,
+    )
+    benchmark(
+        'rulescomp',
+        executable('bench-rulescomp', 'bench/rulescomp.c', dependencies: test_dep),
+        env: bench_env,
+    )
+    if cc.has_header_symbol('getopt.h', 'getopt_long', prefix: '#define _GNU_SOURCE')
+        benchmark(
+            'compile-keymap',
+            executable(
+                'bench-compile-keymap',
+                'bench/compile-keymap.c',
+                dependencies: test_dep
+            ),
+            env: bench_env,
+        )
+        benchmark(
+            'dump-keymap',
+            executable(
+                'bench-dump-keymap',
+                'bench/compile-keymap.c',
+                dependencies: test_dep,
+                c_args: ['-DKEYMAP_DUMP'],
+            ),
+            env: bench_env,
+        )
+    endif
+    benchmark(
+        'compose',
+        executable('bench-compose', 'bench/compose.c', dependencies: test_dep),
+        env: bench_env,
+    )
+    benchmark(
+        'compose-traversal',
+        executable(
+            'bench-compose-traversal',
+            'bench/compose-traversal.c',
+            'bench/bench.h',
+            'test/compose-iter.c',
+            'test/compose-iter.h',
+            'test/test.h',
             dependencies: test_dep
         ),
         env: bench_env,
     )
     benchmark(
-        'dump-keymap',
-        executable(
-            'bench-dump-keymap',
-            'bench/compile-keymap.c',
-            dependencies: test_dep,
-            c_args: ['-DKEYMAP_DUMP'],
-        ),
+        'atom',
+        executable('bench-atom', 'bench/atom.c', dependencies: test_dep),
         env: bench_env,
     )
-endif
-benchmark(
-    'compose',
-    executable('bench-compose', 'bench/compose.c', dependencies: test_dep),
-    env: bench_env,
-)
-benchmark(
-    'compose-traversal',
-    executable(
-        'bench-compose-traversal',
-        'bench/compose-traversal.c',
-        'bench/bench.h',
-        'test/compose-iter.c',
-        'test/compose-iter.h',
-        'test/test.h',
-        dependencies: test_dep
-    ),
-    env: bench_env,
-)
-benchmark(
-    'atom',
-    executable('bench-atom', 'bench/atom.c', dependencies: test_dep),
-    env: bench_env,
-)
-if get_option('enable-x11')
-  benchmark(
-      'x11',
-      executable('bench-x11', 'bench/x11.c', dependencies: x11_test_dep),
-      env: bench_env,
-  )
+    if get_option('enable-x11')
+        benchmark(
+            'x11',
+            executable('bench-x11', 'bench/x11.c', dependencies: x11_test_dep),
+            env: bench_env,
+        )
+    endif
 endif
 
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -90,3 +90,15 @@ option(
     value: true,
     description: 'Enable installing bash completion scripts',
 )
+option(
+    'enable-benchmarks',
+    type: 'boolean',
+    value: false,
+    description: 'Enable building the benches',
+)
+option(
+    'enable-fuzzers',
+    type: 'boolean',
+    value: false,
+    description: 'Enable building the fuzzers',
+)


### PR DESCRIPTION
I do not think there is a reason to make everybody build those *by default*.