### PR TITLE
symbols: Fix 2 possible null pointer deferences

### DIFF
--- a/src/xkbcomp/ast-build.c
+++ b/src/xkbcomp/ast-build.c
@@ -184,6 +184,12 @@ ExprCreateArrayRef(xkb_atom_t element, xkb_atom_t field, ExprDef *entry)
 }
 
 ExprDef *
+ExprEmptyList(void)
+{
+    return ExprCreate(EXPR_EMPTY_LIST, EXPR_TYPE_UNKNOWN, sizeof(ExprCommon));
+}
+
+ExprDef *
 ExprCreateAction(xkb_atom_t name, ExprDef *args)
 {
     ExprDef *expr = ExprCreate(EXPR_ACTION_DECL, EXPR_TYPE_UNKNOWN, sizeof(ExprAction));
@@ -851,6 +857,7 @@ static const char *expr_op_type_strings[_EXPR_NUM_VALUES] = {
     [EXPR_ACTION_DECL] = "action declaration",
     [EXPR_FIELD_REF] = "field reference",
     [EXPR_ARRAY_REF] = "array reference",
+    [EXPR_EMPTY_LIST] = "empty list",
     [EXPR_KEYSYM_LIST] = "list of keysyms",
     [EXPR_ACTION_LIST] = "list of actions",
     [EXPR_ADD] = "addition",

--- a/src/xkbcomp/ast-build.h
+++ b/src/xkbcomp/ast-build.h
@@ -59,6 +59,9 @@ ExprDef *
 ExprCreateArrayRef(xkb_atom_t element, xkb_atom_t field, ExprDef *entry);
 
 ExprDef *
+ExprEmptyList(void);
+
+ExprDef *
 ExprCreateAction(xkb_atom_t name, ExprDef *args);
 
 ExprDef *

--- a/src/xkbcomp/ast.h
+++ b/src/xkbcomp/ast.h
@@ -111,6 +111,8 @@ enum expr_op_type {
     EXPR_ACTION_DECL,
     EXPR_FIELD_REF,
     EXPR_ARRAY_REF,
+    /* Needed because of the ambiguity between keysym and action empty lists */
+    EXPR_EMPTY_LIST,
     EXPR_KEYSYM_LIST,
     EXPR_ACTION_LIST,
     EXPR_ADD,

--- a/src/xkbcomp/expr.c
+++ b/src/xkbcomp/expr.c
@@ -189,6 +189,7 @@ ExprResolveBoolean(struct xkb_context *ctx, const ExprDef *expr,
     case EXPR_ASSIGN:
     case EXPR_NEGATE:
     case EXPR_UNARY_PLUS:
+    case EXPR_EMPTY_LIST:
     case EXPR_ACTION_DECL:
     case EXPR_ACTION_LIST:
     case EXPR_KEYSYM_LIST:
@@ -500,6 +501,7 @@ ExprResolveString(struct xkb_context *ctx, const ExprDef *expr,
     case EXPR_INVERT:
     case EXPR_NOT:
     case EXPR_UNARY_PLUS:
+    case EXPR_EMPTY_LIST:
     case EXPR_ACTION_DECL:
     case EXPR_ACTION_LIST:
     case EXPR_KEYSYM_LIST:

--- a/src/xkbcomp/parser.y
+++ b/src/xkbcomp/parser.y
@@ -485,7 +485,7 @@ ArrayInit       :       OBRACKET MultiKeySymList CBRACKET
                 |       OBRACKET MultiActionList CBRACKET
                         { $$ = $2; }
                 |       OBRACKET CBRACKET
-                        { $$ = NULL; }
+                        { $$ = ExprEmptyList(); }
                 ;
 
 GroupCompatDecl :       GROUP Integer EQUALS Expr SEMI

--- a/src/xkbcomp/parser.y
+++ b/src/xkbcomp/parser.y
@@ -882,7 +882,9 @@ parse(struct xkb_context *ctx, struct scanner *scanner, const char *map)
     }
 
     if (ret != 0) {
+        /* Some error happend; clear the Xkbfiles parsed so far */
         FreeXkbFile(first);
+        FreeXkbFile(param.rtrn);
         return NULL;
     }
 

--- a/test/buffercomp.c
+++ b/test/buffercomp.c
@@ -285,6 +285,20 @@ test_invalid_symbols_fields(struct xkb_context *ctx)
         "    xkb_types { };\n"
         "    xkb_compat { };\n"
         "    xkb_symbols { key <> { groupsredirect = [] }; };\n"
+        "};",
+        /* Used to parse without error because the “repeats” key field is valid,
+         * but we should fail in the following 2 keymaps */
+        "xkb_keymap {\n"
+        "    xkb_keycodes { <> = 9; };\n"
+        "    xkb_types { };\n"
+        "    xkb_compat { };\n"
+        "    xkb_symbols { key <> { vmods=[], repeats=false }; };\n"
+        "};",
+        "xkb_keymap {\n"
+        "    xkb_keycodes { <> = 9; };\n"
+        "    xkb_types { };\n"
+        "    xkb_compat { };\n"
+        "    xkb_symbols { key <> { repeats=false, vmods=[] }; };\n"
         "};"
     };
     for (unsigned int k = 0; k < ARRAY_SIZE(keymaps); k++) {

--- a/test/buffercomp.c
+++ b/test/buffercomp.c
@@ -250,6 +250,50 @@ test_multi_keysyms_actions(struct xkb_context *ctx)
 #undef run_test
 }
 
+static void
+test_invalid_symbols_fields(struct xkb_context *ctx)
+{
+    /* Any of the following is invalid syntax, but also use to trigger
+     * a NULL pointer deference, thus this regression test */
+    const char * const keymaps[] = {
+        "xkb_keymap {\n"
+        "    xkb_keycodes { <> = 9; };\n"
+        "    xkb_types { };\n"
+        "    xkb_compat { };\n"
+        "    xkb_symbols { key <> { vmods = [] }; };\n"
+        "};",
+        "xkb_keymap {\n"
+        "    xkb_keycodes { <> = 9; };\n"
+        "    xkb_types { };\n"
+        "    xkb_compat { };\n"
+        "    xkb_symbols { key <> { repeat = [] }; };\n"
+        "};",
+        "xkb_keymap {\n"
+        "    xkb_keycodes { <> = 9; };\n"
+        "    xkb_types { };\n"
+        "    xkb_compat { };\n"
+        "    xkb_symbols { key <> { type = [] }; };\n"
+        "};",
+        "xkb_keymap {\n"
+        "    xkb_keycodes { <> = 9; };\n"
+        "    xkb_types { };\n"
+        "    xkb_compat { };\n"
+        "    xkb_symbols { key <> { groupswrap = [] }; };\n"
+        "};",
+        "xkb_keymap {\n"
+        "    xkb_keycodes { <> = 9; };\n"
+        "    xkb_types { };\n"
+        "    xkb_compat { };\n"
+        "    xkb_symbols { key <> { groupsredirect = [] }; };\n"
+        "};"
+    };
+    for (unsigned int k = 0; k < ARRAY_SIZE(keymaps); k++) {
+        const struct xkb_keymap *keymap =
+            test_compile_buffer(ctx, keymaps[k], strlen(keymaps[k]));
+        assert(!keymap);
+    }
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -315,6 +359,7 @@ main(int argc, char *argv[])
 
     test_recursive(ctx);
     test_multi_keysyms_actions(ctx);
+    test_invalid_symbols_fields(ctx);
 
     xkb_context_unref(ctx);
 


### PR DESCRIPTION
Detected using `clang-tidy`. We probably need to activate some automatic fuzzer to ensure there are no other hazardous code paths!