### PR TITLE
Fix latches

### DIFF
--- a/changes/api/+fix-latch-unexpected-break.bugfix.md
+++ b/changes/api/+fix-latch-unexpected-break.bugfix.md
@@ -1,0 +1,7 @@
+Make the key events that break *latches* also the only events that
+prevent the latches to trigger. Previously any down event would prevent
+it.
+
+The major effect of this change is that depressing and releasing
+two latching keys simultaneously will now activate both latches, as
+expected.

--- a/src/state.c
+++ b/src/state.c
@@ -310,6 +310,12 @@ xkb_filter_group_lock_func(struct xkb_state *state,
 static bool
 xkb_action_breaks_latch(const union xkb_action *action)
 {
+    /*
+     * XKB specification, §2.1 “Locking and Latching Modifiers and Groups”:
+     *
+     *     Latched modifiers or groups apply only to the next key event that
+     *     does not change keyboard state.
+     */
     switch (action->type) {
     case ACTION_TYPE_NONE:
     case ACTION_TYPE_PTR_BUTTON:
@@ -373,42 +379,57 @@ xkb_filter_group_latch_func(struct xkb_state *state,
     union group_latch_priv priv = {.priv = filter->priv};
     enum xkb_key_latch_state latch = priv.latch;
 
-    if (direction == XKB_KEY_DOWN && latch == LATCH_PENDING) {
-        /* If this is a new keypress and we're awaiting our single latched
-         * keypress, then either break the latch if any random key is pressed,
-         * or promote it to a lock if it's the same group delta & flags and
-         * latchToLock option is enabled. */
+    if (direction == XKB_KEY_DOWN) {
         const union xkb_action *actions = NULL;
         unsigned int count = xkb_key_get_actions(state, key, &actions);
-        for (unsigned int k = 0; k < count; k++) {
-            if (actions[k].type == ACTION_TYPE_GROUP_LATCH &&
-                actions[k].group.group == filter->action.group.group &&
-                actions[k].group.flags == filter->action.group.flags) {
-                filter->action = actions[k];
-                if (filter->action.group.flags & ACTION_LATCH_TO_LOCK &&
-                    filter->action.group.group != 0) {
-                    /* Promote to lock */
-                    filter->action.type = ACTION_TYPE_GROUP_LOCK;
-                    filter->func = xkb_filter_group_lock_func;
-                    xkb_filter_group_lock_new(state, filter);
-                    state->components.latched_group -= priv.group_delta;
-                    filter->key = key;
-                    /* XXX beep beep! */
-                    return XKB_FILTER_CONSUME;
+        if (latch == LATCH_PENDING) {
+            /* If this is a new keypress and we're awaiting our single latched
+             * keypress, then either break the latch if any random key is pressed,
+             * or promote it to a lock if it's the same group delta & flags and
+             * latchToLock option is enabled. */
+            for (unsigned int k = 0; k < count; k++) {
+                if (actions[k].type == ACTION_TYPE_GROUP_LATCH &&
+                    actions[k].group.group == filter->action.group.group &&
+                    actions[k].group.flags == filter->action.group.flags) {
+                    filter->action = actions[k];
+                    if (filter->action.group.flags & ACTION_LATCH_TO_LOCK &&
+                        filter->action.group.group != 0) {
+                        /* Promote to lock */
+                        filter->action.type = ACTION_TYPE_GROUP_LOCK;
+                        filter->func = xkb_filter_group_lock_func;
+                        xkb_filter_group_lock_new(state, filter);
+                        state->components.latched_group -= priv.group_delta;
+                        filter->key = key;
+                        /* XXX beep beep! */
+                        return XKB_FILTER_CONSUME;
+                    }
+                    /* Do nothing if latchToLock option is not activated; if the
+                     * latch is not broken by the following actions and the key is
+                     * not consummed, then another latch filter will be created.
+                     */
+                    continue;
                 }
-                /* Do nothing if latchToLock option is not activated; if the
-                 * latch is not broken by the following actions and the key is
-                 * not consummed, then another latch filter will be created.
-                 */
-                continue;
-            }
-            else if (xkb_action_breaks_latch(&(actions[k]))) {
-                /* Breaks the latch */
-                state->components.latched_group -= priv.group_delta;
-                filter->func = NULL;
-                return XKB_FILTER_CONTINUE;
+                else if (xkb_action_breaks_latch(&(actions[k]))) {
+                    /* Breaks the latch */
+                    state->components.latched_group -= priv.group_delta;
+                    filter->func = NULL;
+                    return XKB_FILTER_CONTINUE;
+                }
             }
         }
+        else if (latch == LATCH_KEY_DOWN) {
+            /* Another key was pressed while we’ve still got the latching key
+             * held down. If some of the released key’s actions breaks latches,
+             * prevent the latch to trigger and keep the base group unchanged;
+             * it will be reset as soon as our modifier key gets released. */
+            for (unsigned int k = 0; k < count; k++) {
+                if (xkb_action_breaks_latch(&(actions[k]))) {
+                    latch = NO_LATCH;
+                    break;
+                }
+            }
+        }
+        /* Ignore press in NO_LATCH state */
     }
     else if (direction == XKB_KEY_UP && key == filter->key) {
         /* Our key got released.  If we've set it to clear locks, and we
@@ -437,13 +458,7 @@ xkb_filter_group_latch_func(struct xkb_state *state,
             /* XXX beep beep! */
         }
     }
-    else if (direction == XKB_KEY_DOWN && latch == LATCH_KEY_DOWN) {
-        /* Another key was pressed while we've still got the latching
-         * key held down, so keep the base group active (from
-         * xkb_filter_group_latch_new), but don't trip the latch, just clear
-         * it as soon as the group key gets released. */
-        latch = NO_LATCH;
-    }
+    /* Ignore release of other keys */
 
     priv.latch = latch;
     filter->priv = priv.priv;
@@ -533,41 +548,59 @@ xkb_filter_mod_latch_func(struct xkb_state *state,
 {
     enum xkb_key_latch_state latch = filter->priv;
 
-    if (direction == XKB_KEY_DOWN && latch == LATCH_PENDING) {
-        /* If this is a new keypress and we're awaiting our single latched
-         * keypress, then either break the latch if any random key is pressed,
-         * or promote it to a lock or plain base set if it's the same
-         * modifier. */
+    if (direction == XKB_KEY_DOWN) {
         const union xkb_action *actions = NULL;
         unsigned int count = xkb_key_get_actions(state, key, &actions);
-        for (unsigned int k = 0; k < count; k++) {
-            if (actions[k].type == ACTION_TYPE_MOD_LATCH &&
-                actions[k].mods.flags == filter->action.mods.flags &&
-                actions[k].mods.mods.mask == filter->action.mods.mods.mask) {
-                filter->action = actions[k];
-                if (filter->action.mods.flags & ACTION_LATCH_TO_LOCK) {
-                    filter->action.type = ACTION_TYPE_MOD_LOCK;
-                    filter->func = xkb_filter_mod_lock_func;
-                    state->components.locked_mods |= filter->action.mods.mods.mask;
+        if (latch == LATCH_PENDING) {
+            /* If this is a new keypress and we're awaiting our single latched
+             * keypress, then either break the latch if any random key is pressed,
+             * or promote it to a lock or plain base set if it's the same
+             * modifier. */
+            for (unsigned int k = 0; k < count; k++) {
+                if (actions[k].type == ACTION_TYPE_MOD_LATCH &&
+                    actions[k].mods.flags == filter->action.mods.flags &&
+                    actions[k].mods.mods.mask == filter->action.mods.mods.mask) {
+                    filter->action = actions[k];
+                    if (filter->action.mods.flags & ACTION_LATCH_TO_LOCK) {
+                        filter->action.type = ACTION_TYPE_MOD_LOCK;
+                        filter->func = xkb_filter_mod_lock_func;
+                        state->components.locked_mods |=
+                            filter->action.mods.mods.mask;
+                        state->components.latched_mods &=
+                            ~filter->action.mods.mods.mask;
+                        filter->key = key;
+                        /* XXX beep beep! */
+                        return XKB_FILTER_CONSUME;
+                    }
+                    /* Do nothing if latchToLock option is not activated; if the
+                     * latch is not broken by the following actions and the key is
+                     * is not consummed, then another latch filter will be created.
+                     */
+                    continue;
                 }
-                else {
-                    filter->action.type = ACTION_TYPE_MOD_SET;
-                    filter->func = xkb_filter_mod_set_func;
-                    state->set_mods |= filter->action.mods.mods.mask;
+                else if (xkb_action_breaks_latch(&(actions[k]))) {
+                    /* XXX: This may be totally broken, we might need to break
+                     *      the latch in the next run after this press? */
+                    state->components.latched_mods &=
+                        ~filter->action.mods.mods.mask;
+                    filter->func = NULL;
+                    return XKB_FILTER_CONTINUE;
                 }
-                filter->key = key;
-                state->components.latched_mods &= ~filter->action.mods.mods.mask;
-                /* XXX beep beep! */
-                return XKB_FILTER_CONSUME;
-            }
-            else if (xkb_action_breaks_latch(&(actions[k]))) {
-                /* XXX: This may be totally broken, we might need to break the
-                *      latch in the next run after this press? */
-                state->components.latched_mods &= ~filter->action.mods.mods.mask;
-                filter->func = NULL;
-                return XKB_FILTER_CONTINUE;
             }
         }
+        else if (latch == LATCH_KEY_DOWN) {
+            /* Another key was pressed while we’ve still got the latching key
+             * held down. If some of the released key’s actions breaks latches,
+             * prevent the latch to trigger and keep the base modifier active;
+             * it will be cleared as soon as our modifier key gets released. */
+            for (unsigned int k = 0; k < count; k++) {
+                if (xkb_action_breaks_latch(&(actions[k]))) {
+                    latch = NO_LATCH;
+                    break;
+                }
+            }
+        }
+        /* Ignore press in NO_LATCH state */
     }
     else if (direction == XKB_KEY_UP && key == filter->key) {
         /* Our key got released.  If we've set it to clear locks, and we
@@ -596,13 +629,7 @@ xkb_filter_mod_latch_func(struct xkb_state *state,
             /* XXX beep beep! */
         }
     }
-    else if (direction == XKB_KEY_DOWN && latch == LATCH_KEY_DOWN) {
-        /* Someone's pressed another key while we've still got the latching
-         * key held down, so keep the base modifier state active (from
-         * xkb_filter_mod_latch_new), but don't trip the latch, just clear
-         * it as soon as the modifier gets released. */
-        latch = NO_LATCH;
-    }
+    /* Ignore release of other keys */
 
     filter->priv = latch;
 

--- a/test/data/symbols/latch
+++ b/test/data/symbols/latch
@@ -1,0 +1,48 @@
+default partial alphanumeric_keys
+xkb_symbols "modifiers" {
+	name[Group1] = "Test latching behavior";
+
+	virtual_modifiers LevelThree;
+
+	key <AE01> { [ 1, exclam, onesuperior, exclamdown, plus ], type[Group1]="CTRL+ALT"};
+
+	key <AD01> { [ q, Q ], type[Group1] = "ALPHABETIC" };
+
+	key <LFSH> {
+		symbols[Group1] = [ Shift_L ],
+		actions[Group1] = [ LatchMods(modifiers=Shift,latchToLock=true,clearLocks=true) ]
+	};
+
+	key <RTSH> {
+		symbols[Group1] = [ Shift_R ],
+		actions[Group1] = [ LatchMods(modifiers=Shift,latchToLock=false,clearLocks=false) ]
+	};
+
+	key <LCTL> {
+		symbols[Group1] = [ Control_L ],
+		actions[Group1] = [ LatchMods(modifiers=Control) ]
+	};
+
+	key <LALT> {
+		type[Group1] = "ONE_LEVEL",
+		symbols[Group1] = [ Alt_L ],
+		actions[Group1] = [ LatchMods(modifiers=Alt) ]
+	};
+
+	key <RALT> {
+		type[Group1] = "ONE_LEVEL",
+		symbols[Group1] = [ ISO_Level3_Latch ],
+		actions[Group1] = [ LatchMods(modifiers=LevelThree,latchToLock=true,clearLocks=true) ]
+	};
+
+	key <MENU> {
+		type[Group1] = "ONE_LEVEL",
+		symbols[Group1] = [ ISO_Level3_Latch ],
+		actions[Group1] = [ LatchMods(modifiers=LevelThree,latchToLock=false,clearLocks=false) ]
+	};
+
+	key <FK01> { [XF86_Switch_VT_1], type[Group1] = "ONE_LEVEL" };
+	key <FK02> { [ISO_Group_Shift], type[Group1] = "ONE_LEVEL" };
+
+	key <LSGT> { [ ISO_Level3_Lock ], type[Group1] = "ONE_LEVEL" };
+};

--- a/test/keyseq.c
+++ b/test/keyseq.c
@@ -27,6 +27,10 @@
 #include "test.h"
 #include "keymap.h"
 
+enum fake_keys {
+    KEY_LVL3 = 84
+};
+
 static void
 test_group_latch(struct xkb_context *ctx)
 {
@@ -34,7 +38,7 @@ test_group_latch(struct xkb_context *ctx)
     struct xkb_keymap *keymap = test_compile_rules(
         ctx, "evdev", "evdev",
         "us,il,ru,de", ",,phonetic,neo",
-        "grp:menu_latch_group2,grp:sclk_toggle");
+        "grp:menu_latch_group2,grp:sclk_toggle,grp:lctrl_rctrl_switch");
     assert(keymap);
 
     /* Set only */
@@ -82,11 +86,69 @@ test_group_latch(struct xkb_context *ctx)
 #define test_latch_not_broken_by_modifier(keymap_)                           \
     assert(test_key_seq(keymap_,                                             \
                         KEY_H,        BOTH,  XKB_KEY_h,               NEXT,  \
+                        /* Sequential */                                     \
                         KEY_COMPOSE,  BOTH,  XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_LEFTALT,  BOTH,  XKB_KEY_Alt_L,           NEXT,  \
+                        KEY_H,        BOTH,  XKB_KEY_hebrew_yod,      NEXT,  \
+                        KEY_H,        BOTH,  XKB_KEY_h,               NEXT,  \
+                        /* Simultaneous */                                   \
+                        KEY_COMPOSE,  DOWN,  XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_LEFTALT,  BOTH,  XKB_KEY_Alt_L,           NEXT,  \
+                        KEY_COMPOSE,  UP,    XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_H,        BOTH,  XKB_KEY_hebrew_yod,      NEXT,  \
+                        KEY_H,        BOTH,  XKB_KEY_h,               NEXT,  \
+                        /* Simultaneous */                                   \
                         KEY_LEFTALT,  DOWN,  XKB_KEY_Alt_L,           NEXT,  \
+                        KEY_COMPOSE,  BOTH,  XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_LEFTALT,  UP,    XKB_KEY_Alt_L,           NEXT,  \
+                        KEY_H,        BOTH,  XKB_KEY_hebrew_yod,      NEXT,  \
+                        KEY_H,        BOTH,  XKB_KEY_h,               NEXT,  \
+                        /* Simultaneous */                                   \
+                        KEY_LEFTALT,  DOWN,  XKB_KEY_Alt_L,           NEXT,  \
+                        KEY_COMPOSE,  DOWN,  XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_LEFTALT,  UP,    XKB_KEY_Alt_L,           NEXT,  \
+                        KEY_COMPOSE,  UP,    XKB_KEY_ISO_Group_Latch, NEXT,  \
                         KEY_H,        BOTH,  XKB_KEY_hebrew_yod,      NEXT,  \
                         KEY_H,        BOTH,  XKB_KEY_h,               FINISH))
     test_latch_not_broken_by_modifier(keymap);
+
+    /* Simulatenous group actions */
+#define test_simultaneous_group_latches(keymap_)                              \
+    assert(test_key_seq(keymap_,                                              \
+                        KEY_H,          BOTH, XKB_KEY_h,               NEXT,  \
+                        /* Sequential */                                      \
+                        KEY_COMPOSE,    BOTH, XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_SCROLLLOCK, BOTH, XKB_KEY_ISO_Next_Group,  NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_Cyrillic_ha,     NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_hebrew_yod,      NEXT,  \
+                        KEY_LEFTCTRL,   BOTH, XKB_KEY_ISO_First_Group, NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_h,               NEXT,  \
+                        /* Simultaneous */                                    \
+                        KEY_COMPOSE,    DOWN, XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_SCROLLLOCK, BOTH, XKB_KEY_ISO_Next_Group,  NEXT,  \
+                        KEY_COMPOSE,    UP,   XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_Cyrillic_ha,     NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_hebrew_yod,      NEXT,  \
+                        KEY_LEFTCTRL,   BOTH, XKB_KEY_ISO_First_Group, NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_h,               NEXT,  \
+                        /* Simultaneous */                                    \
+                        KEY_SCROLLLOCK, DOWN, XKB_KEY_ISO_Next_Group,  NEXT,  \
+                        KEY_COMPOSE,    BOTH, XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_SCROLLLOCK, UP,   XKB_KEY_ISO_Next_Group,  NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_Cyrillic_ha,     NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_hebrew_yod,      NEXT,  \
+                        KEY_LEFTCTRL,   BOTH, XKB_KEY_ISO_First_Group, NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_h,               NEXT,  \
+                        /* Simultaneous */                                    \
+                        KEY_SCROLLLOCK, DOWN, XKB_KEY_ISO_Next_Group,  NEXT,  \
+                        KEY_COMPOSE,    DOWN, XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_SCROLLLOCK, UP,   XKB_KEY_ISO_Next_Group,  NEXT,  \
+                        KEY_COMPOSE,    UP,   XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_Cyrillic_ha,     NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_hebrew_yod,      NEXT,  \
+                        KEY_LEFTCTRL,   BOTH, XKB_KEY_ISO_First_Group, NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_h,               FINISH))
+    test_simultaneous_group_latches(keymap);
 
     /* No lock */
 #define test_no_latch_to_lock(keymap_)                                         \
@@ -123,12 +185,13 @@ test_group_latch(struct xkb_context *ctx)
     keymap = test_compile_rules(
         ctx, "evdev", "evdev",
         "us,il,ru,de", ",,phonetic,neo",
-        "grp:menu_latch_group2_lock,grp:sclk_toggle");
+        "grp:menu_latch_group2_lock,grp:sclk_toggle,grp:lctrl_rctrl_switch");
     assert(keymap);
 
     test_set_only(keymap);
     test_latch_only(keymap);
     test_latch_not_broken_by_modifier(keymap);
+    test_simultaneous_group_latches(keymap);
 
     /* Lock */
     assert(test_key_seq(keymap,
@@ -154,12 +217,13 @@ test_group_latch(struct xkb_context *ctx)
     keymap = test_compile_rules(
         ctx, "evdev", "evdev",
         "us,il,ru,de", ",,phonetic,neo",
-        "grp:menu_latch,grp:sclk_toggle");
+        "grp:menu_latch,grp:sclk_toggle,grp:lctrl_rctrl_switch");
     assert(keymap);
 
     test_set_only(keymap);
     test_latch_only(keymap);
     test_latch_not_broken_by_modifier(keymap);
+    test_simultaneous_group_latches(keymap);
     test_no_latch_to_lock(keymap);
 
     xkb_keymap_unref(keymap);
@@ -168,12 +232,13 @@ test_group_latch(struct xkb_context *ctx)
     keymap = test_compile_rules(
         ctx, "evdev", "evdev",
         "us,il,ru,de", ",,phonetic,neo",
-        "grp:menu_latch_lock,grp:sclk_toggle");
+        "grp:menu_latch_lock,grp:sclk_toggle,grp:lctrl_rctrl_switch");
     assert(keymap);
 
     test_set_only(keymap);
     test_latch_only(keymap);
     test_latch_not_broken_by_modifier(keymap);
+    test_simultaneous_group_latches(keymap);
 
     /* Lock */
     assert(test_key_seq(keymap,
@@ -198,12 +263,13 @@ test_group_latch(struct xkb_context *ctx)
 #undef test_set_only
 #undef test_latch_only
 #undef test_latch_not_broken_by_modifier
+#undef test_simultaneous_group_latches
 
     /* Relative group (negative), no lock */
     keymap = test_compile_rules(
         ctx, "evdev", "evdev",
         "us,il,ru,de", ",,phonetic,neo",
-        "grp:menu_latch_negative,grp:sclk_toggle");
+        "grp:menu_latch_negative,grp:sclk_toggle,grp:lctrl_rctrl_switch");
     assert(keymap);
 
     /* Set only */
@@ -248,11 +314,71 @@ test_group_latch(struct xkb_context *ctx)
 #define test_latch_not_broken_by_modifier(keymap_)                           \
     assert(test_key_seq(keymap_,                                             \
                         KEY_H,        BOTH,  XKB_KEY_h,               NEXT,  \
+                        /* Sequential */                                     \
                         KEY_COMPOSE,  BOTH,  XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_LEFTALT,  BOTH,  XKB_KEY_Alt_L,           NEXT,  \
+                        KEY_H,        BOTH,  XKB_KEY_s,               NEXT,  \
+                        KEY_H,        BOTH,  XKB_KEY_h,               NEXT,  \
+                        /* Simultaneous */                                   \
+                        KEY_COMPOSE,  DOWN,  XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_LEFTALT,  BOTH,  XKB_KEY_Alt_L,           NEXT,  \
+                        KEY_COMPOSE,  UP,    XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_H,        BOTH,  XKB_KEY_s,               NEXT,  \
+                        KEY_H,        BOTH,  XKB_KEY_h,               NEXT,  \
+                        /* Simultaneous */                                   \
                         KEY_LEFTALT,  DOWN,  XKB_KEY_Alt_L,           NEXT,  \
+                        KEY_COMPOSE,  BOTH,  XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_LEFTALT,  UP,    XKB_KEY_Alt_L,           NEXT,  \
+                        KEY_H,        BOTH,  XKB_KEY_s,               NEXT,  \
+                        KEY_H,        BOTH,  XKB_KEY_h,               NEXT,  \
+                        /* Simultaneous */                                   \
+                        KEY_LEFTALT,  DOWN,  XKB_KEY_Alt_L,           NEXT,  \
+                        KEY_COMPOSE,  DOWN,  XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_LEFTALT,  UP,    XKB_KEY_Alt_L,           NEXT,  \
+                        KEY_COMPOSE,  UP,    XKB_KEY_ISO_Group_Latch, NEXT,  \
                         KEY_H,        BOTH,  XKB_KEY_s,               NEXT,  \
                         KEY_H,        BOTH,  XKB_KEY_h,               FINISH))
     test_latch_not_broken_by_modifier(keymap);
+
+    /* Simulatenous group actions */
+#define test_simultaneous_group_latches(keymap_)                              \
+    assert(test_key_seq(keymap_,                                              \
+                        KEY_H,          BOTH, XKB_KEY_h,               NEXT,  \
+                        KEY_RIGHTCTRL,  BOTH, XKB_KEY_ISO_Last_Group,  NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_hebrew_yod,      NEXT,  \
+                        /* Sequential */                                      \
+                        KEY_COMPOSE,    BOTH, XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_SCROLLLOCK, BOTH, XKB_KEY_ISO_Next_Group,  NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_hebrew_yod,      NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_Cyrillic_ha,     NEXT,  \
+                        KEY_RIGHTCTRL,  BOTH, XKB_KEY_ISO_Last_Group,  NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_hebrew_yod,      NEXT,  \
+                        /* Simultaneous */                                    \
+                        KEY_COMPOSE,    DOWN, XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_SCROLLLOCK, BOTH, XKB_KEY_ISO_Next_Group,  NEXT,  \
+                        KEY_COMPOSE,    UP,   XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_hebrew_yod,      NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_Cyrillic_ha,     NEXT,  \
+                        KEY_RIGHTCTRL,  BOTH, XKB_KEY_ISO_Last_Group,  NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_hebrew_yod,      NEXT,  \
+                        /* Simultaneous */                                    \
+                        KEY_SCROLLLOCK, DOWN, XKB_KEY_ISO_Next_Group,  NEXT,  \
+                        KEY_COMPOSE,    BOTH, XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_SCROLLLOCK, UP,   XKB_KEY_ISO_Next_Group,  NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_hebrew_yod,      NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_Cyrillic_ha,     NEXT,  \
+                        KEY_RIGHTCTRL,  BOTH, XKB_KEY_ISO_Last_Group,  NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_hebrew_yod,      NEXT,  \
+                        /* Simultaneous */                                    \
+                        KEY_SCROLLLOCK, DOWN, XKB_KEY_ISO_Next_Group,  NEXT,  \
+                        KEY_COMPOSE,    DOWN, XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_SCROLLLOCK, UP,   XKB_KEY_ISO_Next_Group,  NEXT,  \
+                        KEY_COMPOSE,    UP,   XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_hebrew_yod,      NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_Cyrillic_ha,     NEXT,  \
+                        KEY_RIGHTCTRL,  BOTH, XKB_KEY_ISO_Last_Group,  NEXT,  \
+                        KEY_H,          BOTH, XKB_KEY_hebrew_yod,      FINISH))
+    test_simultaneous_group_latches(keymap);
 
     test_no_latch_to_lock(keymap);
 
@@ -262,12 +388,14 @@ test_group_latch(struct xkb_context *ctx)
     keymap = test_compile_rules(
         ctx, "evdev", "evdev",
         "us,il,ru,de", ",,phonetic,neo",
-        "grp:menu_latch_negative_lock,grp:sclk_toggle");
+        "grp:menu_latch_negative_lock,grp:sclk_toggle,grp:lctrl_rctrl_switch");
     assert(keymap);
 
     test_set_only(keymap);
     test_latch_only(keymap);
     test_latch_not_broken_by_modifier(keymap);
+    test_simultaneous_group_latches(keymap);
+    test_simultaneous_group_latches(keymap);
 
     /* Lock */
     assert(test_key_seq(keymap,
@@ -294,7 +422,407 @@ test_group_latch(struct xkb_context *ctx)
 #undef test_set_only
 #undef test_latch_only
 #undef test_latch_not_broken_by_modifier
+#undef test_simultaneous_group_latches
 #undef test_no_latch_to_lock
+}
+
+static void
+test_mod_latch(struct xkb_context *context)
+{
+    struct xkb_keymap *keymap;
+
+    keymap = test_compile_rules(context, "evdev", "", "latch", "", "");
+    assert(keymap);
+
+    /* Set: basic */
+    assert(test_key_seq(keymap,
+        KEY_Q         , BOTH, XKB_KEY_q      , NEXT,
+        KEY_1         , BOTH, XKB_KEY_1      , NEXT,
+
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L, NEXT,
+        KEY_Q         , BOTH, XKB_KEY_Q      , NEXT,  /* Prevent latch */
+        KEY_LEFTSHIFT , UP,   XKB_KEY_Shift_L, NEXT,
+        KEY_Q         , BOTH, XKB_KEY_q      , NEXT,
+
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L, NEXT,
+        KEY_Q         , BOTH, XKB_KEY_Q      , NEXT,  /* Prevent latch */
+        KEY_1         , BOTH, XKB_KEY_exclam , NEXT,
+        KEY_LEFTSHIFT , UP,   XKB_KEY_Shift_L, NEXT,
+        KEY_Q         , BOTH, XKB_KEY_q      , FINISH
+    ));
+
+    /* Set: mix with regular set */
+    assert(test_key_seq(keymap,
+        KEY_LVL3      , DOWN, XKB_KEY_ISO_Level3_Shift, NEXT, /* Set Level3 (regular) */
+        KEY_1         , BOTH, XKB_KEY_onesuperior     , NEXT,
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L         , NEXT, /* Set Shift (latch) */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* Prevent Shift latch */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* State unchanged */
+        KEY_LEFTSHIFT , UP,   XKB_KEY_Shift_L         , NEXT,
+        KEY_1         , BOTH, XKB_KEY_onesuperior     , NEXT,
+        KEY_LVL3      , UP,   XKB_KEY_ISO_Level3_Shift, NEXT, /* Unset Level3 */
+        KEY_1         , BOTH, XKB_KEY_1               , NEXT,
+
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L         , NEXT, /* Set Shift (latch) */
+        KEY_LVL3      , DOWN, XKB_KEY_ISO_Level3_Shift, NEXT, /* Set Level3 (regular) */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* Prevent Shift latch */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* State unchanged */
+        KEY_LEFTSHIFT , UP,   XKB_KEY_Shift_L         , NEXT,
+        KEY_1         , BOTH, XKB_KEY_onesuperior     , NEXT,
+        KEY_LVL3      , UP,   XKB_KEY_ISO_Level3_Shift, NEXT, /* Unset Level3 */
+        KEY_1         , BOTH, XKB_KEY_1               , FINISH
+    ));
+
+    /* Set: mix with regular lock */
+    assert(test_key_seq(keymap,
+        /* Only Lock */
+        KEY_102ND     , BOTH, XKB_KEY_ISO_Level3_Lock , NEXT, /* Lock Level3 */
+        KEY_1         , BOTH, XKB_KEY_onesuperior     , NEXT,
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L         , NEXT, /* Set Shift (latch) */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* Prevent Shift latch */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* State unchanged */
+        KEY_LEFTSHIFT , UP,   XKB_KEY_Shift_L         , NEXT, /* Unset shift (latch) */
+        KEY_1         , BOTH, XKB_KEY_onesuperior     , NEXT,
+        KEY_102ND     , BOTH, XKB_KEY_ISO_Level3_Lock , NEXT, /* Unlock Level3 */
+        KEY_1         , BOTH, XKB_KEY_1               , NEXT,
+
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L         , NEXT, /* Set Shift (latch) */
+        KEY_102ND     , BOTH, XKB_KEY_ISO_Level3_Lock , NEXT, /* Lock Level3 */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* Prevent Shift latch */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* State unchanged */
+        KEY_LEFTSHIFT , UP,   XKB_KEY_Shift_L         , NEXT, /* Unset shift (latch) */
+        KEY_1         , BOTH, XKB_KEY_onesuperior     , NEXT,
+        KEY_102ND     , BOTH, XKB_KEY_ISO_Level3_Lock , NEXT, /* Unlock Level3 */
+        KEY_1         , BOTH, XKB_KEY_1               , NEXT,
+
+        /* Set, then Lock */
+        KEY_102ND     , DOWN, XKB_KEY_ISO_Level3_Lock , NEXT, /* Set Level3 (lock) */
+        KEY_1         , BOTH, XKB_KEY_onesuperior     , NEXT,
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L         , NEXT, /* Set Shift (latch) */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* Prevent Shift latch */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* State unchanged */
+        KEY_LEFTSHIFT , UP,   XKB_KEY_Shift_L         , NEXT, /* Unset shift (latch) */
+        KEY_1         , BOTH, XKB_KEY_onesuperior     , NEXT,
+        KEY_102ND     , UP,   XKB_KEY_ISO_Level3_Lock , NEXT, /* Unset and lock Level3 */
+        KEY_1         , BOTH, XKB_KEY_onesuperior     , NEXT,
+        KEY_1         , BOTH, XKB_KEY_onesuperior     , NEXT,
+        KEY_102ND     , BOTH, XKB_KEY_ISO_Level3_Lock , NEXT, /* Unlock Level3 */
+        KEY_1         , BOTH, XKB_KEY_1               , NEXT,
+
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L         , NEXT, /* Set Shift (latch) */
+        KEY_102ND     , DOWN, XKB_KEY_ISO_Level3_Lock , NEXT, /* Set Level3 (lock) */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* Prevent Shift latch */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* State unchanged */
+        KEY_LEFTSHIFT , UP,   XKB_KEY_Shift_L         , NEXT, /* Unset shift (latch) */
+        KEY_1         , BOTH, XKB_KEY_onesuperior     , NEXT,
+        KEY_102ND     , UP,   XKB_KEY_ISO_Level3_Lock , NEXT, /* Unset and lock Level3 */
+        KEY_1         , BOTH, XKB_KEY_onesuperior     , NEXT,
+        KEY_1         , BOTH, XKB_KEY_onesuperior     , NEXT,
+        KEY_102ND     , BOTH, XKB_KEY_ISO_Level3_Lock , NEXT, /* Unlock Level3 */
+        KEY_1         , BOTH, XKB_KEY_1               , FINISH
+    ));
+
+    /* Basic latch/unlatch: breaking/preventing latch */
+    assert(test_key_seq(keymap,
+        /* Latch break: sequential */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L, NEXT,  /* Latch Shift */
+        KEY_Q         , BOTH, XKB_KEY_Q      , NEXT,  /* No action: unlatch Shift */
+        KEY_Q         , BOTH, XKB_KEY_q      , NEXT,
+
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L        , NEXT, /* Latch Shift */
+        KEY_F1        , BOTH, XKB_KEY_XF86Switch_VT_1, NEXT, /* VT action: unlatch Shift */
+        KEY_1         , BOTH, XKB_KEY_1              , NEXT,
+
+        /* Latch prevented (DOWN/UP events) */
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L, NEXT, /* Set Shift */
+        KEY_Q         , BOTH, XKB_KEY_Q      , NEXT, /* Prevent latch on DOWN event */
+        KEY_LEFTSHIFT , UP  , XKB_KEY_Shift_L, NEXT, /* Unset Shift */
+        KEY_Q         , BOTH, XKB_KEY_q      , NEXT,
+
+        /* Latch prevented (DOWN event) */
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L, NEXT, /* Set Shift */
+        KEY_Q         , DOWN, XKB_KEY_Q      , NEXT, /* Prevent latch */
+        KEY_LEFTSHIFT , UP  , XKB_KEY_Shift_L, NEXT, /* Unset Shift */
+        KEY_Q         , UP  , XKB_KEY_q      , NEXT,
+
+        /* Latch not prevented (UP event) */
+        KEY_Q         , DOWN, XKB_KEY_q      , NEXT, /* Prevent latch */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L, NEXT, /* Latch Shift */
+        KEY_Q         , UP  , XKB_KEY_Q      , NEXT, /* Do not prevent latch */
+        KEY_Q         , BOTH, XKB_KEY_Q      , NEXT, /* Unlatch Shift */
+        KEY_Q         , BOTH, XKB_KEY_q      , NEXT,
+
+        KEY_Q         , DOWN, XKB_KEY_q      , NEXT,
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L, NEXT, /* Set Shift */
+        KEY_Q         , UP  , XKB_KEY_Q      , NEXT, /* Do not prevent latch */
+        KEY_LEFTSHIFT , UP  , XKB_KEY_Shift_L, NEXT, /* Latch Shift */
+        KEY_Q         , BOTH, XKB_KEY_Q      , NEXT, /* Unlatch Shift */
+        KEY_Q         , BOTH, XKB_KEY_q      , FINISH
+    ));
+
+    /* Basic latch/unlatch: not breaking nor preventing latch */
+    assert(test_key_seq(keymap,
+        /* No latch break: sequential */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L        , NEXT, /* Latch Shift */
+        KEY_RIGHTCTRL , BOTH, XKB_KEY_Control_R      , NEXT, /* Modifier action does not break latches */
+        KEY_Q         , BOTH, XKB_KEY_Q              , NEXT, /* Unlatch Shift */
+        KEY_Q         , BOTH, XKB_KEY_q              , NEXT,
+
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L        , NEXT, /* Latch Shift */
+        KEY_102ND     , BOTH, XKB_KEY_ISO_Level3_Lock, NEXT, /* Modifier action does not break latches */
+        KEY_1         , BOTH, XKB_KEY_exclamdown     , NEXT, /* Unlatch Shift */
+        KEY_1         , BOTH, XKB_KEY_onesuperior    , NEXT,
+        KEY_102ND     , BOTH, XKB_KEY_ISO_Level3_Lock, NEXT,
+        KEY_1         , BOTH, XKB_KEY_1              , NEXT,
+
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L        , NEXT, /* Latch Shift */
+        KEY_F2        , BOTH, XKB_KEY_ISO_Group_Shift, NEXT, /* Group action does not break latches */
+        KEY_Q         , BOTH, XKB_KEY_Q              , NEXT, /* Unlatch Shift */
+        KEY_Q         , BOTH, XKB_KEY_q              , NEXT,
+
+        /* Latch not prevented (DOWN/UP events) */
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L  , NEXT, /* Set Shift */
+        KEY_RIGHTCTRL , BOTH, XKB_KEY_Control_R, NEXT,
+        KEY_LEFTSHIFT , UP  , XKB_KEY_Shift_L  , NEXT, /* Latch Shift */
+        KEY_Q         , BOTH, XKB_KEY_Q        , NEXT, /* Unlatch Shift */
+        KEY_Q         , BOTH, XKB_KEY_q        , NEXT,
+
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L        , NEXT, /* Set Shift */
+        KEY_102ND     , BOTH, XKB_KEY_ISO_Level3_Lock, NEXT,
+        KEY_LEFTSHIFT , UP  , XKB_KEY_Shift_L        , NEXT, /* Latch Shift */
+        KEY_1         , BOTH, XKB_KEY_exclamdown     , NEXT, /* Unlatch Shift */
+        KEY_1         , BOTH, XKB_KEY_onesuperior    , NEXT,
+        KEY_102ND     , BOTH, XKB_KEY_ISO_Level3_Lock, NEXT,
+        KEY_1         , BOTH, XKB_KEY_1              , NEXT,
+
+        /* Latch not prevented (DOWN event) */
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L  , NEXT, /* Set Shift */
+        KEY_RIGHTCTRL , DOWN, XKB_KEY_Control_R, NEXT,
+        KEY_LEFTSHIFT , UP  , XKB_KEY_Shift_L  , NEXT, /* Latch Shift */
+        KEY_RIGHTCTRL , UP  , XKB_KEY_Control_R, NEXT,
+        KEY_Q         , BOTH, XKB_KEY_Q        , NEXT, /* Unlatch Shift */
+        KEY_Q         , BOTH, XKB_KEY_q        , NEXT,
+
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L        , NEXT, /* Set Shift */
+        KEY_102ND     , DOWN, XKB_KEY_ISO_Level3_Lock, NEXT,
+        KEY_LEFTSHIFT , UP  , XKB_KEY_Shift_L        , NEXT, /* Latch Shift */
+        KEY_102ND     , UP  , XKB_KEY_ISO_Level3_Lock, NEXT,
+        KEY_1         , BOTH, XKB_KEY_exclamdown     , NEXT, /* Unlatch Shift */
+        KEY_1         , BOTH, XKB_KEY_onesuperior    , NEXT,
+        KEY_102ND     , BOTH, XKB_KEY_ISO_Level3_Lock, NEXT,
+        KEY_1         , BOTH, XKB_KEY_1              , NEXT,
+
+        /* Latch not prevented (UP event) */
+        KEY_RIGHTCTRL , DOWN, XKB_KEY_Control_R, NEXT,
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L  , NEXT, /* Latch Shift */
+        KEY_RIGHTCTRL , UP  , XKB_KEY_Control_R, NEXT,
+        KEY_Q         , BOTH, XKB_KEY_Q        , NEXT, /* Unlatch Shift */
+        KEY_Q         , BOTH, XKB_KEY_q        , NEXT,
+
+        KEY_RIGHTCTRL , DOWN, XKB_KEY_Control_R, NEXT,
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L  , NEXT, /* Set Shift */
+        KEY_RIGHTCTRL , UP  , XKB_KEY_Control_R, NEXT,
+        KEY_LEFTSHIFT , UP  , XKB_KEY_Shift_L  , NEXT, /* Latch Shift */
+        KEY_Q         , BOTH, XKB_KEY_Q        , NEXT, /* Unlatch Shift */
+        KEY_Q         , BOTH, XKB_KEY_q        , NEXT,
+
+        KEY_102ND     , DOWN, XKB_KEY_ISO_Level3_Lock, NEXT,
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L        , NEXT, /* Latch Shift */
+        KEY_102ND     , UP  , XKB_KEY_ISO_Level3_Lock, NEXT,
+        KEY_1         , BOTH, XKB_KEY_exclamdown     , NEXT, /* Unlatch Shift */
+        KEY_1         , BOTH, XKB_KEY_onesuperior    , NEXT,
+        KEY_102ND     , BOTH, XKB_KEY_ISO_Level3_Lock, NEXT,
+        KEY_1         , BOTH, XKB_KEY_1              , NEXT,
+
+        KEY_102ND     , DOWN, XKB_KEY_ISO_Level3_Lock, NEXT,
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L        , NEXT, /* Latch Shift */
+        KEY_102ND     , UP  , XKB_KEY_ISO_Level3_Lock, NEXT,
+        KEY_LEFTSHIFT , UP  , XKB_KEY_Shift_L        , NEXT, /* Latch Shift */
+        KEY_1         , BOTH, XKB_KEY_exclamdown     , NEXT, /* Unlatch Shift */
+        KEY_1         , BOTH, XKB_KEY_onesuperior    , NEXT,
+        KEY_102ND     , BOTH, XKB_KEY_ISO_Level3_Lock, NEXT,
+        KEY_1         , BOTH, XKB_KEY_1              , FINISH
+    ));
+
+    /* Latch-to-lock */
+    assert(test_key_seq(keymap,
+        /* Lock */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L, NEXT,  /* Latch Shift */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L, NEXT,  /* Lock Shift */
+        KEY_Q         , BOTH, XKB_KEY_Q      , NEXT,
+        KEY_Q         , BOTH, XKB_KEY_Q      , NEXT,
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L, NEXT,  /* Unlock Shift */
+        KEY_Q         , BOTH, XKB_KEY_q      , NEXT,
+        KEY_Q         , BOTH, XKB_KEY_q      , NEXT,
+
+        /* No lock */
+        KEY_RIGHTSHIFT, BOTH, XKB_KEY_Shift_R, NEXT,  /* Latch Shift */
+        KEY_RIGHTSHIFT, BOTH, XKB_KEY_Shift_R, NEXT,  /* Latch Shift */
+        KEY_Q         , BOTH, XKB_KEY_Q      , NEXT,
+        KEY_Q         , BOTH, XKB_KEY_q      , FINISH
+
+        // TODO: mix with regular set and lock
+    ));
+
+    /* Sequential (at most one key down at a time) */
+    assert(test_key_seq(keymap,
+        /* Latch */
+        KEY_LEFTCTRL  , BOTH, XKB_KEY_Control_L, NEXT, /* Latch Control */
+        KEY_LEFTALT   , BOTH, XKB_KEY_Alt_L    , NEXT, /* Latch Alt */
+        KEY_1         , BOTH, XKB_KEY_plus     , NEXT, /* Unlatch Control, Unlatch Alt */
+        KEY_1         , BOTH, XKB_KEY_1        , NEXT,
+
+        /* Latch (repeat, no latch-to-lock) */
+        KEY_RIGHTSHIFT, BOTH, XKB_KEY_Shift_R         , NEXT, /* Latch Shift */
+        KEY_RIGHTSHIFT, BOTH, XKB_KEY_Shift_R         , NEXT, /* Latch Shift (no lock) */
+        KEY_RIGHTALT  , BOTH, XKB_KEY_ISO_Level3_Latch, NEXT, /* Latch Level3 */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* Unlatch all */
+        KEY_1         , BOTH, XKB_KEY_1               , NEXT,
+
+        KEY_RIGHTSHIFT, BOTH, XKB_KEY_Shift_R         , NEXT, /* Latch Shift */
+        KEY_RIGHTALT  , BOTH, XKB_KEY_ISO_Level3_Latch, NEXT, /* Latch Level3 */
+        KEY_RIGHTSHIFT, BOTH, XKB_KEY_Shift_R         , NEXT, /* Latch Shift (no lock) */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* Unlatch all */
+        KEY_1         , BOTH, XKB_KEY_1               , NEXT,
+
+        /* Lock one, latch the other */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Latch Shift */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Lock Shift */
+        KEY_RIGHTALT  , BOTH, XKB_KEY_ISO_Level3_Latch, NEXT, /* Latch Level3 */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* Unlatch Level3 */
+        KEY_1         , BOTH, XKB_KEY_exclam          , NEXT,
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Unlock Shift */
+        KEY_1         , BOTH, XKB_KEY_1               , NEXT,
+
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Latch Shift */
+        KEY_RIGHTALT  , BOTH, XKB_KEY_ISO_Level3_Latch, NEXT, /* Latch Level3 */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Lock Shift */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* Unlatch Level3 */
+        KEY_1         , BOTH, XKB_KEY_exclam          , NEXT,
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Unlock Shift */
+        KEY_1         , BOTH, XKB_KEY_1               , NEXT,
+
+        /* Lock both */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Latch Shift */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Lock Shift */
+        KEY_RIGHTALT  , BOTH, XKB_KEY_ISO_Level3_Latch, NEXT, /* Latch Level3 */
+        KEY_RIGHTALT  , BOTH, XKB_KEY_ISO_Level3_Latch, NEXT, /* Lock Level3 */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT,
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT,
+        KEY_RIGHTALT  , BOTH, XKB_KEY_ISO_Level3_Latch, NEXT, /* Unlock Level3 */
+        KEY_1         , BOTH, XKB_KEY_exclam          , NEXT,
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Unlock Shift */
+        KEY_1         , BOTH, XKB_KEY_1               , NEXT,
+
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Latch Shift */
+        KEY_RIGHTALT  , BOTH, XKB_KEY_ISO_Level3_Latch, NEXT, /* Latch Level3 */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Lock Shift */
+        KEY_RIGHTALT  , BOTH, XKB_KEY_ISO_Level3_Latch, NEXT, /* Lock Level3 */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT,
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT,
+        KEY_RIGHTALT  , BOTH, XKB_KEY_ISO_Level3_Latch, NEXT, /* Unlock Level3 */
+        KEY_1         , BOTH, XKB_KEY_exclam          , NEXT,
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Unlock Shift */
+        KEY_1         , BOTH, XKB_KEY_1               , FINISH
+    ));
+
+    // TODO: Sequential with regular set & lock
+
+    /* Simultaneous (multiple keys down) */
+    assert(test_key_seq(keymap,
+        /* Set */
+        KEY_RIGHTALT  , DOWN, XKB_KEY_ISO_Level3_Latch, NEXT, /* Set Level3 */
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L         , NEXT, /* Set Shift */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* Prevent latches */
+        KEY_RIGHTALT  , UP  , XKB_KEY_ISO_Level3_Latch, NEXT, /* Unset Level3 */
+        KEY_1         , BOTH, XKB_KEY_exclam          , NEXT, /* Shift still active */
+        KEY_LEFTSHIFT , UP  , XKB_KEY_Shift_L         , NEXT, /* Unset Shift */
+        KEY_1         , BOTH, XKB_KEY_1               , NEXT,
+
+        /* Set one, latch the other */
+        KEY_RIGHTALT  , DOWN, XKB_KEY_ISO_Level3_Latch, NEXT, /* Set Level3 */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Latch Shift */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* Unlatch Shift, forbid Level3 latch */
+        KEY_RIGHTALT  , UP  , XKB_KEY_ISO_Level3_Latch, NEXT, /* Unset Level3 */
+        KEY_1         , BOTH, XKB_KEY_1               , NEXT,
+
+        KEY_RIGHTALT  , DOWN, XKB_KEY_ISO_Level3_Latch, NEXT, /* Set Level3 */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Latch Shift */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* Unlatch Shift, forbid Level3 latch */
+        KEY_1         , BOTH, XKB_KEY_onesuperior     , NEXT, /* Level 3 still active */
+        KEY_RIGHTALT  , UP  , XKB_KEY_ISO_Level3_Latch, NEXT, /* Unset Level3 */
+        KEY_1         , BOTH, XKB_KEY_1               , NEXT,
+
+        /* Set both, latch both */
+        KEY_RIGHTALT  , DOWN, XKB_KEY_ISO_Level3_Latch, NEXT, /* Set Level3 */
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L         , NEXT, /* Set Shift */
+        KEY_RIGHTALT  , UP  , XKB_KEY_ISO_Level3_Latch, NEXT, /* Latch Level3 */
+        KEY_LEFTSHIFT , UP  , XKB_KEY_Shift_L         , NEXT, /* Latch Shift */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* Unlatch both */
+        KEY_1         , BOTH, XKB_KEY_1               , NEXT,
+
+        KEY_RIGHTALT  , DOWN, XKB_KEY_ISO_Level3_Latch, NEXT, /* Set Level3 */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Latch Shift */
+        KEY_RIGHTALT  , UP  , XKB_KEY_ISO_Level3_Latch, NEXT, /* Latch Level3 */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* Unlatch both */
+        KEY_1         , BOTH, XKB_KEY_1               , NEXT,
+
+        /* Set one, lock the other */
+        KEY_RIGHTALT  , DOWN, XKB_KEY_ISO_Level3_Latch, NEXT, /* Set Level3 */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Latch Shift */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Lock Shift */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT,
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT,
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Unlock Shift */
+        KEY_1         , BOTH, XKB_KEY_onesuperior     , NEXT,
+        KEY_RIGHTALT  , UP  , XKB_KEY_ISO_Level3_Latch, NEXT, /* Unset Level3 */
+        KEY_1         , BOTH, XKB_KEY_1               , NEXT,
+
+        KEY_RIGHTALT  , DOWN, XKB_KEY_ISO_Level3_Latch, NEXT, /* Set Level3 */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Latch Shift */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Lock Shift */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT,
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT,
+        KEY_RIGHTALT  , UP  , XKB_KEY_ISO_Level3_Latch, NEXT, /* Unset Level3 */
+        KEY_1         , BOTH, XKB_KEY_exclam          , NEXT,
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Unlock Shift */
+        KEY_1         , BOTH, XKB_KEY_1               , NEXT,
+
+        /* Latch one, set the other */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Latch Shift */
+        KEY_RIGHTALT  , DOWN, XKB_KEY_ISO_Level3_Latch, NEXT, /* Set Level3 */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* Unlatch Shift, forbid Level3 latch */
+        KEY_RIGHTALT  , UP  , XKB_KEY_ISO_Level3_Latch, NEXT, /* Unset Level3 */
+        KEY_1         , BOTH, XKB_KEY_1               , NEXT,
+
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Latch Shift */
+        KEY_RIGHTALT  , DOWN, XKB_KEY_ISO_Level3_Latch, NEXT, /* Set Level3 */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* Unlatch Shift, forbid Level3 latch */
+        KEY_1         , BOTH, XKB_KEY_onesuperior     , NEXT, /* Level3 still active */
+        KEY_RIGHTALT  , UP  , XKB_KEY_ISO_Level3_Latch, NEXT, /* Unset Level3 */
+        KEY_1         , BOTH, XKB_KEY_1               , NEXT,
+
+        /* Latch one, lock the other */
+        KEY_RIGHTALT  , DOWN, XKB_KEY_ISO_Level3_Latch, NEXT, /* Set Level3 */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Latch Shift */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Lock Shift */
+        KEY_RIGHTALT  , UP  , XKB_KEY_ISO_Level3_Latch, NEXT, /* Latch Level3 */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* Unlatch level 3*/
+        KEY_1         , BOTH, XKB_KEY_exclam          , NEXT,
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Unlock Shift */
+        KEY_1         , BOTH, XKB_KEY_1               , NEXT,
+
+        KEY_RIGHTALT  , DOWN, XKB_KEY_ISO_Level3_Latch, NEXT, /* Set Level3 */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Latch Shift */
+        KEY_RIGHTALT  , UP  , XKB_KEY_ISO_Level3_Latch, NEXT, /* Latch Level3 */
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Lock Shift */
+        KEY_1         , BOTH, XKB_KEY_exclamdown      , NEXT, /* Unlatch level 3*/
+        KEY_1         , BOTH, XKB_KEY_exclam          , NEXT,
+        KEY_LEFTSHIFT , BOTH, XKB_KEY_Shift_L         , NEXT, /* Unlock Shift */
+        KEY_1         , BOTH, XKB_KEY_1               , FINISH
+    ));
+
+    xkb_keymap_unref(keymap);
 }
 
 struct key_properties {
@@ -462,6 +990,7 @@ main(void)
 
     test_simultaneous_modifier_clear(ctx);
     test_group_latch(ctx);
+    test_mod_latch(ctx);
     test_explicit_actions(ctx);
 
     keymap = test_compile_rules(ctx, "evdev", "evdev",


### PR DESCRIPTION
Prior to this MR, "latch A down" → "latch B down" → "latch A up" → "latch B up" would result in only B being latched. After this MR, both A and B end up latched.

Changed latching behavior so that the same rules used to detect whether an action breaks a latch after the latching key is released, are now also used to detect whether the action prevents the latch from triggering at the latching key release.

The major effect of this change is that depressing and releasing two latching keys simultaneously will now activate both latches, as expected. This will allow us to **provide proper Sticky Key support**.

Note that it seems X11 handle simultaneous modifiers only if pressed sequentially, not simultaneously. But I have not done extensive tests. It seems a bug however; according to [the XKB specification §2.1](https://www.x.org/releases/current/doc/kbproto/xkbproto.html#:~:text=Latched%20modifiers%20or,change%20keyboard%20state):

> Latched modifiers or groups apply only to the next key event that does not change keyboard state.

CC @Jules-Bertholet @mahkoh

---

@Jules-Bertholet I extracted the bug fix from #569 (good catch!), reworked it and added a big bunch of tests.
