### PR TITLE
xkbcomp: rework ActionList and KeysymList AST representation

### DIFF
--- a/src/xkbcomp/ast-build.c
+++ b/src/xkbcomp/ast-build.c
@@ -216,65 +216,23 @@ ExprCreateKeysymList(xkb_keysym_t sym)
     ExprDef *expr = ExprCreate(EXPR_KEYSYM_LIST, EXPR_TYPE_SYMBOLS, sizeof(ExprKeysymList));
     if (!expr)
         return NULL;
-
     darray_init(expr->keysym_list.syms);
-    darray_init(expr->keysym_list.symsMapIndex);
-    darray_init(expr->keysym_list.symsNumEntries);
-
-    darray_append(expr->keysym_list.symsMapIndex, 0);
     if (sym == XKB_KEY_NoSymbol) {
         /* Discard NoSymbol */
-        darray_append(expr->keysym_list.symsNumEntries, 0);
     } else {
-        darray_append(expr->keysym_list.symsNumEntries, 1);
         darray_append(expr->keysym_list.syms, sym);
     }
-
-    return expr;
-}
-
-ExprDef *
-ExprCreateMultiKeysymList(ExprDef *expr)
-{
-    const unsigned nLevels = darray_size(expr->keysym_list.syms);
-
-    darray_resize(expr->keysym_list.symsMapIndex, 1);
-    darray_resize(expr->keysym_list.symsNumEntries, 1);
-    darray_item(expr->keysym_list.symsMapIndex, 0) = 0;
-    darray_item(expr->keysym_list.symsNumEntries, 0) = nLevels;
-
     return expr;
 }
 
 ExprDef *
 ExprAppendKeysymList(ExprDef *expr, xkb_keysym_t sym)
 {
-    const unsigned nSyms = darray_size(expr->keysym_list.syms);
-    darray_append(expr->keysym_list.symsMapIndex, nSyms);
-
     if (sym == XKB_KEY_NoSymbol) {
         /* Discard NoSymbol */
-        darray_append(expr->keysym_list.symsNumEntries, 0);
     } else {
-        darray_append(expr->keysym_list.symsNumEntries, 1);
         darray_append(expr->keysym_list.syms, sym);
     }
-
-    return expr;
-}
-
-ExprDef *
-ExprAppendMultiKeysymList(ExprDef *expr, ExprDef *append)
-{
-    const unsigned nSyms = darray_size(expr->keysym_list.syms);
-    const unsigned numEntries = darray_size(append->keysym_list.syms);
-
-    darray_append(expr->keysym_list.symsMapIndex, nSyms);
-    darray_append(expr->keysym_list.symsNumEntries, numEntries);
-    darray_concat(expr->keysym_list.syms, append->keysym_list.syms);
-
-    FreeStmt((ParseCommon *) append);
-
     return expr;
 }
 
@@ -645,8 +603,6 @@ FreeExpr(ExprDef *expr)
 
     case EXPR_KEYSYM_LIST:
         darray_free(expr->keysym_list.syms);
-        darray_free(expr->keysym_list.symsMapIndex);
-        darray_free(expr->keysym_list.symsNumEntries);
         break;
 
     default:

--- a/src/xkbcomp/ast-build.c
+++ b/src/xkbcomp/ast-build.c
@@ -206,58 +206,7 @@ ExprCreateActionList(ExprDef *actions)
     ExprDef *expr = ExprCreate(EXPR_ACTION_LIST, EXPR_TYPE_ACTIONS, sizeof(ExprActionList));
     if (!expr)
         return NULL;
-
-    darray_init(expr->actions.actions);
-    darray_init(expr->actions.actionsMapIndex);
-    darray_init(expr->actions.actionsNumEntries);
-
-    darray_append(expr->actions.actions, actions);
-    darray_append(expr->actions.actionsMapIndex, 0);
-    darray_append(expr->actions.actionsNumEntries, 1);
-    return expr;
-}
-
-ExprDef *
-ExprCreateMultiActionList(ExprDef *expr)
-{
-    unsigned nLevels = darray_size(expr->actions.actionsMapIndex);
-
-    darray_resize(expr->actions.actionsMapIndex, 1);
-    darray_resize(expr->actions.actionsNumEntries, 1);
-    darray_item(expr->actions.actionsMapIndex, 0) = 0;
-    darray_item(expr->actions.actionsNumEntries, 0) = nLevels;
-
-    return expr;
-}
-
-ExprDef *
-ExprAppendActionList(ExprDef *expr, ExprDef *action)
-{
-    /* TODO: drop NoAction() here if multi-actions list (add drop parameter) */
-    unsigned nActions = darray_size(expr->actions.actions);
-
-    darray_append(expr->actions.actionsMapIndex, nActions);
-    darray_append(expr->actions.actionsNumEntries, 1);
-    darray_append(expr->actions.actions, action);
-
-    return expr;
-}
-
-ExprDef *
-ExprAppendMultiActionList(ExprDef *expr, ExprDef *append)
-{
-    unsigned nSyms = darray_size(expr->actions.actions);
-    unsigned numEntries = darray_size(append->actions.actions);
-
-    darray_append(expr->actions.actionsMapIndex, nSyms);
-    darray_append(expr->actions.actionsNumEntries, numEntries);
-
-    /* Steal */
-    darray_concat(expr->actions.actions, append->actions.actions);
-    darray_free(append->actions.actions);
-
-    FreeStmt((ParseCommon *) append);
-
+    expr->actions.actions = actions;
     return expr;
 }
 
@@ -665,8 +614,6 @@ FreeExpr(ExprDef *expr)
     if (!expr)
         return;
 
-    ExprDef** action;
-
     switch (expr->expr.op) {
     case EXPR_NEGATE:
     case EXPR_UNARY_PLUS:
@@ -689,12 +636,7 @@ FreeExpr(ExprDef *expr)
         break;
 
     case EXPR_ACTION_LIST:
-        darray_foreach(action, expr->actions.actions) {
-            FreeStmt((ParseCommon *) *action);
-        }
-        darray_free(expr->actions.actions);
-        darray_free(expr->actions.actionsMapIndex);
-        darray_free(expr->actions.actionsNumEntries);
+        FreeStmt((ParseCommon *) expr->actions.actions);
         break;
 
     case EXPR_ARRAY_REF:

--- a/src/xkbcomp/ast-build.h
+++ b/src/xkbcomp/ast-build.h
@@ -70,13 +70,7 @@ ExprDef *
 ExprCreateActionList(ExprDef *actions);
 
 ExprDef *
-ExprCreateMultiKeysymList(ExprDef *list);
-
-ExprDef *
 ExprCreateKeysymList(xkb_keysym_t sym);
-
-ExprDef *
-ExprAppendMultiKeysymList(ExprDef *list, ExprDef *append);
 
 ExprDef *
 ExprAppendKeysymList(ExprDef *list, xkb_keysym_t sym);

--- a/src/xkbcomp/ast-build.h
+++ b/src/xkbcomp/ast-build.h
@@ -70,15 +70,6 @@ ExprDef *
 ExprCreateActionList(ExprDef *actions);
 
 ExprDef *
-ExprCreateMultiActionList(ExprDef *expr);
-
-ExprDef *
-ExprAppendActionList(ExprDef *expr, ExprDef *action);
-
-ExprDef *
-ExprAppendMultiActionList(ExprDef *expr, ExprDef *append);
-
-ExprDef *
 ExprCreateMultiKeysymList(ExprDef *list);
 
 ExprDef *

--- a/src/xkbcomp/ast.h
+++ b/src/xkbcomp/ast.h
@@ -244,12 +244,8 @@ typedef struct {
 
 typedef struct {
     ExprCommon expr;
-    /* List of keysym for all levels, flattened */
+    /* List of keysym for a single level. */
     darray(xkb_keysym_t) syms;
-    /* List of start index in `syms`, per level */
-    darray(unsigned int) symsMapIndex;
-    /* List of number of keysyms, per level */
-    darray(unsigned int) symsNumEntries;
 } ExprKeysymList;
 
 union ExprDef {

--- a/src/xkbcomp/ast.h
+++ b/src/xkbcomp/ast.h
@@ -238,12 +238,8 @@ typedef struct {
 
 typedef struct {
     ExprCommon expr;
-    /* List of actions for all levels, flattened */
-    darray(ExprDef*) actions;
-    /* List of start index in `actions`, per level */
-    darray(unsigned int) actionsMapIndex;
-    /* List of number of actions, per level */
-    darray(unsigned int) actionsNumEntries;
+    /* List of actions for a single level. */
+    ExprDef *actions;
 } ExprActionList;
 
 typedef struct {


### PR DESCRIPTION
The AST is heavily based on intrusive lists for representing lists, but actions and keysyms are an exception, instead using darray. I don't see any reason for this; it ends up allocating more, and we don't especially need a flat array for this.

Change it to use the familiar linked-list style.

bench/rulescomp allocations, before:

```
total heap usage: 11,391,536 allocs, 11,391,536 frees, 511,335,213 bytes allocated
```

after:

```
total heap usage: 10,965,536 allocs, 10,965,536 frees, 496,327,213 bytes allocated
```