### PR TITLE
[POC] xkbcomp: allocate AST nodes using bump allocator

### DIFF
--- a/include/xkbcommon/xkbcommon-compose.h
+++ b/include/xkbcommon/xkbcommon-compose.h
@@ -232,7 +232,7 @@ enum xkb_compose_format {
  *
  * @memberof xkb_compose_table
  */
-struct xkb_compose_table *
+XKB_EXPORT struct xkb_compose_table *
 xkb_compose_table_new_from_locale(struct xkb_context *context,
                                   const char *locale,
                                   enum xkb_compose_compile_flags flags);
@@ -256,7 +256,7 @@ xkb_compose_table_new_from_locale(struct xkb_context *context,
  *
  * @memberof xkb_compose_table
  */
-struct xkb_compose_table *
+XKB_EXPORT struct xkb_compose_table *
 xkb_compose_table_new_from_file(struct xkb_context *context,
                                 FILE *file,
                                 const char *locale,
@@ -272,7 +272,7 @@ xkb_compose_table_new_from_file(struct xkb_context *context,
  * @see xkb_compose_table_new_from_file()
  * @memberof xkb_compose_table
  */
-struct xkb_compose_table *
+XKB_EXPORT struct xkb_compose_table *
 xkb_compose_table_new_from_buffer(struct xkb_context *context,
                                   const char *buffer, size_t length,
                                   const char *locale,
@@ -286,7 +286,7 @@ xkb_compose_table_new_from_buffer(struct xkb_context *context,
  *
  * @memberof xkb_compose_table
  */
-struct xkb_compose_table *
+XKB_EXPORT struct xkb_compose_table *
 xkb_compose_table_ref(struct xkb_compose_table *table);
 
 /**
@@ -296,7 +296,7 @@ xkb_compose_table_ref(struct xkb_compose_table *table);
  *
  * @memberof xkb_compose_table
  */
-void
+XKB_EXPORT void
 xkb_compose_table_unref(struct xkb_compose_table *table);
 
 /**
@@ -332,7 +332,7 @@ struct xkb_compose_table_entry;
  * @memberof xkb_compose_table_entry
  * @since 1.6.0
  */
-const xkb_keysym_t *
+XKB_EXPORT const xkb_keysym_t *
 xkb_compose_table_entry_sequence(struct xkb_compose_table_entry *entry,
                                  size_t *sequence_length);
 
@@ -353,7 +353,7 @@ xkb_compose_table_entry_sequence(struct xkb_compose_table_entry *entry,
  * @memberof xkb_compose_table_entry
  * @since 1.6.0
  */
-xkb_keysym_t
+XKB_EXPORT xkb_keysym_t
 xkb_compose_table_entry_keysym(struct xkb_compose_table_entry *entry);
 
 /**
@@ -375,7 +375,7 @@ xkb_compose_table_entry_keysym(struct xkb_compose_table_entry *entry);
  * @memberof xkb_compose_table_entry
  * @since 1.6.0
  */
-const char *
+XKB_EXPORT const char *
 xkb_compose_table_entry_utf8(struct xkb_compose_table_entry *entry);
 
 /**
@@ -407,7 +407,7 @@ struct xkb_compose_table_iterator;
  * @sa xkb_compose_table_iterator_free()
  * @since 1.6.0
  */
-struct xkb_compose_table_iterator *
+XKB_EXPORT struct xkb_compose_table_iterator *
 xkb_compose_table_iterator_new(struct xkb_compose_table *table);
 
 /**
@@ -416,7 +416,7 @@ xkb_compose_table_iterator_new(struct xkb_compose_table *table);
  * @memberof xkb_compose_table_iterator
  * @since 1.6.0
  */
-void
+XKB_EXPORT void
 xkb_compose_table_iterator_free(struct xkb_compose_table_iterator *iter);
 
 /**
@@ -433,7 +433,7 @@ xkb_compose_table_iterator_free(struct xkb_compose_table_iterator *iter);
  * @memberof xkb_compose_table_iterator
  * @since 1.6.0
  */
-struct xkb_compose_table_entry *
+XKB_EXPORT struct xkb_compose_table_entry *
 xkb_compose_table_iterator_next(struct xkb_compose_table_iterator *iter);
 
 /** Flags for compose state creation. */
@@ -454,7 +454,7 @@ enum xkb_compose_state_flags {
  *
  * @memberof xkb_compose_state
  */
-struct xkb_compose_state *
+XKB_EXPORT struct xkb_compose_state *
 xkb_compose_state_new(struct xkb_compose_table *table,
                       enum xkb_compose_state_flags flags);
 
@@ -465,7 +465,7 @@ xkb_compose_state_new(struct xkb_compose_table *table,
  *
  * @memberof xkb_compose_state
  */
-struct xkb_compose_state *
+XKB_EXPORT struct xkb_compose_state *
 xkb_compose_state_ref(struct xkb_compose_state *state);
 
 /**
@@ -475,7 +475,7 @@ xkb_compose_state_ref(struct xkb_compose_state *state);
  *
  * @memberof xkb_compose_state
  */
-void
+XKB_EXPORT void
 xkb_compose_state_unref(struct xkb_compose_state *state);
 
 /**
@@ -490,7 +490,7 @@ xkb_compose_state_unref(struct xkb_compose_state *state);
  *
  * @memberof xkb_compose_state
  */
-struct xkb_compose_table *
+XKB_EXPORT struct xkb_compose_table *
 xkb_compose_state_get_compose_table(struct xkb_compose_state *state);
 
 /** Status of the Compose sequence state machine. */
@@ -558,7 +558,7 @@ enum xkb_compose_feed_result {
  *
  * @memberof xkb_compose_state
  */
-enum xkb_compose_feed_result
+XKB_EXPORT enum xkb_compose_feed_result
 xkb_compose_state_feed(struct xkb_compose_state *state,
                        xkb_keysym_t keysym);
 
@@ -570,7 +570,7 @@ xkb_compose_state_feed(struct xkb_compose_state *state,
  *
  * @memberof xkb_compose_state
  */
-void
+XKB_EXPORT void
 xkb_compose_state_reset(struct xkb_compose_state *state);
 
 /**
@@ -579,7 +579,7 @@ xkb_compose_state_reset(struct xkb_compose_state *state);
  * @see xkb_compose_status
  * @memberof xkb_compose_state
  **/
-enum xkb_compose_status
+XKB_EXPORT enum xkb_compose_status
 xkb_compose_state_get_status(struct xkb_compose_state *state);
 
 /**
@@ -610,7 +610,7 @@ xkb_compose_state_get_status(struct xkb_compose_state *state);
  *
  * @memberof xkb_compose_state
  **/
-int
+XKB_EXPORT int
 xkb_compose_state_get_utf8(struct xkb_compose_state *state,
                            char *buffer, size_t size);
 
@@ -625,7 +625,7 @@ xkb_compose_state_get_utf8(struct xkb_compose_state *state,
  *
  * @memberof xkb_compose_state
  **/
-xkb_keysym_t
+XKB_EXPORT xkb_keysym_t
 xkb_compose_state_get_one_sym(struct xkb_compose_state *state);
 
 /** @} */

--- a/include/xkbcommon/xkbcommon-x11.h
+++ b/include/xkbcommon/xkbcommon-x11.h
@@ -163,7 +163,7 @@ enum xkb_x11_setup_xkb_extension_flags {
  *
  * @returns 1 on success, or 0 on failure.
  */
-int
+XKB_EXPORT int
 xkb_x11_setup_xkb_extension(xcb_connection_t *connection,
                             uint16_t major_xkb_version,
                             uint16_t minor_xkb_version,
@@ -181,7 +181,7 @@ xkb_x11_setup_xkb_extension(xcb_connection_t *connection,
  * @returns A device ID which may be used with other xkb_x11_* functions,
  *          or -1 on failure.
  */
-int32_t
+XKB_EXPORT int32_t
 xkb_x11_get_core_keyboard_device_id(xcb_connection_t *connection);
 
 /**
@@ -206,7 +206,7 @@ xkb_x11_get_core_keyboard_device_id(xcb_connection_t *connection);
  *
  * @memberof xkb_keymap
  */
-struct xkb_keymap *
+XKB_EXPORT struct xkb_keymap *
 xkb_x11_keymap_new_from_device(struct xkb_context *context,
                                xcb_connection_t *connection,
                                int32_t device_id,
@@ -230,7 +230,7 @@ xkb_x11_keymap_new_from_device(struct xkb_context *context,
  *
  * @memberof xkb_state
  */
-struct xkb_state *
+XKB_EXPORT struct xkb_state *
 xkb_x11_state_new_from_device(struct xkb_keymap *keymap,
                               xcb_connection_t *connection,
                               int32_t device_id);

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -92,6 +92,12 @@
 extern "C" {
 #endif
 
+#if defined(__GNUC__) && !defined(__CYGWIN__)
+# define XKB_EXPORT      __attribute__((visibility("default")))
+#else
+# define XKB_EXPORT
+#endif
+
 /**
  * @file
  * Main libxkbcommon API.
@@ -452,7 +458,7 @@ struct xkb_rule_names {
  *
  * @sa xkb_keysym_t
  */
-int
+XKB_EXPORT int
 xkb_keysym_get_name(xkb_keysym_t keysym, char *buffer, size_t size);
 
 /** Flags for xkb_keysym_from_name(). */
@@ -486,7 +492,7 @@ enum xkb_keysym_flags {
  *
  * @sa xkb_keysym_t
  */
-xkb_keysym_t
+XKB_EXPORT xkb_keysym_t
 xkb_keysym_from_name(const char *name, enum xkb_keysym_flags flags);
 
 /**
@@ -505,7 +511,7 @@ xkb_keysym_from_name(const char *name, enum xkb_keysym_flags flags);
  *
  * @sa xkb_state_key_get_utf8()
  */
-int
+XKB_EXPORT int
 xkb_keysym_to_utf8(xkb_keysym_t keysym, char *buffer, size_t size);
 
 /**
@@ -520,7 +526,7 @@ xkb_keysym_to_utf8(xkb_keysym_t keysym, char *buffer, size_t size);
  *
  * @sa xkb_state_key_get_utf32()
  */
-uint32_t
+XKB_EXPORT uint32_t
 xkb_keysym_to_utf32(xkb_keysym_t keysym);
 
 /**
@@ -543,7 +549,7 @@ xkb_keysym_to_utf32(xkb_keysym_t keysym);
  * @sa xkb_keysym_to_utf32()
  * @since 1.0.0
  */
-xkb_keysym_t
+XKB_EXPORT xkb_keysym_t
 xkb_utf32_to_keysym(uint32_t ucs);
 
 /**
@@ -568,7 +574,7 @@ xkb_utf32_to_keysym(uint32_t ucs);
  * @since 0.8.0: Initial implementation, based on `libX11`.
  * @since 1.8.0: Use Unicode 16.0 mappings for complete Unicode coverage.
  */
-xkb_keysym_t
+XKB_EXPORT xkb_keysym_t
 xkb_keysym_to_upper(xkb_keysym_t ks);
 
 /**
@@ -584,7 +590,7 @@ xkb_keysym_to_upper(xkb_keysym_t ks);
  * @since 0.8.0: Initial implementation, based on `libX11`.
  * @since 1.8.0: Use Unicode 16.0 mappings for complete Unicode coverage.
  */
-xkb_keysym_t
+XKB_EXPORT xkb_keysym_t
 xkb_keysym_to_lower(xkb_keysym_t ks);
 
 /** @} */
@@ -641,7 +647,7 @@ enum xkb_context_flags {
  *
  * @memberof xkb_context
  */
-struct xkb_context *
+XKB_EXPORT struct xkb_context *
 xkb_context_new(enum xkb_context_flags flags);
 
 /**
@@ -651,7 +657,7 @@ xkb_context_new(enum xkb_context_flags flags);
  *
  * @memberof xkb_context
  */
-struct xkb_context *
+XKB_EXPORT struct xkb_context *
 xkb_context_ref(struct xkb_context *context);
 
 /**
@@ -661,7 +667,7 @@ xkb_context_ref(struct xkb_context *context);
  *
  * @memberof xkb_context
  */
-void
+XKB_EXPORT void
 xkb_context_unref(struct xkb_context *context);
 
 /**
@@ -672,7 +678,7 @@ xkb_context_unref(struct xkb_context *context);
  *
  * @memberof xkb_context
  */
-void
+XKB_EXPORT void
 xkb_context_set_user_data(struct xkb_context *context, void *user_data);
 
 /**
@@ -686,7 +692,7 @@ xkb_context_set_user_data(struct xkb_context *context, void *user_data);
  *
  * @memberof xkb_context
  **/
-void *
+XKB_EXPORT void *
 xkb_context_get_user_data(struct xkb_context *context);
 
 /** @} */
@@ -720,7 +726,7 @@ xkb_context_get_user_data(struct xkb_context *context);
  *
  * @memberof xkb_context
  */
-int
+XKB_EXPORT int
 xkb_context_include_path_append(struct xkb_context *context, const char *path);
 
 /**
@@ -730,7 +736,7 @@ xkb_context_include_path_append(struct xkb_context *context, const char *path);
  *
  * @memberof xkb_context
  */
-int
+XKB_EXPORT int
 xkb_context_include_path_append_default(struct xkb_context *context);
 
 /**
@@ -743,7 +749,7 @@ xkb_context_include_path_append_default(struct xkb_context *context);
  *
  * @memberof xkb_context
  */
-int
+XKB_EXPORT int
 xkb_context_include_path_reset_defaults(struct xkb_context *context);
 
 /**
@@ -751,7 +757,7 @@ xkb_context_include_path_reset_defaults(struct xkb_context *context);
  *
  * @memberof xkb_context
  */
-void
+XKB_EXPORT void
 xkb_context_include_path_clear(struct xkb_context *context);
 
 /**
@@ -759,7 +765,7 @@ xkb_context_include_path_clear(struct xkb_context *context);
  *
  * @memberof xkb_context
  */
-unsigned int
+XKB_EXPORT unsigned int
 xkb_context_num_include_paths(struct xkb_context *context);
 
 /**
@@ -770,7 +776,7 @@ xkb_context_num_include_paths(struct xkb_context *context);
  *
  * @memberof xkb_context
  */
-const char *
+XKB_EXPORT const char *
 xkb_context_include_path_get(struct xkb_context *context, unsigned int index);
 
 /** @} */
@@ -804,7 +810,7 @@ enum xkb_log_level {
  *
  * @memberof xkb_context
  */
-void
+XKB_EXPORT void
 xkb_context_set_log_level(struct xkb_context *context,
                           enum xkb_log_level level);
 
@@ -813,7 +819,7 @@ xkb_context_set_log_level(struct xkb_context *context,
  *
  * @memberof xkb_context
  */
-enum xkb_log_level
+XKB_EXPORT enum xkb_log_level
 xkb_context_get_log_level(struct xkb_context *context);
 
 /**
@@ -835,7 +841,7 @@ xkb_context_get_log_level(struct xkb_context *context);
  *
  * @memberof xkb_context
  */
-void
+XKB_EXPORT void
 xkb_context_set_log_verbosity(struct xkb_context *context, int verbosity);
 
 /**
@@ -843,7 +849,7 @@ xkb_context_set_log_verbosity(struct xkb_context *context, int verbosity);
  *
  * @memberof xkb_context
  */
-int
+XKB_EXPORT int
 xkb_context_get_log_verbosity(struct xkb_context *context);
 
 /**
@@ -866,7 +872,7 @@ xkb_context_get_log_verbosity(struct xkb_context *context);
  *
  * @memberof xkb_context
  */
-void
+XKB_EXPORT void
 xkb_context_set_log_fn(struct xkb_context *context,
                        void (*log_fn)(struct xkb_context *context,
                                       enum xkb_log_level level,
@@ -903,7 +909,7 @@ enum xkb_keymap_compile_flags {
  * @sa xkb_rule_names
  * @memberof xkb_keymap
  */
-struct xkb_keymap *
+XKB_EXPORT struct xkb_keymap *
 xkb_keymap_new_from_names(struct xkb_context *context,
                           const struct xkb_rule_names *names,
                           enum xkb_keymap_compile_flags flags);
@@ -932,7 +938,7 @@ enum xkb_keymap_format {
  *
  * @memberof xkb_keymap
  */
-struct xkb_keymap *
+XKB_EXPORT struct xkb_keymap *
 xkb_keymap_new_from_file(struct xkb_context *context, FILE *file,
                          enum xkb_keymap_format format,
                          enum xkb_keymap_compile_flags flags);
@@ -946,7 +952,7 @@ xkb_keymap_new_from_file(struct xkb_context *context, FILE *file,
  * @see xkb_keymap_new_from_file()
  * @memberof xkb_keymap
  */
-struct xkb_keymap *
+XKB_EXPORT struct xkb_keymap *
 xkb_keymap_new_from_string(struct xkb_context *context, const char *string,
                            enum xkb_keymap_format format,
                            enum xkb_keymap_compile_flags flags);
@@ -961,7 +967,7 @@ xkb_keymap_new_from_string(struct xkb_context *context, const char *string,
  * @memberof xkb_keymap
  * @since 0.3.0
  */
-struct xkb_keymap *
+XKB_EXPORT struct xkb_keymap *
 xkb_keymap_new_from_buffer(struct xkb_context *context, const char *buffer,
                            size_t length, enum xkb_keymap_format format,
                            enum xkb_keymap_compile_flags flags);
@@ -973,7 +979,7 @@ xkb_keymap_new_from_buffer(struct xkb_context *context, const char *buffer,
  *
  * @memberof xkb_keymap
  */
-struct xkb_keymap *
+XKB_EXPORT struct xkb_keymap *
 xkb_keymap_ref(struct xkb_keymap *keymap);
 
 /**
@@ -983,7 +989,7 @@ xkb_keymap_ref(struct xkb_keymap *keymap);
  *
  * @memberof xkb_keymap
  */
-void
+XKB_EXPORT void
 xkb_keymap_unref(struct xkb_keymap *keymap);
 
 /**
@@ -1010,7 +1016,7 @@ xkb_keymap_unref(struct xkb_keymap *keymap);
  *
  * @memberof xkb_keymap
  */
-char *
+XKB_EXPORT char *
 xkb_keymap_get_as_string(struct xkb_keymap *keymap,
                          enum xkb_keymap_format format);
 
@@ -1030,7 +1036,7 @@ xkb_keymap_get_as_string(struct xkb_keymap *keymap,
  * @memberof xkb_keymap
  * @since 0.3.1
  */
-xkb_keycode_t
+XKB_EXPORT xkb_keycode_t
 xkb_keymap_min_keycode(struct xkb_keymap *keymap);
 
 /**
@@ -1040,7 +1046,7 @@ xkb_keymap_min_keycode(struct xkb_keymap *keymap);
  * @memberof xkb_keymap
  * @since 0.3.1
  */
-xkb_keycode_t
+XKB_EXPORT xkb_keycode_t
 xkb_keymap_max_keycode(struct xkb_keymap *keymap);
 
 /**
@@ -1063,7 +1069,7 @@ typedef void
  * @memberof xkb_keymap
  * @since 0.3.1
  */
-void
+XKB_EXPORT void
 xkb_keymap_key_for_each(struct xkb_keymap *keymap, xkb_keymap_key_iter_t iter,
                         void *data);
 
@@ -1080,7 +1086,7 @@ xkb_keymap_key_for_each(struct xkb_keymap *keymap, xkb_keymap_key_iter_t iter,
  * @memberof xkb_keymap
  * @since 0.6.0
  */
-const char *
+XKB_EXPORT const char *
 xkb_keymap_key_get_name(struct xkb_keymap *keymap, xkb_keycode_t key);
 
 /**
@@ -1095,7 +1101,7 @@ xkb_keymap_key_get_name(struct xkb_keymap *keymap, xkb_keycode_t key);
  * @memberof xkb_keymap
  * @since 0.6.0
  */
-xkb_keycode_t
+XKB_EXPORT xkb_keycode_t
 xkb_keymap_key_by_name(struct xkb_keymap *keymap, const char *name);
 
 /**
@@ -1104,7 +1110,7 @@ xkb_keymap_key_by_name(struct xkb_keymap *keymap, const char *name);
  * @sa xkb_mod_index_t
  * @memberof xkb_keymap
  */
-xkb_mod_index_t
+XKB_EXPORT xkb_mod_index_t
 xkb_keymap_num_mods(struct xkb_keymap *keymap);
 
 /**
@@ -1115,7 +1121,7 @@ xkb_keymap_num_mods(struct xkb_keymap *keymap);
  * @sa xkb_mod_index_t
  * @memberof xkb_keymap
  */
-const char *
+XKB_EXPORT const char *
 xkb_keymap_mod_get_name(struct xkb_keymap *keymap, xkb_mod_index_t idx);
 
 /**
@@ -1127,7 +1133,7 @@ xkb_keymap_mod_get_name(struct xkb_keymap *keymap, xkb_mod_index_t idx);
  * @sa xkb_mod_index_t
  * @memberof xkb_keymap
  */
-xkb_mod_index_t
+XKB_EXPORT xkb_mod_index_t
 xkb_keymap_mod_get_index(struct xkb_keymap *keymap, const char *name);
 
 /**
@@ -1136,7 +1142,7 @@ xkb_keymap_mod_get_index(struct xkb_keymap *keymap, const char *name);
  * @sa xkb_layout_index_t xkb_rule_names xkb_keymap_num_layouts_for_key()
  * @memberof xkb_keymap
  */
-xkb_layout_index_t
+XKB_EXPORT xkb_layout_index_t
 xkb_keymap_num_layouts(struct xkb_keymap *keymap);
 
 /**
@@ -1149,7 +1155,7 @@ xkb_keymap_num_layouts(struct xkb_keymap *keymap);
  *     For notes on layout names.
  * @memberof xkb_keymap
  */
-const char *
+XKB_EXPORT const char *
 xkb_keymap_layout_get_name(struct xkb_keymap *keymap, xkb_layout_index_t idx);
 
 /**
@@ -1163,7 +1169,7 @@ xkb_keymap_layout_get_name(struct xkb_keymap *keymap, xkb_layout_index_t idx);
  *     For notes on layout names.
  * @memberof xkb_keymap
  */
-xkb_layout_index_t
+XKB_EXPORT xkb_layout_index_t
 xkb_keymap_layout_get_index(struct xkb_keymap *keymap, const char *name);
 
 /**
@@ -1177,7 +1183,7 @@ xkb_keymap_layout_get_index(struct xkb_keymap *keymap, const char *name);
  * @sa xkb_led_index_t
  * @memberof xkb_keymap
  */
-xkb_led_index_t
+XKB_EXPORT xkb_led_index_t
 xkb_keymap_num_leds(struct xkb_keymap *keymap);
 
 /**
@@ -1187,7 +1193,7 @@ xkb_keymap_num_leds(struct xkb_keymap *keymap);
  *
  * @memberof xkb_keymap
  */
-const char *
+XKB_EXPORT const char *
 xkb_keymap_led_get_name(struct xkb_keymap *keymap, xkb_led_index_t idx);
 
 /**
@@ -1198,7 +1204,7 @@ xkb_keymap_led_get_name(struct xkb_keymap *keymap, xkb_led_index_t idx);
  *
  * @memberof xkb_keymap
  */
-xkb_led_index_t
+XKB_EXPORT xkb_led_index_t
 xkb_keymap_led_get_index(struct xkb_keymap *keymap, const char *name);
 
 /**
@@ -1211,7 +1217,7 @@ xkb_keymap_led_get_index(struct xkb_keymap *keymap, const char *name);
  * @sa xkb_layout_index_t
  * @memberof xkb_keymap
  */
-xkb_layout_index_t
+XKB_EXPORT xkb_layout_index_t
 xkb_keymap_num_layouts_for_key(struct xkb_keymap *keymap, xkb_keycode_t key);
 
 /**
@@ -1224,7 +1230,7 @@ xkb_keymap_num_layouts_for_key(struct xkb_keymap *keymap, xkb_keycode_t key);
  * @sa xkb_level_index_t
  * @memberof xkb_keymap
  */
-xkb_level_index_t
+XKB_EXPORT xkb_level_index_t
 xkb_keymap_num_levels_for_key(struct xkb_keymap *keymap, xkb_keycode_t key,
                               xkb_layout_index_t layout);
 
@@ -1264,7 +1270,7 @@ xkb_keymap_num_levels_for_key(struct xkb_keymap *keymap, xkb_keycode_t key,
  * @memberof xkb_keymap
  * @since 1.0.0
  */
-size_t
+XKB_EXPORT size_t
 xkb_keymap_key_get_mods_for_level(struct xkb_keymap *keymap,
                                   xkb_keycode_t key,
                                   xkb_layout_index_t layout,
@@ -1300,7 +1306,7 @@ xkb_keymap_key_get_mods_for_level(struct xkb_keymap *keymap,
  * @sa xkb_state_key_get_syms()
  * @memberof xkb_keymap
  */
-int
+XKB_EXPORT int
 xkb_keymap_key_get_syms_by_level(struct xkb_keymap *keymap,
                                  xkb_keycode_t key,
                                  xkb_layout_index_t layout,
@@ -1322,7 +1328,7 @@ xkb_keymap_key_get_syms_by_level(struct xkb_keymap *keymap,
  *
  * @memberof xkb_keymap
  */
-int
+XKB_EXPORT int
 xkb_keymap_key_repeats(struct xkb_keymap *keymap, xkb_keycode_t key);
 
 /** @} */
@@ -1343,7 +1349,7 @@ xkb_keymap_key_repeats(struct xkb_keymap *keymap, xkb_keycode_t key);
  *
  * @memberof xkb_state
  */
-struct xkb_state *
+XKB_EXPORT struct xkb_state *
 xkb_state_new(struct xkb_keymap *keymap);
 
 /**
@@ -1353,7 +1359,7 @@ xkb_state_new(struct xkb_keymap *keymap);
  *
  * @memberof xkb_state
  */
-struct xkb_state *
+XKB_EXPORT struct xkb_state *
 xkb_state_ref(struct xkb_state *state);
 
 /**
@@ -1363,7 +1369,7 @@ xkb_state_ref(struct xkb_state *state);
  *
  * @memberof xkb_state
  */
-void
+XKB_EXPORT void
 xkb_state_unref(struct xkb_state *state);
 
 /**
@@ -1378,7 +1384,7 @@ xkb_state_unref(struct xkb_state *state);
  *
  * @memberof xkb_state
  */
-struct xkb_keymap *
+XKB_EXPORT struct xkb_keymap *
 xkb_state_get_keymap(struct xkb_state *state);
 
 /**
@@ -1476,7 +1482,7 @@ enum xkb_state_component {
  *
  * @sa xkb_state_update_mask()
  */
-enum xkb_state_component
+XKB_EXPORT enum xkb_state_component
 xkb_state_update_key(struct xkb_state *state, xkb_keycode_t key,
                      enum xkb_key_direction direction);
 
@@ -1502,7 +1508,7 @@ xkb_state_update_key(struct xkb_state *state, xkb_keycode_t key,
  * @sa xkb_state_component
  * @sa xkb_state_update_key
  */
-enum xkb_state_component
+XKB_EXPORT enum xkb_state_component
 xkb_state_update_mask(struct xkb_state *state,
                       xkb_mod_mask_t depressed_mods,
                       xkb_mod_mask_t latched_mods,
@@ -1537,7 +1543,7 @@ xkb_state_update_mask(struct xkb_state *state,
  *
  * @memberof xkb_state
  */
-int
+XKB_EXPORT int
 xkb_state_key_get_syms(struct xkb_state *state, xkb_keycode_t key,
                        const xkb_keysym_t **syms_out);
 
@@ -1567,7 +1573,7 @@ xkb_state_key_get_syms(struct xkb_state *state, xkb_keycode_t key,
  * @memberof xkb_state
  * @since 0.4.1
  */
-int
+XKB_EXPORT int
 xkb_state_key_get_utf8(struct xkb_state *state, xkb_keycode_t key,
                        char *buffer, size_t size);
 
@@ -1584,7 +1590,7 @@ xkb_state_key_get_utf8(struct xkb_state *state, xkb_keycode_t key,
  * @memberof xkb_state
  * @since 0.4.1
  */
-uint32_t
+XKB_EXPORT uint32_t
 xkb_state_key_get_utf32(struct xkb_state *state, xkb_keycode_t key);
 
 /**
@@ -1604,7 +1610,7 @@ xkb_state_key_get_utf32(struct xkb_state *state, xkb_keycode_t key);
  * @sa xkb_state_key_get_syms()
  * @memberof xkb_state
  */
-xkb_keysym_t
+XKB_EXPORT xkb_keysym_t
 xkb_state_key_get_one_sym(struct xkb_state *state, xkb_keycode_t key);
 
 /**
@@ -1621,7 +1627,7 @@ xkb_state_key_get_one_sym(struct xkb_state *state, xkb_keycode_t key);
  *
  * @memberof xkb_state
  */
-xkb_layout_index_t
+XKB_EXPORT xkb_layout_index_t
 xkb_state_key_get_layout(struct xkb_state *state, xkb_keycode_t key);
 
 /**
@@ -1646,7 +1652,7 @@ xkb_state_key_get_layout(struct xkb_state *state, xkb_keycode_t key);
  *
  * @memberof xkb_state
  */
-xkb_level_index_t
+XKB_EXPORT xkb_level_index_t
 xkb_state_key_get_level(struct xkb_state *state, xkb_keycode_t key,
                         xkb_layout_index_t layout);
 
@@ -1685,7 +1691,7 @@ enum xkb_state_match {
  *
  * @memberof xkb_state
  */
-xkb_mod_mask_t
+XKB_EXPORT xkb_mod_mask_t
 xkb_state_serialize_mods(struct xkb_state *state,
                          enum xkb_state_component components);
 
@@ -1708,7 +1714,7 @@ xkb_state_serialize_mods(struct xkb_state *state,
  *
  * @memberof xkb_state
  */
-xkb_layout_index_t
+XKB_EXPORT xkb_layout_index_t
 xkb_state_serialize_layout(struct xkb_state *state,
                            enum xkb_state_component components);
 
@@ -1729,7 +1735,7 @@ xkb_state_serialize_layout(struct xkb_state *state,
  * [virtual modifiers]: @ref virtual-modifier-def
  * [real modifiers]: @ref real-modifier-def
  */
-int
+XKB_EXPORT int
 xkb_state_mod_name_is_active(struct xkb_state *state, const char *name,
                              enum xkb_state_component type);
 
@@ -1759,7 +1765,7 @@ xkb_state_mod_name_is_active(struct xkb_state *state, const char *name,
  * [virtual modifiers]: @ref virtual-modifier-def
  * [real modifiers]: @ref real-modifier-def
  */
-int
+XKB_EXPORT int
 xkb_state_mod_names_are_active(struct xkb_state *state,
                                enum xkb_state_component type,
                                enum xkb_state_match match,
@@ -1782,7 +1788,7 @@ xkb_state_mod_names_are_active(struct xkb_state *state,
  * [virtual modifiers]: @ref virtual-modifier-def
  * [real modifiers]: @ref real-modifier-def
  */
-int
+XKB_EXPORT int
 xkb_state_mod_index_is_active(struct xkb_state *state, xkb_mod_index_t idx,
                               enum xkb_state_component type);
 
@@ -1812,7 +1818,7 @@ xkb_state_mod_index_is_active(struct xkb_state *state, xkb_mod_index_t idx,
  * [virtual modifiers]: @ref virtual-modifier-def
  * [real modifiers]: @ref real-modifier-def
  */
-int
+XKB_EXPORT int
 xkb_state_mod_indices_are_active(struct xkb_state *state,
                                  enum xkb_state_component type,
                                  enum xkb_state_match match,
@@ -1934,7 +1940,7 @@ enum xkb_consumed_mode {
  *
  * [real modifiers]: @ref real-modifier-def
  */
-xkb_mod_mask_t
+XKB_EXPORT xkb_mod_mask_t
 xkb_state_key_get_consumed_mods2(struct xkb_state *state, xkb_keycode_t key,
                                  enum xkb_consumed_mode mode);
 
@@ -1944,7 +1950,7 @@ xkb_state_key_get_consumed_mods2(struct xkb_state *state, xkb_keycode_t key,
  * @memberof xkb_state
  * @since 0.4.1
  */
-xkb_mod_mask_t
+XKB_EXPORT xkb_mod_mask_t
 xkb_state_key_get_consumed_mods(struct xkb_state *state, xkb_keycode_t key);
 
 /**
@@ -1971,7 +1977,7 @@ xkb_state_key_get_consumed_mods(struct xkb_state *state, xkb_keycode_t key);
  * [virtual modifiers]: @ref virtual-modifier-def
  * [real modifiers]: @ref real-modifier-def
  */
-int
+XKB_EXPORT int
 xkb_state_mod_index_is_consumed2(struct xkb_state *state,
                                  xkb_keycode_t key,
                                  xkb_mod_index_t idx,
@@ -1990,7 +1996,7 @@ xkb_state_mod_index_is_consumed2(struct xkb_state *state,
  * [virtual modifiers]: @ref virtual-modifier-def
  * [real modifiers]: @ref real-modifier-def
  */
-int
+XKB_EXPORT int
 xkb_state_mod_index_is_consumed(struct xkb_state *state, xkb_keycode_t key,
                                 xkb_mod_index_t idx);
 
@@ -2011,7 +2017,7 @@ xkb_state_mod_index_is_consumed(struct xkb_state *state, xkb_keycode_t key,
  *
  * [real modifiers]: @ref real-modifier-def
  */
-xkb_mod_mask_t
+XKB_EXPORT xkb_mod_mask_t
 xkb_state_mod_mask_remove_consumed(struct xkb_state *state, xkb_keycode_t key,
                                    xkb_mod_mask_t mask);
 
@@ -2027,7 +2033,7 @@ xkb_state_mod_mask_remove_consumed(struct xkb_state *state, xkb_keycode_t key,
  * @sa xkb_layout_index_t
  * @memberof xkb_state
  */
-int
+XKB_EXPORT int
 xkb_state_layout_name_is_active(struct xkb_state *state, const char *name,
                                 enum xkb_state_component type);
 
@@ -2040,7 +2046,7 @@ xkb_state_layout_name_is_active(struct xkb_state *state, const char *name,
  * @sa xkb_layout_index_t
  * @memberof xkb_state
  */
-int
+XKB_EXPORT int
 xkb_state_layout_index_is_active(struct xkb_state *state,
                                  xkb_layout_index_t idx,
                                  enum xkb_state_component type);
@@ -2054,7 +2060,7 @@ xkb_state_layout_index_is_active(struct xkb_state *state,
  * @sa xkb_led_index_t
  * @memberof xkb_state
  */
-int
+XKB_EXPORT int
 xkb_state_led_name_is_active(struct xkb_state *state, const char *name);
 
 /**
@@ -2066,7 +2072,7 @@ xkb_state_led_name_is_active(struct xkb_state *state, const char *name);
  * @sa xkb_led_index_t
  * @memberof xkb_state
  */
-int
+XKB_EXPORT int
 xkb_state_led_index_is_active(struct xkb_state *state, xkb_led_index_t idx);
 
 /** @} */

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -94,6 +94,8 @@ extern "C" {
 
 #if defined(__GNUC__) && !defined(__CYGWIN__)
 # define XKB_EXPORT      __attribute__((visibility("default")))
+#elif defined(_WIN32)
+# define XKB_EXPORT      __declspec(dllexport)
 #else
 # define XKB_EXPORT
 #endif

--- a/include/xkbcommon/xkbregistry.h
+++ b/include/xkbcommon/xkbregistry.h
@@ -40,6 +40,8 @@ extern "C" {
 
 #if defined(__GNUC__) && !defined(__CYGWIN__)
 # define RXKB_EXPORT      __attribute__((visibility("default")))
+#elif defined(_WIN32)
+# define RXKB_EXPORT      __declspec(dllexport)
 #else
 # define RXKB_EXPORT
 #endif

--- a/include/xkbcommon/xkbregistry.h
+++ b/include/xkbcommon/xkbregistry.h
@@ -38,6 +38,12 @@
 extern "C" {
 #endif
 
+#if defined(__GNUC__) && !defined(__CYGWIN__)
+# define RXKB_EXPORT      __attribute__((visibility("default")))
+#else
+# define RXKB_EXPORT
+#endif
+
 /**
  * @defgroup registry Query for available RMLVO
  *
@@ -184,7 +190,7 @@ enum rxkb_context_flags {
  * @param flags Flags affecting context behavior
  * @return A new xkb registry context or NULL on failure
  */
-struct rxkb_context *
+RXKB_EXPORT struct rxkb_context *
 rxkb_context_new(enum rxkb_context_flags flags);
 
 /** Specifies a logging level. */
@@ -207,14 +213,14 @@ enum rxkb_log_level {
  * RXKB_LOG_LEVEL, if set at the time the context was created, overrides the
  * default value.  It may be specified as a level number or name.
  */
-void
+RXKB_EXPORT void
 rxkb_context_set_log_level(struct rxkb_context *ctx,
                            enum rxkb_log_level level);
 
 /**
  * Get the current logging level.
  */
-enum rxkb_log_level
+RXKB_EXPORT enum rxkb_log_level
 rxkb_context_get_log_level(struct rxkb_context *ctx);
 
 /**
@@ -235,7 +241,7 @@ rxkb_context_get_log_level(struct rxkb_context *ctx);
  * rxkb_context_get_user_data() from within the logging function to provide
  * it with additional private context.
  */
-void
+RXKB_EXPORT void
 rxkb_context_set_log_fn(struct rxkb_context *ctx,
                         void (*log_fn)(struct rxkb_context *ctx,
                                        enum rxkb_log_level level,
@@ -262,14 +268,14 @@ rxkb_context_set_log_fn(struct rxkb_context *ctx,
  * @param ruleset The ruleset to parse, e.g. "evdev"
  * @return true on success or false on failure
  */
-bool
+RXKB_EXPORT bool
 rxkb_context_parse(struct rxkb_context *ctx, const char *ruleset);
 
 /**
  * Parse the default ruleset as configured at build time. See
  * rxkb_context_parse() for details.
  */
-bool
+RXKB_EXPORT bool
 rxkb_context_parse_default_ruleset(struct rxkb_context *ctx);
 
 /**
@@ -278,7 +284,7 @@ rxkb_context_parse_default_ruleset(struct rxkb_context *ctx);
  * @param ctx The xkb registry context
  * @return The passed in object
  */
-struct rxkb_context*
+RXKB_EXPORT struct rxkb_context*
 rxkb_context_ref(struct rxkb_context *ctx);
 
 /**
@@ -288,7 +294,7 @@ rxkb_context_ref(struct rxkb_context *ctx);
  * @param ctx The xkb registry context
  * @return always NULL
  */
-struct rxkb_context*
+RXKB_EXPORT struct rxkb_context*
 rxkb_context_unref(struct rxkb_context *ctx);
 
 /**
@@ -299,7 +305,7 @@ rxkb_context_unref(struct rxkb_context *ctx);
  * @param ctx The xkb registry context
  * @param user_data User-specific data pointer
  */
-void
+RXKB_EXPORT void
 rxkb_context_set_user_data(struct rxkb_context *ctx, void *user_data);
 
 /**
@@ -308,7 +314,7 @@ rxkb_context_set_user_data(struct rxkb_context *ctx, void *user_data);
  * @param ctx The xkb registry context
  * @return User-specific data pointer
  */
-void *
+RXKB_EXPORT void *
 rxkb_context_get_user_data(struct rxkb_context *ctx);
 
 /**
@@ -375,7 +381,7 @@ rxkb_context_get_user_data(struct rxkb_context *ctx);
  * @returns true on success, or false if the include path could not be added
  * or is inaccessible.
  */
-bool
+RXKB_EXPORT bool
 rxkb_context_include_path_append(struct rxkb_context *ctx, const char *path);
 
 /**
@@ -388,7 +394,7 @@ rxkb_context_include_path_append(struct rxkb_context *ctx, const char *path);
  * @returns true on success, or false if the include path could not be added
  * or is inaccessible.
  */
-bool
+RXKB_EXPORT bool
 rxkb_context_include_path_append_default(struct rxkb_context *ctx);
 
 /**
@@ -400,7 +406,7 @@ rxkb_context_include_path_append_default(struct rxkb_context *ctx);
  *
  * @return The first model in the model list.
  */
-struct rxkb_model *
+RXKB_EXPORT struct rxkb_model *
 rxkb_model_first(struct rxkb_context *ctx);
 
 /**
@@ -412,7 +418,7 @@ rxkb_model_first(struct rxkb_context *ctx);
  *
  * @return the next model or NULL at the end of the list
  */
-struct rxkb_model *
+RXKB_EXPORT struct rxkb_model *
 rxkb_model_next(struct rxkb_model *m);
 
 /**
@@ -420,7 +426,7 @@ rxkb_model_next(struct rxkb_model *m);
  *
  * @returns The argument passed in to this function.
  */
-struct rxkb_model *
+RXKB_EXPORT struct rxkb_model *
 rxkb_model_ref(struct rxkb_model *m);
 
 /**
@@ -429,33 +435,33 @@ rxkb_model_ref(struct rxkb_model *m);
  *
  * @returns always NULL
  */
-struct rxkb_model *
+RXKB_EXPORT struct rxkb_model *
 rxkb_model_unref(struct rxkb_model *m);
 
 /**
  * Return the name of this model. This is the value for M in RMLVO, to be used
  * with libxkbcommon.
  */
-const char *
+RXKB_EXPORT const char *
 rxkb_model_get_name(struct rxkb_model *m);
 
 /**
  * Return a human-readable description of this model. This function may return
  * NULL.
  */
-const char *
+RXKB_EXPORT const char *
 rxkb_model_get_description(struct rxkb_model *m);
 
 /**
  * Return the vendor name for this model. This function may return NULL.
  */
-const char *
+RXKB_EXPORT const char *
 rxkb_model_get_vendor(struct rxkb_model *m);
 
 /**
  * Return the popularity for this model.
  */
-enum rxkb_popularity
+RXKB_EXPORT enum rxkb_popularity
 rxkb_model_get_popularity(struct rxkb_model *m);
 
 /**
@@ -467,7 +473,7 @@ rxkb_model_get_popularity(struct rxkb_model *m);
  *
  * @return The first layout in the layout list.
  */
-struct rxkb_layout *
+RXKB_EXPORT struct rxkb_layout *
 rxkb_layout_first(struct rxkb_context *ctx);
 
 /**
@@ -479,7 +485,7 @@ rxkb_layout_first(struct rxkb_context *ctx);
  *
  * @return the next layout or NULL at the end of the list
  */
-struct rxkb_layout *
+RXKB_EXPORT struct rxkb_layout *
 rxkb_layout_next(struct rxkb_layout *l);
 
 /**
@@ -487,7 +493,7 @@ rxkb_layout_next(struct rxkb_layout *l);
  *
  * @returns The argument passed in to this function.
  */
-struct rxkb_layout *
+RXKB_EXPORT struct rxkb_layout *
 rxkb_layout_ref(struct rxkb_layout *l);
 
 /**
@@ -496,14 +502,14 @@ rxkb_layout_ref(struct rxkb_layout *l);
  *
  * @returns always NULL
  */
-struct rxkb_layout *
+RXKB_EXPORT struct rxkb_layout *
 rxkb_layout_unref(struct rxkb_layout *l);
 
 /**
  * Return the name of this layout. This is the value for L in RMLVO, to be used
  * with libxkbcommon.
  */
-const char *
+RXKB_EXPORT const char *
 rxkb_layout_get_name(struct rxkb_layout *l);
 
 /**
@@ -516,27 +522,27 @@ rxkb_layout_get_name(struct rxkb_layout *l);
  *
  * Where the variant is NULL, the layout is the base layout (e.g. "us").
  */
-const char *
+RXKB_EXPORT const char *
 rxkb_layout_get_variant(struct rxkb_layout *l);
 
 /**
  * Return a short (one-word) description of this layout. This function may
  * return NULL.
  */
-const char *
+RXKB_EXPORT const char *
 rxkb_layout_get_brief(struct rxkb_layout *l);
 
 /**
  * Return a human-readable description of this layout. This function may return
  * NULL.
  */
-const char *
+RXKB_EXPORT const char *
 rxkb_layout_get_description(struct rxkb_layout *l);
 
 /**
  * Return the popularity for this layout.
  */
-enum rxkb_popularity
+RXKB_EXPORT enum rxkb_popularity
 rxkb_layout_get_popularity(struct rxkb_layout *l);
 
 /**
@@ -550,7 +556,7 @@ rxkb_layout_get_popularity(struct rxkb_layout *l);
  *
  * @return The first option group in the option group list.
  */
-struct rxkb_option_group *
+RXKB_EXPORT struct rxkb_option_group *
 rxkb_option_group_first(struct rxkb_context *ctx);
 
 /**
@@ -563,7 +569,7 @@ rxkb_option_group_first(struct rxkb_context *ctx);
  *
  * @return the next option group or NULL at the end of the list
  */
-struct rxkb_option_group *
+RXKB_EXPORT struct rxkb_option_group *
 rxkb_option_group_next(struct rxkb_option_group *g);
 
 /**
@@ -571,7 +577,7 @@ rxkb_option_group_next(struct rxkb_option_group *g);
  *
  * @returns The argument passed in to this function.
  */
-struct rxkb_option_group *
+RXKB_EXPORT struct rxkb_option_group *
 rxkb_option_group_ref(struct rxkb_option_group *g);
 
 /**
@@ -580,7 +586,7 @@ rxkb_option_group_ref(struct rxkb_option_group *g);
  *
  * @returns always NULL
  */
-struct rxkb_option_group *
+RXKB_EXPORT struct rxkb_option_group *
 rxkb_option_group_unref(struct rxkb_option_group *g);
 
 /**
@@ -588,14 +594,14 @@ rxkb_option_group_unref(struct rxkb_option_group *g);
  * RMLVO, the name can be used for internal sorting in the caller. This function
  * may return NULL.
  */
-const char *
+RXKB_EXPORT const char *
 rxkb_option_group_get_name(struct rxkb_option_group *m);
 
 /**
  * Return a human-readable description of this option group. This function may
  * return NULL.
  */
-const char *
+RXKB_EXPORT const char *
 rxkb_option_group_get_description(struct rxkb_option_group *m);
 
 /**
@@ -603,13 +609,13 @@ rxkb_option_group_get_description(struct rxkb_option_group *m);
  *              simultaneously, false if all options within this option group
  *              are mutually exclusive.
  */
-bool
+RXKB_EXPORT bool
 rxkb_option_group_allows_multiple(struct rxkb_option_group *g);
 
 /**
  * Return the popularity for this option group.
  */
-enum rxkb_popularity
+RXKB_EXPORT enum rxkb_popularity
 rxkb_option_group_get_popularity(struct rxkb_option_group *g);
 
 /**
@@ -622,7 +628,7 @@ rxkb_option_group_get_popularity(struct rxkb_option_group *g);
  *
  * @return The first option in the option list.
  */
-struct rxkb_option *
+RXKB_EXPORT struct rxkb_option *
 rxkb_option_first(struct rxkb_option_group *group);
 
 /**
@@ -634,7 +640,7 @@ rxkb_option_first(struct rxkb_option_group *group);
  *
  * @returns The next option or NULL at the end of the list
  */
-struct rxkb_option *
+RXKB_EXPORT struct rxkb_option *
 rxkb_option_next(struct rxkb_option *o);
 
 /**
@@ -642,7 +648,7 @@ rxkb_option_next(struct rxkb_option *o);
  *
  * @returns The argument passed in to this function.
  */
-struct rxkb_option *
+RXKB_EXPORT struct rxkb_option *
 rxkb_option_ref(struct rxkb_option *o);
 
 /**
@@ -651,34 +657,34 @@ rxkb_option_ref(struct rxkb_option *o);
  *
  * @returns always NULL
  */
-struct rxkb_option *
+RXKB_EXPORT struct rxkb_option *
 rxkb_option_unref(struct rxkb_option *o);
 
 /**
  * Return the name of this option. This is the value for O in RMLVO, to be used
  * with libxkbcommon.
  */
-const char *
+RXKB_EXPORT const char *
 rxkb_option_get_name(struct rxkb_option *o);
 
 /**
  * Return a short (one-word) description of this option. This function may
  * return NULL.
  */
-const char *
+RXKB_EXPORT const char *
 rxkb_option_get_brief(struct rxkb_option *o);
 
 /**
  * Return a human-readable description of this option. This function may return
  * NULL.
  */
-const char *
+RXKB_EXPORT const char *
 rxkb_option_get_description(struct rxkb_option *o);
 
 /**
  * Return the popularity for this option.
  */
-enum rxkb_popularity
+RXKB_EXPORT enum rxkb_popularity
 rxkb_option_get_popularity(struct rxkb_option *o);
 
 /**
@@ -686,7 +692,7 @@ rxkb_option_get_popularity(struct rxkb_option *o);
  *
  * @returns The argument passed in to this function.
  */
-struct rxkb_iso639_code *
+RXKB_EXPORT struct rxkb_iso639_code *
 rxkb_iso639_code_ref(struct rxkb_iso639_code *iso639);
 
 /**
@@ -695,13 +701,13 @@ rxkb_iso639_code_ref(struct rxkb_iso639_code *iso639);
  *
  * @returns always NULL
  */
-struct rxkb_iso639_code *
+RXKB_EXPORT struct rxkb_iso639_code *
 rxkb_iso639_code_unref(struct rxkb_iso639_code *iso639);
 
 /**
  * Return the ISO 639-3 code for this code (e.g. "eng", "fra").
  */
-const char *
+RXKB_EXPORT const char *
 rxkb_iso639_code_get_code(struct rxkb_iso639_code *iso639);
 
 /**
@@ -714,7 +720,7 @@ rxkb_iso639_code_get_code(struct rxkb_iso639_code *iso639);
  *
  * @return The first code in the code list.
  */
-struct rxkb_iso639_code *
+RXKB_EXPORT struct rxkb_iso639_code *
 rxkb_layout_get_iso639_first(struct rxkb_layout *layout);
 
 /**
@@ -727,7 +733,7 @@ rxkb_layout_get_iso639_first(struct rxkb_layout *layout);
  *
  * @returns The next code or NULL at the end of the list
  */
-struct rxkb_iso639_code *
+RXKB_EXPORT struct rxkb_iso639_code *
 rxkb_iso639_code_next(struct rxkb_iso639_code *iso639);
 
 /**
@@ -735,7 +741,7 @@ rxkb_iso639_code_next(struct rxkb_iso639_code *iso639);
  *
  * @returns The argument passed in to this function.
  */
-struct rxkb_iso3166_code *
+RXKB_EXPORT struct rxkb_iso3166_code *
 rxkb_iso3166_code_ref(struct rxkb_iso3166_code *iso3166);
 
 /**
@@ -744,13 +750,13 @@ rxkb_iso3166_code_ref(struct rxkb_iso3166_code *iso3166);
  *
  * @returns always NULL
  */
-struct rxkb_iso3166_code *
+RXKB_EXPORT struct rxkb_iso3166_code *
 rxkb_iso3166_code_unref(struct rxkb_iso3166_code *iso3166);
 
 /**
  * Return the ISO 3166 Alpha 2 code for this code (e.g. "US", "FR").
  */
-const char *
+RXKB_EXPORT const char *
 rxkb_iso3166_code_get_code(struct rxkb_iso3166_code *iso3166);
 
 /**
@@ -764,7 +770,7 @@ rxkb_iso3166_code_get_code(struct rxkb_iso3166_code *iso3166);
  *
  * @return The first code in the code list.
  */
-struct rxkb_iso3166_code *
+RXKB_EXPORT struct rxkb_iso3166_code *
 rxkb_layout_get_iso3166_first(struct rxkb_layout *layout);
 
 /**
@@ -777,7 +783,7 @@ rxkb_layout_get_iso3166_first(struct rxkb_layout *layout);
  *
  * @returns The next code or NULL at the end of the list
  */
-struct rxkb_iso3166_code *
+RXKB_EXPORT struct rxkb_iso3166_code *
 rxkb_iso3166_code_next(struct rxkb_iso3166_code *iso3166);
 
 /** @} */

--- a/meson.build
+++ b/meson.build
@@ -448,18 +448,12 @@ icu_dep = dependency('icu-uc', required: false)
 build_tools = get_option('enable-tools') and cc.has_header_symbol('getopt.h', 'getopt_long', prefix: '#define _GNU_SOURCE')
 if build_tools
     # Common resources
-    libxkbcommon_tools_internal_sources = [
-        'tools/tools-common.h',
-        'tools/tools-common.c',
-    ]
-    libxkbcommon_tools_internal = static_library(
-        'tools-internal',
-        libxkbcommon_tools_internal_sources,
-        dependencies: dep_libxkbcommon,
-    )
     tools_dep = declare_dependency(
+        sources: [
+            'tools/tools-common.h',
+            'tools/tools-common.c',
+        ],
         include_directories: [include_directories('tools', 'include')],
-        link_with: libxkbcommon_tools_internal,
         dependencies: dep_libxkbcommon,
     )
     configh_data.set10('HAVE_TOOLS', true)
@@ -549,8 +543,6 @@ if build_tools
         # The same tool again, but with access to some private APIs.
         executable('interactive-evdev',
                 'tools/interactive-evdev.c',
-                libxkbcommon_sources,
-                libxkbcommon_tools_internal_sources,
                 dependencies: [tools_dep],
                 c_args: ['-DENABLE_PRIVATE_APIS'],
                 include_directories: [include_directories('src', 'include')],
@@ -683,30 +675,34 @@ configure_file(output: 'test-config.h', configuration: test_configh_data)
 m_dep = cc.find_library('m', required : false)
 # Some tests need to use unexported symbols, so we link them against
 # an internal copy of libxkbcommon with all symbols exposed.
-libxkbcommon_test_internal = static_library(
+libxkbcommon_test_internal = library(
     'xkbcommon-test-internal',
-    'test/common.c',
-    'test/test.h',
-    'test/evdev-scancodes.h',
-    'bench/bench.c',
-    'bench/bench.h',
     libxkbcommon_sources,
     include_directories: include_directories('src', 'include'),
     c_args: ['-DENABLE_PRIVATE_APIS'],
-    dependencies: [m_dep],
+    gnu_symbol_visibility: 'hidden',
 )
 test_dep = declare_dependency(
+    sources: [
+        'bench/bench.c',
+        'bench/bench.h',
+        'test/common.c',
+        'test/evdev-scancodes.h',
+        'test/test.h',
+        'tools/tools-common.c',
+        'tools/tools-common.h',
+    ],
     include_directories: include_directories('src', 'include'),
     link_with: libxkbcommon_test_internal,
-    dependencies: [tools_dep],
+    dependencies: [m_dep],
 )
 if get_option('enable-x11')
-    libxkbcommon_x11_test_internal = static_library(
+    libxkbcommon_x11_test_internal = library(
         'xkbcommon-x11-internal',
         libxkbcommon_x11_sources,
-        'test/xvfb-wrapper.c',
-        'test/xvfb-wrapper.h',
         include_directories: include_directories('src', 'include'),
+        c_args: ['-DENABLE_PRIVATE_APIS'],
+        gnu_symbol_visibility: 'hidden',
         link_with: libxkbcommon_test_internal,
         dependencies: [
             xcb_dep,
@@ -718,8 +714,14 @@ if get_option('enable-x11')
         dependencies: [
             test_dep,
             xcb_dep,
-            xcb_xkb_dep,
         ],
+    )
+    x11_xvfb_test_dep = declare_dependency(
+        sources: [
+            'test/xvfb-wrapper.c',
+            'test/xvfb-wrapper.h',
+        ],
+        dependencies: [x11_test_dep],
     )
 endif
 # TODO: version range?
@@ -885,13 +887,13 @@ if get_option('enable-x11')
     endif
     test(
         'x11',
-        executable('test-x11', 'test/x11.c', dependencies: x11_test_dep),
+        executable('test-x11', 'test/x11.c', dependencies: x11_xvfb_test_dep),
         env: test_env,
         is_parallel : false,
     )
     test(
         'x11comp',
-        executable('test-x11comp', 'test/x11comp.c', dependencies: x11_test_dep),
+        executable('test-x11comp', 'test/x11comp.c', dependencies: x11_xvfb_test_dep),
         env: test_env,
         is_parallel : false,
     )

--- a/meson.build
+++ b/meson.build
@@ -47,7 +47,6 @@ cflags = [
     '-Wwrite-strings',
     '-Wno-documentation-deprecated-sync',
     '-Wno-pedantic',
-    '-Wno-gnu-alignof-expression',
 ]
 add_project_arguments(cc.get_supported_arguments(cflags), language: 'c')
 

--- a/meson.build
+++ b/meson.build
@@ -232,6 +232,8 @@ libxkbcommon_sources = [
     'src/xkbcomp/xkbcomp-priv.h',
     'src/atom.c',
     'src/atom.h',
+    'src/bump.c',
+    'src/bump.h',
     'src/context.c',
     'src/context.h',
     'src/context-priv.c',

--- a/meson.build
+++ b/meson.build
@@ -47,6 +47,7 @@ cflags = [
     '-Wwrite-strings',
     '-Wno-documentation-deprecated-sync',
     '-Wno-pedantic',
+    '-Wno-gnu-alignof-expression',
 ]
 add_project_arguments(cc.get_supported_arguments(cflags), language: 'c')
 

--- a/meson.build
+++ b/meson.build
@@ -266,7 +266,7 @@ elif cc.get_argument_syntax() == 'msvc'
     libxkbcommon_def = custom_target('xkbcommon.def',
         command: [map_to_def, '@INPUT@', '@OUTPUT@'],
         input: 'xkbcommon.map',
-        output: 'kxbcommon.def',
+        output: 'xkbcommon.def',
     )
     libxkbcommon_link_deps += libxkbcommon_def
     libxkbcommon_link_args += '/DEF:' + libxkbcommon_def.full_path()

--- a/scripts/update-unicode.py
+++ b/scripts/update-unicode.py
@@ -1746,7 +1746,7 @@ struct CaseMappings{{
 
 {unicode_mappings}
 
-XKB_EXPORT xkb_keysym_t
+xkb_keysym_t
 xkb_keysym_to_lower(xkb_keysym_t ks)
 {{
     if (ks <= 0x{max_non_unicode:0>4x}) {{
@@ -1765,7 +1765,7 @@ xkb_keysym_to_lower(xkb_keysym_t ks)
     }}
 }}
 
-XKB_EXPORT xkb_keysym_t
+xkb_keysym_t
 xkb_keysym_to_upper(xkb_keysym_t ks)
 {{
     if (ks <= 0x{max_non_unicode:0>4x}) {{

--- a/src/atom.h
+++ b/src/atom.h
@@ -28,22 +28,24 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "utils.h"
+
 typedef uint32_t xkb_atom_t;
 
 #define XKB_ATOM_NONE 0
 
 struct atom_table;
 
-struct atom_table *
+XKB_EXPORT_PRIVATE struct atom_table *
 atom_table_new(void);
 
-void
+XKB_EXPORT_PRIVATE void
 atom_table_free(struct atom_table *table);
 
-xkb_atom_t
+XKB_EXPORT_PRIVATE xkb_atom_t
 atom_intern(struct atom_table *table, const char *string, size_t len, bool add);
 
-const char *
+XKB_EXPORT_PRIVATE const char *
 atom_text(struct atom_table *table, xkb_atom_t atom);
 
 #endif /* ATOM_H */

--- a/src/bump.c
+++ b/src/bump.c
@@ -2,14 +2,15 @@
 
 #include <assert.h>
 #include <stdalign.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "bump.h"
 
- // Size of initial chunk.
+/* Size of initial chunk. */
 #define INITIAL_CHUNK_SIZE 4096
-// Factor by which to grow chunk sizes.
+/* Factor by which to grow chunk sizes. */
 #define GROWTH_FACTOR 2
 
 static struct bump_chunk dummy_chunk = {
@@ -26,18 +27,18 @@ bump_init(struct bump *bump)
 }
 
 void *
-bump_alloc(struct bump *bump, size_t size)
+bump_aligned_alloc(struct bump *bump, size_t alignment, size_t size)
 {
     assert(size <= INITIAL_CHUNK_SIZE);
 
     /* Align size to the max alignemnt. */
     const size_t max_alignment = alignof(max_align_t);
-    size = (size + max_alignment - 1) & ~(max_alignment - 1);
 
     struct bump_chunk *chunk = bump->current;
+    char *ptr = (char *) (((uintptr_t) chunk->ptr + alignment - 1) & ~(alignment - 1));
 
     /* Check if there is enough space in the current chunk. */
-    if ((size_t) (chunk->ptr - chunk->memory) + size > chunk->size) {
+    if ((size_t) (ptr - chunk->memory) + size > chunk->size) {
         /* Not enough space, create a new chunk. */
         size_t new_chunk_size = chunk->size == 0 ? INITIAL_CHUNK_SIZE : chunk->size * GROWTH_FACTOR;
         struct bump_chunk *new_chunk = aligned_alloc(max_alignment, sizeof(*new_chunk) + new_chunk_size);
@@ -50,10 +51,10 @@ bump_alloc(struct bump *bump, size_t size)
 
         bump->current = new_chunk;
         chunk = new_chunk;
+        ptr = chunk->memory;
     }
 
-    void *ptr = chunk->ptr;
-    chunk->ptr += size;
+    chunk->ptr = ptr + size;
     return ptr;
 }
 
@@ -61,7 +62,7 @@ char *
 bump_strdup(struct bump *bump, const char *s)
 {
     size_t len = strlen(s) + 1;
-    char *new = bump_alloc(bump, len);
+    char *new = bump_aligned_alloc(bump, 1, len);
     if (!new) {
         return NULL;
     }

--- a/src/bump.c
+++ b/src/bump.c
@@ -39,7 +39,7 @@ align_up(char *ptr, size_t alignment)
     return ptr + (aligned_addr - addr);
 }
 
-ATTR_NOINLINE static void *
+ATTR_NOINLINE ATTR_MALLOC ATTR_ALLOC_ALIGN(2) static void *
 bump_aligned_alloc_slow(struct bump *bump, size_t alignment, size_t size)
 {
     struct bump_chunk *prev_chunk = bump->current;
@@ -65,7 +65,7 @@ bump_aligned_alloc_slow(struct bump *bump, size_t alignment, size_t size)
     return ptr;
 }
 
-void *
+ATTR_MALLOC ATTR_ALLOC_ALIGN(2) void *
 bump_aligned_alloc(struct bump *bump, size_t alignment, size_t size)
 {
     struct bump_chunk *chunk = bump->current;

--- a/src/bump.c
+++ b/src/bump.c
@@ -15,8 +15,8 @@ const size_t INITIAL_CHUNK_SIZE = 4096;
 const size_t GROWTH_FACTOR = 2;
 
 static struct bump_chunk dummy_chunk = {
-    .end = 0,
-    .ptr = 0,
+    .end = dummy_chunk.memory,
+    .ptr = dummy_chunk.memory,
     .prev = NULL,
 };
 

--- a/src/bump.c
+++ b/src/bump.c
@@ -1,0 +1,81 @@
+#include "config.h"
+
+#include <assert.h>
+#include <stdalign.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "bump.h"
+
+ // Size of initial chunk.
+#define INITIAL_CHUNK_SIZE 4096
+// Factor by which to grow chunk sizes.
+#define GROWTH_FACTOR 2
+
+static struct bump_chunk dummy_chunk = {
+    .size = 0,
+    .ptr = 0,
+    .prev = NULL,
+};
+
+void
+bump_init(struct bump *bump)
+{
+    // Create the first chunk
+    bump->current = &dummy_chunk;
+}
+
+void *
+bump_alloc(struct bump *bump, size_t size)
+{
+    assert(size <= INITIAL_CHUNK_SIZE);
+
+    /* Align size to the max alignemnt. */
+    const size_t max_alignment = alignof(max_align_t);
+    size = (size + max_alignment - 1) & ~(max_alignment - 1);
+
+    struct bump_chunk *chunk = bump->current;
+
+    /* Check if there is enough space in the current chunk. */
+    if ((size_t) (chunk->ptr - chunk->memory) + size > chunk->size) {
+        /* Not enough space, create a new chunk. */
+        size_t new_chunk_size = chunk->size == 0 ? INITIAL_CHUNK_SIZE : chunk->size * GROWTH_FACTOR;
+        struct bump_chunk *new_chunk = aligned_alloc(max_alignment, sizeof(*new_chunk) + new_chunk_size);
+        if (!new_chunk) {
+            return NULL;
+        }
+        new_chunk->size = new_chunk_size;
+        new_chunk->ptr = new_chunk->memory;
+        new_chunk->prev = chunk;
+
+        bump->current = new_chunk;
+        chunk = new_chunk;
+    }
+
+    void *ptr = chunk->ptr;
+    chunk->ptr += size;
+    return ptr;
+}
+
+char *
+bump_strdup(struct bump *bump, const char *s)
+{
+    size_t len = strlen(s) + 1;
+    char *new = bump_alloc(bump, len);
+    if (!new) {
+        return NULL;
+    }
+    memcpy(new, s, len);
+    return new;
+}
+
+void
+bump_uninit(struct bump *bump)
+{
+    struct bump_chunk *chunk = bump->current;
+    while (chunk != &dummy_chunk) {
+        struct bump_chunk *prev = chunk->prev;
+        free(chunk);
+        chunk = prev;
+    }
+}

--- a/src/bump.h
+++ b/src/bump.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdalign.h>
+
+struct bump_chunk {
+    // Size of the chunk.
+    size_t size;
+    // Next free address in memory.
+    char *ptr;
+    // Pointer to the previous chunk.
+    struct bump_chunk *prev;
+    // Pointer to the allocated memory.
+    alignas(max_align_t) char memory[0];
+};
+
+struct bump {
+    struct bump_chunk *current;
+};
+
+void
+bump_init(struct bump *bump);
+void
+bump_uninit(struct bump *bump);
+void
+*bump_alloc(struct bump *bump, size_t size);
+char *
+bump_strdup(struct bump *bump, const char *s);

--- a/src/bump.h
+++ b/src/bump.h
@@ -6,13 +6,13 @@
 #include <stddef.h>
 
 struct bump_chunk {
-    // One past the end of memory.
+    /* One past the end of memory. */
     char *end;
-    // Next free address in memory.
+    /* Next free address in memory. */
     char *ptr;
-    // Pointer to the previous chunk.
+    /* Pointer to the previous chunk. */
     struct bump_chunk *prev;
-    // Pointer to the allocated memory.
+    /* Pointer to the allocated memory. */
     char memory[0];
 };
 
@@ -29,4 +29,4 @@ bump_aligned_alloc(struct bump *bump, size_t alignment, size_t size);
 char *
 bump_strdup(struct bump *bump, const char *s);
 
-#define bump_alloc(bump, of) bump_aligned_alloc((bump), alignof(of), sizeof(of))
+#define bump_alloc(bump, of) bump_aligned_alloc((bump), alignof(__typeof__(of)), sizeof(of))

--- a/src/bump.h
+++ b/src/bump.h
@@ -1,17 +1,19 @@
 #pragma once
 
-#include <stddef.h>
+#include "config.h"
+
 #include <stdalign.h>
+#include <stddef.h>
 
 struct bump_chunk {
-    // Size of the chunk.
-    size_t size;
+    // One past the end of memory.
+    char *end;
     // Next free address in memory.
     char *ptr;
     // Pointer to the previous chunk.
     struct bump_chunk *prev;
     // Pointer to the allocated memory.
-    alignas(max_align_t) char memory[0];
+    char memory[0];
 };
 
 struct bump {

--- a/src/bump.h
+++ b/src/bump.h
@@ -22,7 +22,9 @@ void
 bump_init(struct bump *bump);
 void
 bump_uninit(struct bump *bump);
-void
-*bump_alloc(struct bump *bump, size_t size);
+void *
+bump_aligned_alloc(struct bump *bump, size_t alignment, size_t size);
 char *
 bump_strdup(struct bump *bump, const char *s);
+
+#define bump_alloc(bump, of) bump_aligned_alloc((bump), alignof(of), sizeof(of))

--- a/src/compose/dump.c
+++ b/src/compose/dump.c
@@ -34,7 +34,6 @@
 #include "escape.h"
 #include "dump.h"
 #include "src/keysym.h"
-#include "src/utils.h"
 
 bool
 print_compose_table_entry(FILE *file, struct xkb_compose_table_entry *entry)

--- a/src/compose/parser.c
+++ b/src/compose/parser.c
@@ -504,7 +504,7 @@ parse_string_literal(struct xkb_context *ctx, const char *string)
 {
     struct scanner s;
     union lvalue val;
-    scanner_init(&s, ctx, NULL, string, strlen(string), "(unamed)", NULL);
+    scanner_init(&s, ctx, string, strlen(string), "(unamed)", NULL);
     switch (lex(&s, &val)) {
         case TOK_STRING:
             return strdup(val.string.str);
@@ -551,7 +551,7 @@ do_include(struct xkb_compose_table *table, struct scanner *s,
         goto err_file;
     }
 
-    scanner_init(&new_s, table->ctx, NULL, string, size, path, s->priv);
+    scanner_init(&new_s, table->ctx, string, size, path, s->priv);
 
     ok = parse(table, &new_s, include_depth + 1);
     if (!ok)
@@ -804,7 +804,7 @@ parse_string(struct xkb_compose_table *table, const char *string, size_t len,
              const char *file_name)
 {
     struct scanner s;
-    scanner_init(&s, table->ctx, NULL, string, len, file_name, NULL);
+    scanner_init(&s, table->ctx, string, len, file_name, NULL);
     if (!parse(table, &s, 0))
         return false;
     /* Maybe the allocator can use the excess space. */

--- a/src/compose/parser.c
+++ b/src/compose/parser.c
@@ -504,7 +504,7 @@ parse_string_literal(struct xkb_context *ctx, const char *string)
 {
     struct scanner s;
     union lvalue val;
-    scanner_init(&s, ctx, string, strlen(string), "(unamed)", NULL);
+    scanner_init(&s, ctx, NULL, string, strlen(string), "(unamed)", NULL);
     switch (lex(&s, &val)) {
         case TOK_STRING:
             return strdup(val.string.str);
@@ -551,7 +551,7 @@ do_include(struct xkb_compose_table *table, struct scanner *s,
         goto err_file;
     }
 
-    scanner_init(&new_s, table->ctx, string, size, path, s->priv);
+    scanner_init(&new_s, table->ctx, NULL, string, size, path, s->priv);
 
     ok = parse(table, &new_s, include_depth + 1);
     if (!ok)
@@ -804,7 +804,7 @@ parse_string(struct xkb_compose_table *table, const char *string, size_t len,
              const char *file_name)
 {
     struct scanner s;
-    scanner_init(&s, table->ctx, string, len, file_name, NULL);
+    scanner_init(&s, table->ctx, NULL, string, len, file_name, NULL);
     if (!parse(table, &s, 0))
         return false;
     /* Maybe the allocator can use the excess space. */

--- a/src/compose/parser.h
+++ b/src/compose/parser.h
@@ -31,12 +31,14 @@
 #include "xkbcommon/xkbcommon.h"
 #include "xkbcommon/xkbcommon-compose.h"
 
+#include "src/utils.h"
+
 #define MAX_LHS_LEN 10
 #define MAX_INCLUDE_DEPTH 5
 /** Maximum size of the string returned by xkb_compose_state_get_utf8() */
 #define XKB_COMPOSE_MAX_STRING_SIZE 256
 
-char *
+XKB_EXPORT_PRIVATE char *
 parse_string_literal(struct xkb_context *ctx, const char *string);
 
 bool

--- a/src/compose/state.c
+++ b/src/compose/state.c
@@ -45,7 +45,7 @@ struct xkb_compose_state {
     uint32_t context;
 };
 
-XKB_EXPORT struct xkb_compose_state *
+struct xkb_compose_state *
 xkb_compose_state_new(struct xkb_compose_table *table,
                       enum xkb_compose_state_flags flags)
 {
@@ -65,14 +65,14 @@ xkb_compose_state_new(struct xkb_compose_table *table,
     return state;
 }
 
-XKB_EXPORT struct xkb_compose_state *
+struct xkb_compose_state *
 xkb_compose_state_ref(struct xkb_compose_state *state)
 {
     state->refcnt++;
     return state;
 }
 
-XKB_EXPORT void
+void
 xkb_compose_state_unref(struct xkb_compose_state *state)
 {
     if (!state || --state->refcnt > 0)
@@ -82,13 +82,13 @@ xkb_compose_state_unref(struct xkb_compose_state *state)
     free(state);
 }
 
-XKB_EXPORT struct xkb_compose_table *
+struct xkb_compose_table *
 xkb_compose_state_get_compose_table(struct xkb_compose_state *state)
 {
     return state->table;
 }
 
-XKB_EXPORT enum xkb_compose_feed_result
+enum xkb_compose_feed_result
 xkb_compose_state_feed(struct xkb_compose_state *state, xkb_keysym_t keysym)
 {
     uint32_t context;
@@ -128,14 +128,14 @@ xkb_compose_state_feed(struct xkb_compose_state *state, xkb_keysym_t keysym)
     return XKB_COMPOSE_FEED_ACCEPTED;
 }
 
-XKB_EXPORT void
+void
 xkb_compose_state_reset(struct xkb_compose_state *state)
 {
     state->prev_context = 0;
     state->context = 0;
 }
 
-XKB_EXPORT enum xkb_compose_status
+enum xkb_compose_status
 xkb_compose_state_get_status(struct xkb_compose_state *state)
 {
     const struct compose_node *prev_node, *node;
@@ -155,7 +155,7 @@ xkb_compose_state_get_status(struct xkb_compose_state *state)
     return XKB_COMPOSE_COMPOSED;
 }
 
-XKB_EXPORT int
+int
 xkb_compose_state_get_utf8(struct xkb_compose_state *state,
                            char *buffer, size_t size)
 {
@@ -190,7 +190,7 @@ fail:
     return 0;
 }
 
-XKB_EXPORT xkb_keysym_t
+xkb_keysym_t
 xkb_compose_state_get_one_sym(struct xkb_compose_state *state)
 {
     const struct compose_node *node =

--- a/src/compose/table.c
+++ b/src/compose/table.c
@@ -70,14 +70,14 @@ xkb_compose_table_new(struct xkb_context *ctx,
     return table;
 }
 
-XKB_EXPORT struct xkb_compose_table *
+struct xkb_compose_table *
 xkb_compose_table_ref(struct xkb_compose_table *table)
 {
     table->refcnt++;
     return table;
 }
 
-XKB_EXPORT void
+void
 xkb_compose_table_unref(struct xkb_compose_table *table)
 {
     if (!table || --table->refcnt > 0)
@@ -89,7 +89,7 @@ xkb_compose_table_unref(struct xkb_compose_table *table)
     free(table);
 }
 
-XKB_EXPORT struct xkb_compose_table *
+struct xkb_compose_table *
 xkb_compose_table_new_from_file(struct xkb_context *ctx,
                                 FILE *file,
                                 const char *locale,
@@ -124,7 +124,7 @@ xkb_compose_table_new_from_file(struct xkb_context *ctx,
     return table;
 }
 
-XKB_EXPORT struct xkb_compose_table *
+struct xkb_compose_table *
 xkb_compose_table_new_from_buffer(struct xkb_context *ctx,
                                   const char *buffer, size_t length,
                                   const char *locale,
@@ -159,7 +159,7 @@ xkb_compose_table_new_from_buffer(struct xkb_context *ctx,
     return table;
 }
 
-XKB_EXPORT struct xkb_compose_table *
+struct xkb_compose_table *
 xkb_compose_table_new_from_locale(struct xkb_context *ctx,
                                   const char *locale,
                                   enum xkb_compose_compile_flags flags)
@@ -227,7 +227,7 @@ found_path:
     return table;
 }
 
-XKB_EXPORT const xkb_keysym_t *
+const xkb_keysym_t *
 xkb_compose_table_entry_sequence(struct xkb_compose_table_entry *entry,
                                  size_t *sequence_length)
 {
@@ -235,13 +235,13 @@ xkb_compose_table_entry_sequence(struct xkb_compose_table_entry *entry,
     return entry->sequence;
 }
 
-XKB_EXPORT xkb_keysym_t
+xkb_keysym_t
 xkb_compose_table_entry_keysym(struct xkb_compose_table_entry *entry)
 {
     return entry->keysym;
 }
 
-XKB_EXPORT const char *
+const char *
 xkb_compose_table_entry_utf8(struct xkb_compose_table_entry *entry)
 {
     return entry->utf8;
@@ -264,7 +264,7 @@ struct xkb_compose_table_iterator {
     darray(struct xkb_compose_table_iterator_pending_node) pending_nodes;
 };
 
-XKB_EXPORT struct xkb_compose_table_iterator *
+struct xkb_compose_table_iterator *
 xkb_compose_table_iterator_new(struct xkb_compose_table *table)
 {
     struct xkb_compose_table_iterator *iter;
@@ -307,7 +307,7 @@ xkb_compose_table_iterator_new(struct xkb_compose_table *table)
     return iter;
 }
 
-XKB_EXPORT void
+void
 xkb_compose_table_iterator_free(struct xkb_compose_table_iterator *iter)
 {
     xkb_compose_table_unref(iter->table);
@@ -316,7 +316,7 @@ xkb_compose_table_iterator_free(struct xkb_compose_table_iterator *iter)
     free(iter);
 }
 
-XKB_EXPORT struct xkb_compose_table_entry *
+struct xkb_compose_table_entry *
 xkb_compose_table_iterator_next(struct xkb_compose_table_iterator *iter)
 {
     /* Traversal algorithm (simplified):

--- a/src/context.c
+++ b/src/context.c
@@ -38,7 +38,7 @@
 /**
  * Append one directory to the context's include path.
  */
-XKB_EXPORT int
+int
 xkb_context_include_path_append(struct xkb_context *ctx, const char *path)
 {
     struct stat stat_buf;
@@ -93,7 +93,7 @@ xkb_context_include_path_get_system_path(struct xkb_context *ctx)
 /**
  * Append the default include directories to the context.
  */
-XKB_EXPORT int
+int
 xkb_context_include_path_append_default(struct xkb_context *ctx)
 {
     const char *home, *xdg, *root, *extra;
@@ -137,7 +137,7 @@ xkb_context_include_path_append_default(struct xkb_context *ctx)
 /**
  * Remove all entries in the context's include path.
  */
-XKB_EXPORT void
+void
 xkb_context_include_path_clear(struct xkb_context *ctx)
 {
     char **path;
@@ -154,7 +154,7 @@ xkb_context_include_path_clear(struct xkb_context *ctx)
 /**
  * xkb_context_include_path_clear() + xkb_context_include_path_append_default()
  */
-XKB_EXPORT int
+int
 xkb_context_include_path_reset_defaults(struct xkb_context *ctx)
 {
     xkb_context_include_path_clear(ctx);
@@ -164,7 +164,7 @@ xkb_context_include_path_reset_defaults(struct xkb_context *ctx)
 /**
  * Returns the number of entries in the context's include path.
  */
-XKB_EXPORT unsigned int
+unsigned int
 xkb_context_num_include_paths(struct xkb_context *ctx)
 {
     return darray_size(ctx->includes);
@@ -174,7 +174,7 @@ xkb_context_num_include_paths(struct xkb_context *ctx)
  * Returns the given entry in the context's include path, or NULL if an
  * invalid index is passed.
  */
-XKB_EXPORT const char *
+const char *
 xkb_context_include_path_get(struct xkb_context *ctx, unsigned int idx)
 {
     if (idx >= xkb_context_num_include_paths(ctx))
@@ -186,7 +186,7 @@ xkb_context_include_path_get(struct xkb_context *ctx, unsigned int idx)
 /**
  * Take a new reference on the context.
  */
-XKB_EXPORT struct xkb_context *
+struct xkb_context *
 xkb_context_ref(struct xkb_context *ctx)
 {
     ctx->refcnt++;
@@ -197,7 +197,7 @@ xkb_context_ref(struct xkb_context *ctx)
  * Drop an existing reference on the context, and free it if the refcnt is
  * now 0.
  */
-XKB_EXPORT void
+void
 xkb_context_unref(struct xkb_context *ctx)
 {
     if (!ctx || --ctx->refcnt > 0)
@@ -278,7 +278,7 @@ log_verbosity(const char *verbosity) {
 /**
  * Create a new context.
  */
-XKB_EXPORT struct xkb_context *
+struct xkb_context *
 xkb_context_new(enum xkb_context_flags flags)
 {
     const char *env;
@@ -323,7 +323,7 @@ xkb_context_new(enum xkb_context_flags flags)
     return ctx;
 }
 
-XKB_EXPORT void
+void
 xkb_context_set_log_fn(struct xkb_context *ctx,
                        void (*log_fn)(struct xkb_context *ctx,
                                       enum xkb_log_level level,
@@ -332,31 +332,31 @@ xkb_context_set_log_fn(struct xkb_context *ctx,
     ctx->log_fn = (log_fn ? log_fn : default_log_fn);
 }
 
-XKB_EXPORT enum xkb_log_level
+enum xkb_log_level
 xkb_context_get_log_level(struct xkb_context *ctx)
 {
     return ctx->log_level;
 }
 
-XKB_EXPORT void
+void
 xkb_context_set_log_level(struct xkb_context *ctx, enum xkb_log_level level)
 {
     ctx->log_level = level;
 }
 
-XKB_EXPORT int
+int
 xkb_context_get_log_verbosity(struct xkb_context *ctx)
 {
     return ctx->log_verbosity;
 }
 
-XKB_EXPORT void
+void
 xkb_context_set_log_verbosity(struct xkb_context *ctx, int verbosity)
 {
     ctx->log_verbosity = verbosity;
 }
 
-XKB_EXPORT void *
+void *
 xkb_context_get_user_data(struct xkb_context *ctx)
 {
     if (ctx)
@@ -364,7 +364,7 @@ xkb_context_get_user_data(struct xkb_context *ctx)
     return NULL;
 }
 
-XKB_EXPORT void
+void
 xkb_context_set_user_data(struct xkb_context *ctx, void *user_data)
 {
     ctx->user_data = user_data;

--- a/src/context.h
+++ b/src/context.h
@@ -85,7 +85,7 @@ xkb_context_include_path_get_system_path(struct xkb_context *ctx);
 xkb_atom_t
 xkb_atom_lookup(struct xkb_context *ctx, const char *string);
 
-xkb_atom_t
+XKB_EXPORT_PRIVATE xkb_atom_t
 xkb_atom_intern(struct xkb_context *ctx, const char *string, size_t len);
 
 #define xkb_atom_intern_literal(ctx, literal) \
@@ -100,13 +100,13 @@ xkb_atom_intern(struct xkb_context *ctx, const char *string, size_t len);
 xkb_atom_t
 xkb_atom_steal(struct xkb_context *ctx, char *string);
 
-const char *
+XKB_EXPORT_PRIVATE const char *
 xkb_atom_text(struct xkb_context *ctx, xkb_atom_t atom);
 
 char *
 xkb_context_get_buffer(struct xkb_context *ctx, size_t size);
 
-ATTR_PRINTF(4, 5) void
+XKB_EXPORT_PRIVATE ATTR_PRINTF(4, 5) void
 xkb_log(struct xkb_context *ctx, enum xkb_log_level level, int verbosity,
         const char *fmt, ...);
 

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -55,14 +55,14 @@
 #include "keymap.h"
 #include "text.h"
 
-XKB_EXPORT struct xkb_keymap *
+struct xkb_keymap *
 xkb_keymap_ref(struct xkb_keymap *keymap)
 {
     keymap->refcnt++;
     return keymap;
 }
 
-XKB_EXPORT void
+void
 xkb_keymap_unref(struct xkb_keymap *keymap)
 {
     if (!keymap || --keymap->refcnt > 0)
@@ -118,7 +118,7 @@ get_keymap_format_ops(enum xkb_keymap_format format)
     return keymap_format_ops[(int) format];
 }
 
-XKB_EXPORT struct xkb_keymap *
+struct xkb_keymap *
 xkb_keymap_new_from_names(struct xkb_context *ctx,
                           const struct xkb_rule_names *rmlvo_in,
                           enum xkb_keymap_compile_flags flags)
@@ -159,7 +159,7 @@ xkb_keymap_new_from_names(struct xkb_context *ctx,
     return keymap;
 }
 
-XKB_EXPORT struct xkb_keymap *
+struct xkb_keymap *
 xkb_keymap_new_from_string(struct xkb_context *ctx,
                            const char *string,
                            enum xkb_keymap_format format,
@@ -169,7 +169,7 @@ xkb_keymap_new_from_string(struct xkb_context *ctx,
                                       format, flags);
 }
 
-XKB_EXPORT struct xkb_keymap *
+struct xkb_keymap *
 xkb_keymap_new_from_buffer(struct xkb_context *ctx,
                            const char *buffer, size_t length,
                            enum xkb_keymap_format format,
@@ -213,7 +213,7 @@ xkb_keymap_new_from_buffer(struct xkb_context *ctx,
     return keymap;
 }
 
-XKB_EXPORT struct xkb_keymap *
+struct xkb_keymap *
 xkb_keymap_new_from_file(struct xkb_context *ctx,
                          FILE *file,
                          enum xkb_keymap_format format,
@@ -253,7 +253,7 @@ xkb_keymap_new_from_file(struct xkb_context *ctx,
     return keymap;
 }
 
-XKB_EXPORT char *
+char *
 xkb_keymap_get_as_string(struct xkb_keymap *keymap,
                          enum xkb_keymap_format format)
 {
@@ -275,7 +275,7 @@ xkb_keymap_get_as_string(struct xkb_keymap *keymap,
 /**
  * Returns the total number of modifiers active in the keymap.
  */
-XKB_EXPORT xkb_mod_index_t
+xkb_mod_index_t
 xkb_keymap_num_mods(struct xkb_keymap *keymap)
 {
     return keymap->mods.num_mods;
@@ -284,7 +284,7 @@ xkb_keymap_num_mods(struct xkb_keymap *keymap)
 /**
  * Return the name for a given modifier.
  */
-XKB_EXPORT const char *
+const char *
 xkb_keymap_mod_get_name(struct xkb_keymap *keymap, xkb_mod_index_t idx)
 {
     if (idx >= keymap->mods.num_mods)
@@ -296,7 +296,7 @@ xkb_keymap_mod_get_name(struct xkb_keymap *keymap, xkb_mod_index_t idx)
 /**
  * Returns the index for a named modifier.
  */
-XKB_EXPORT xkb_mod_index_t
+xkb_mod_index_t
 xkb_keymap_mod_get_index(struct xkb_keymap *keymap, const char *name)
 {
     xkb_atom_t atom;
@@ -311,7 +311,7 @@ xkb_keymap_mod_get_index(struct xkb_keymap *keymap, const char *name)
 /**
  * Return the total number of active groups in the keymap.
  */
-XKB_EXPORT xkb_layout_index_t
+xkb_layout_index_t
 xkb_keymap_num_layouts(struct xkb_keymap *keymap)
 {
     return keymap->num_groups;
@@ -320,7 +320,7 @@ xkb_keymap_num_layouts(struct xkb_keymap *keymap)
 /**
  * Returns the name for a given group.
  */
-XKB_EXPORT const char *
+const char *
 xkb_keymap_layout_get_name(struct xkb_keymap *keymap, xkb_layout_index_t idx)
 {
     if (idx >= keymap->num_group_names)
@@ -332,7 +332,7 @@ xkb_keymap_layout_get_name(struct xkb_keymap *keymap, xkb_layout_index_t idx)
 /**
  * Returns the index for a named layout.
  */
-XKB_EXPORT xkb_layout_index_t
+xkb_layout_index_t
 xkb_keymap_layout_get_index(struct xkb_keymap *keymap, const char *name)
 {
     xkb_atom_t atom = xkb_atom_lookup(keymap->ctx, name);
@@ -351,7 +351,7 @@ xkb_keymap_layout_get_index(struct xkb_keymap *keymap, const char *name)
 /**
  * Returns the number of layouts active for a particular key.
  */
-XKB_EXPORT xkb_layout_index_t
+xkb_layout_index_t
 xkb_keymap_num_layouts_for_key(struct xkb_keymap *keymap, xkb_keycode_t kc)
 {
     const struct xkb_key *key = XkbKey(keymap, kc);
@@ -365,7 +365,7 @@ xkb_keymap_num_layouts_for_key(struct xkb_keymap *keymap, xkb_keycode_t kc)
 /**
  * Returns the number of levels active for a particular key and layout.
  */
-XKB_EXPORT xkb_level_index_t
+xkb_level_index_t
 xkb_keymap_num_levels_for_key(struct xkb_keymap *keymap, xkb_keycode_t kc,
                               xkb_layout_index_t layout)
 {
@@ -386,7 +386,7 @@ xkb_keymap_num_levels_for_key(struct xkb_keymap *keymap, xkb_keycode_t kc,
 /**
  * Return the total number of LEDs in the keymap.
  */
-XKB_EXPORT xkb_led_index_t
+xkb_led_index_t
 xkb_keymap_num_leds(struct xkb_keymap *keymap)
 {
     return keymap->num_leds;
@@ -395,7 +395,7 @@ xkb_keymap_num_leds(struct xkb_keymap *keymap)
 /**
  * Returns the name for a given LED.
  */
-XKB_EXPORT const char *
+const char *
 xkb_keymap_led_get_name(struct xkb_keymap *keymap, xkb_led_index_t idx)
 {
     if (idx >= keymap->num_leds)
@@ -407,7 +407,7 @@ xkb_keymap_led_get_name(struct xkb_keymap *keymap, xkb_led_index_t idx)
 /**
  * Returns the index for a named LED.
  */
-XKB_EXPORT xkb_led_index_t
+xkb_led_index_t
 xkb_keymap_led_get_index(struct xkb_keymap *keymap, const char *name)
 {
     xkb_atom_t atom = xkb_atom_lookup(keymap->ctx, name);
@@ -424,7 +424,7 @@ xkb_keymap_led_get_index(struct xkb_keymap *keymap, const char *name)
     return XKB_LED_INVALID;
 }
 
-XKB_EXPORT size_t
+size_t
 xkb_keymap_key_get_mods_for_level(struct xkb_keymap *keymap,
                                   xkb_keycode_t kc,
                                   xkb_layout_index_t layout,
@@ -487,7 +487,7 @@ xkb_keymap_key_get_mods_for_level(struct xkb_keymap *keymap,
 /**
  * As below, but takes an explicit layout/level rather than state.
  */
-XKB_EXPORT int
+int
 xkb_keymap_key_get_syms_by_level(struct xkb_keymap *keymap,
                                  xkb_keycode_t kc,
                                  xkb_layout_index_t layout,
@@ -524,19 +524,19 @@ err:
     return 0;
 }
 
-XKB_EXPORT xkb_keycode_t
+xkb_keycode_t
 xkb_keymap_min_keycode(struct xkb_keymap *keymap)
 {
     return keymap->min_key_code;
 }
 
-XKB_EXPORT xkb_keycode_t
+xkb_keycode_t
 xkb_keymap_max_keycode(struct xkb_keymap *keymap)
 {
     return keymap->max_key_code;
 }
 
-XKB_EXPORT void
+void
 xkb_keymap_key_for_each(struct xkb_keymap *keymap, xkb_keymap_key_iter_t iter,
                         void *data)
 {
@@ -546,7 +546,7 @@ xkb_keymap_key_for_each(struct xkb_keymap *keymap, xkb_keymap_key_iter_t iter,
         iter(keymap, key->keycode, data);
 }
 
-XKB_EXPORT const char *
+const char *
 xkb_keymap_key_get_name(struct xkb_keymap *keymap, xkb_keycode_t kc)
 {
     const struct xkb_key *key = XkbKey(keymap, kc);
@@ -557,7 +557,7 @@ xkb_keymap_key_get_name(struct xkb_keymap *keymap, xkb_keycode_t kc)
     return xkb_atom_text(keymap->ctx, key->name);
 }
 
-XKB_EXPORT xkb_keycode_t
+xkb_keycode_t
 xkb_keymap_key_by_name(struct xkb_keymap *keymap, const char *name)
 {
     struct xkb_key *key;
@@ -583,7 +583,7 @@ xkb_keymap_key_by_name(struct xkb_keymap *keymap, const char *name)
 /**
  * Simple boolean specifying whether or not the key should repeat.
  */
-XKB_EXPORT int
+int
 xkb_keymap_key_repeats(struct xkb_keymap *keymap, xkb_keycode_t kc)
 {
     const struct xkb_key *key = XkbKey(keymap, kc);

--- a/src/keysym-case-mappings.c
+++ b/src/keysym-case-mappings.c
@@ -596,7 +596,7 @@ get_unicode_entry(xkb_keysym_t ks)
     return &unicode_data[unicode_offsets1[unicode_offsets2[ks >> 8] + ((ks >> 3) & 0x1f)] + (ks & 0x07)];
 }
 
-XKB_EXPORT xkb_keysym_t
+xkb_keysym_t
 xkb_keysym_to_lower(xkb_keysym_t ks)
 {
     if (ks <= 0x13be) {
@@ -615,7 +615,7 @@ xkb_keysym_to_lower(xkb_keysym_t ks)
     }
 }
 
-XKB_EXPORT xkb_keysym_t
+xkb_keysym_t
 xkb_keysym_to_upper(xkb_keysym_t ks)
 {
     if (ks <= 0x13be) {

--- a/src/keysym-utf.c
+++ b/src/keysym-utf.c
@@ -853,7 +853,7 @@ bin_search(const struct codepair *table, size_t length, xkb_keysym_t keysym)
     return NO_KEYSYM_UNICODE_CONVERSION;
 }
 
-XKB_EXPORT uint32_t
+uint32_t
 xkb_keysym_to_utf32(xkb_keysym_t keysym)
 {
     /* first check for Latin-1 characters (1:1 mapping) */
@@ -894,7 +894,7 @@ xkb_keysym_to_utf32(xkb_keysym_t keysym)
     return bin_search(keysymtab, ARRAY_SIZE(keysymtab) - 1, keysym);
 }
 
-XKB_EXPORT xkb_keysym_t
+xkb_keysym_t
 xkb_utf32_to_keysym(uint32_t ucs)
 {
     /* first check for Latin-1 characters (1:1 mapping) */
@@ -949,7 +949,7 @@ xkb_utf32_to_keysym(uint32_t ucs)
  * Author: Rob Bradford <rob@linux.intel.com>
  */
 
-XKB_EXPORT int
+int
 xkb_keysym_to_utf8(xkb_keysym_t keysym, char *buffer, size_t size)
 {
     uint32_t codepoint;

--- a/src/keysym.c
+++ b/src/keysym.c
@@ -101,7 +101,7 @@ get_unicode_name(xkb_keysym_t ks, char *buffer, size_t size)
     return snprintf(buffer, size, "U%0*lX", width, ks & 0xffffffUL);
 }
 
-XKB_EXPORT int
+int
 xkb_keysym_get_name(xkb_keysym_t ks, char *buffer, size_t size)
 {
     if (ks > XKB_KEYSYM_MAX) {
@@ -245,7 +245,7 @@ parse_keysym_hex(const char *s, uint32_t *out)
     return s[i] == '\0' && i > 0;
 }
 
-XKB_EXPORT xkb_keysym_t
+xkb_keysym_t
 xkb_keysym_from_name(const char *name, enum xkb_keysym_flags flags)
 {
     const struct name_keysym *entry = NULL;

--- a/src/keysym.h
+++ b/src/keysym.h
@@ -52,6 +52,7 @@
 
 #include <stdbool.h>
 #include "xkbcommon/xkbcommon.h"
+#include "utils.h"
 
 /*
  * NOTE: this is not defined in xkbcommon.h, because if we did, it may add
@@ -88,31 +89,31 @@
  * 4 bytes + NULL-terminating byte */
 #define XKB_KEYSYM_UTF8_MAX_SIZE  5
 
-bool
+XKB_EXPORT_PRIVATE bool
 xkb_keysym_is_assigned(xkb_keysym_t ks);
 
 struct xkb_keysym_iterator;
 
-struct xkb_keysym_iterator*
+XKB_EXPORT_PRIVATE struct xkb_keysym_iterator*
 xkb_keysym_iterator_new(bool explicit);
 
-struct xkb_keysym_iterator*
+XKB_EXPORT_PRIVATE struct xkb_keysym_iterator*
 xkb_keysym_iterator_unref(struct xkb_keysym_iterator *iter);
 
-bool
+XKB_EXPORT_PRIVATE bool
 xkb_keysym_iterator_next(struct xkb_keysym_iterator *iter);
 
-xkb_keysym_t
+XKB_EXPORT_PRIVATE xkb_keysym_t
 xkb_keysym_iterator_get_keysym(struct xkb_keysym_iterator *iter);
 
-int
+XKB_EXPORT_PRIVATE int
 xkb_keysym_iterator_get_name(struct xkb_keysym_iterator *iter,
                              char *buffer, size_t size);
 
-bool
+XKB_EXPORT_PRIVATE bool
 xkb_keysym_iterator_is_explicitly_named(struct xkb_keysym_iterator *iter);
 
-bool
+XKB_EXPORT_PRIVATE bool
 xkb_keysym_is_deprecated(xkb_keysym_t keysym,
                          const char *name,
                          const char **reference_name);
@@ -133,16 +134,16 @@ xkb_keysym_is_deprecated(xkb_keysym_t keysym,
         }                                                                                    \
     }
 
-bool
+XKB_EXPORT_PRIVATE bool
 xkb_keysym_is_lower(xkb_keysym_t keysym);
 
-bool
+XKB_EXPORT_PRIVATE bool
 xkb_keysym_is_upper_or_title(xkb_keysym_t keysym);
 
-bool
+XKB_EXPORT_PRIVATE bool
 xkb_keysym_is_keypad(xkb_keysym_t keysym);
 
-bool
+XKB_EXPORT_PRIVATE bool
 xkb_keysym_is_modifier(xkb_keysym_t keysym);
 
 #endif

--- a/src/registry.c
+++ b/src/registry.c
@@ -169,11 +169,11 @@ rxkb_log(struct rxkb_context *ctx, enum rxkb_log_level level,
 
 
 #define DECLARE_REF_UNREF_FOR_TYPE(type_) \
-XKB_EXPORT struct type_ * type_##_ref(struct type_ *object) { \
+struct type_ * type_##_ref(struct type_ *object) { \
     rxkb_object_ref(&object->base); \
     return object; \
 } \
-XKB_EXPORT struct type_ * type_##_unref(struct type_ *object) { \
+struct type_ * type_##_unref(struct type_ *object) { \
     if (!object) return NULL; \
     assert(object->base.refcount >= 1); \
     if (--object->base.refcount == 0) {\
@@ -193,7 +193,7 @@ static inline struct type_ * type_##_create(struct rxkb_object *parent) { \
 }
 
 #define DECLARE_TYPED_GETTER_FOR_TYPE(type_, field_, rtype_) \
-XKB_EXPORT rtype_ type_##_get_##field_(struct type_ *object) { \
+rtype_ type_##_get_##field_(struct type_ *object) { \
     return object->field_; \
 }
 
@@ -201,13 +201,13 @@ XKB_EXPORT rtype_ type_##_get_##field_(struct type_ *object) { \
    DECLARE_TYPED_GETTER_FOR_TYPE(type_, field_, const char*)
 
 #define DECLARE_FIRST_NEXT_FOR_TYPE(type_, parent_type_, parent_field_) \
-XKB_EXPORT struct type_ * type_##_first(struct parent_type_ *parent) { \
+struct type_ * type_##_first(struct parent_type_ *parent) { \
     struct type_ *o = NULL; \
     if (!list_empty(&parent->parent_field_)) \
         o = list_first_entry(&parent->parent_field_, o, base.link); \
     return o; \
 } \
-XKB_EXPORT struct type_ * \
+struct type_ * \
 type_##_next(struct type_ *o) \
 { \
     struct parent_type_ *parent; \
@@ -241,7 +241,7 @@ rxkb_iso639_code_destroy(struct rxkb_iso639_code *code)
     free(code->code);
 }
 
-XKB_EXPORT struct rxkb_iso639_code *
+struct rxkb_iso639_code *
 rxkb_layout_get_iso639_first(struct rxkb_layout *layout)
 {
     struct rxkb_iso639_code *code = NULL;
@@ -252,7 +252,7 @@ rxkb_layout_get_iso639_first(struct rxkb_layout *layout)
     return code;
 }
 
-XKB_EXPORT struct rxkb_iso639_code *
+struct rxkb_iso639_code *
 rxkb_iso639_code_next(struct rxkb_iso639_code *code)
 {
     struct rxkb_iso639_code *next = NULL;
@@ -278,7 +278,7 @@ rxkb_iso3166_code_destroy(struct rxkb_iso3166_code *code)
     free(code->code);
 }
 
-XKB_EXPORT struct rxkb_iso3166_code *
+struct rxkb_iso3166_code *
 rxkb_layout_get_iso3166_first(struct rxkb_layout *layout)
 {
     struct rxkb_iso3166_code *code = NULL;
@@ -289,7 +289,7 @@ rxkb_layout_get_iso3166_first(struct rxkb_layout *layout)
     return code;
 }
 
-XKB_EXPORT struct rxkb_iso3166_code *
+struct rxkb_iso3166_code *
 rxkb_iso3166_code_next(struct rxkb_iso3166_code *code)
 {
     struct rxkb_iso3166_code *next = NULL;
@@ -382,7 +382,7 @@ rxkb_option_group_destroy(struct rxkb_option_group *og)
     }
 }
 
-XKB_EXPORT bool
+bool
 rxkb_option_group_allows_multiple(struct rxkb_option_group *g)
 {
     return g->allow_multiple;
@@ -437,7 +437,7 @@ rxkb_context_getenv(struct rxkb_context *ctx, const char *name)
 }
 
 
-XKB_EXPORT void
+void
 rxkb_context_set_log_level(struct rxkb_context *ctx,
                            enum rxkb_log_level level)
 {
@@ -497,7 +497,7 @@ log_level(const char *level) {
     return RXKB_LOG_LEVEL_ERROR;
 }
 
-XKB_EXPORT struct rxkb_context *
+struct rxkb_context *
 rxkb_context_new(enum rxkb_context_flags flags)
 {
     struct rxkb_context *ctx = rxkb_context_create(NULL);
@@ -530,7 +530,7 @@ rxkb_context_new(enum rxkb_context_flags flags)
     return ctx;
 }
 
-XKB_EXPORT void
+void
 rxkb_context_set_log_fn(struct rxkb_context *ctx,
                         void (*log_fn)(struct rxkb_context *ctx,
                                        enum rxkb_log_level level,
@@ -539,7 +539,7 @@ rxkb_context_set_log_fn(struct rxkb_context *ctx,
     ctx->log_fn = (log_fn ? log_fn : default_log_fn);
 }
 
-XKB_EXPORT bool
+bool
 rxkb_context_include_path_append(struct rxkb_context *ctx, const char *path)
 {
     struct stat stat_buf;
@@ -584,7 +584,7 @@ rxkb_context_include_path_append(struct rxkb_context *ctx, const char *path)
     return true;
 }
 
-XKB_EXPORT bool
+bool
 rxkb_context_include_path_append_default(struct rxkb_context *ctx)
 {
     const char *home, *xdg, *root, *extra;
@@ -629,13 +629,13 @@ rxkb_context_include_path_append_default(struct rxkb_context *ctx)
     return ret;
 }
 
-XKB_EXPORT bool
+bool
 rxkb_context_parse_default_ruleset(struct rxkb_context *ctx)
 {
     return rxkb_context_parse(ctx, DEFAULT_XKB_RULES);
 }
 
-XKB_EXPORT bool
+bool
 rxkb_context_parse(struct rxkb_context *ctx, const char *ruleset)
 {
     char **path;
@@ -672,13 +672,13 @@ rxkb_context_parse(struct rxkb_context *ctx, const char *ruleset)
 }
 
 
-XKB_EXPORT void
+void
 rxkb_context_set_user_data(struct rxkb_context *ctx, void *userdata)
 {
     ctx->userdata = userdata;
 }
 
-XKB_EXPORT void *
+void *
 rxkb_context_get_user_data(struct rxkb_context *ctx)
 {
     return ctx->userdata;

--- a/src/scanner-utils.h
+++ b/src/scanner-utils.h
@@ -28,6 +28,7 @@
 #include <stddef.h>
 #include <string.h>
 
+#include "bump.h"
 #include "context.h"
 #include "darray.h"
 #include "messages-codes.h"
@@ -63,6 +64,7 @@ struct scanner {
     size_t token_line, token_column;
     const char *file_name;
     struct xkb_context *ctx;
+    struct bump *bump;
     void *priv;
 };
 
@@ -87,6 +89,7 @@ struct scanner {
 
 static inline void
 scanner_init(struct scanner *s, struct xkb_context *ctx,
+             struct bump *bump,
              const char *string, size_t len, const char *file_name,
              void *priv)
 {
@@ -97,6 +100,7 @@ scanner_init(struct scanner *s, struct xkb_context *ctx,
     s->token_line = s->token_column = 1;
     s->file_name = file_name;
     s->ctx = ctx;
+    s->bump = bump;
     s->priv = priv;
 }
 

--- a/src/scanner-utils.h
+++ b/src/scanner-utils.h
@@ -64,7 +64,6 @@ struct scanner {
     size_t token_line, token_column;
     const char *file_name;
     struct xkb_context *ctx;
-    struct bump *bump;
     void *priv;
 };
 
@@ -89,7 +88,6 @@ struct scanner {
 
 static inline void
 scanner_init(struct scanner *s, struct xkb_context *ctx,
-             struct bump *bump,
              const char *string, size_t len, const char *file_name,
              void *priv)
 {
@@ -100,7 +98,6 @@ scanner_init(struct scanner *s, struct xkb_context *ctx,
     s->token_line = s->token_column = 1;
     s->file_name = file_name;
     s->ctx = ctx;
-    s->bump = bump;
     s->priv = priv;
 }
 

--- a/src/state.c
+++ b/src/state.c
@@ -141,7 +141,7 @@ get_entry_for_key_state(struct xkb_state *state, const struct xkb_key *key,
  * Returns the level to use for the given key and state, or
  * XKB_LEVEL_INVALID.
  */
-XKB_EXPORT xkb_level_index_t
+xkb_level_index_t
 xkb_state_key_get_level(struct xkb_state *state, xkb_keycode_t kc,
                         xkb_layout_index_t layout)
 {
@@ -163,7 +163,7 @@ xkb_state_key_get_level(struct xkb_state *state, xkb_keycode_t kc,
  * Returns the layout to use for the given key and state, taking
  * wrapping/clamping/etc into account, or XKB_LAYOUT_INVALID.
  */
-XKB_EXPORT xkb_layout_index_t
+xkb_layout_index_t
 xkb_state_key_get_layout(struct xkb_state *state, xkb_keycode_t kc)
 {
     const struct xkb_key *key = XkbKey(state->keymap, kc);
@@ -690,7 +690,7 @@ xkb_filter_apply_all(struct xkb_state *state,
     }
 }
 
-XKB_EXPORT struct xkb_state *
+struct xkb_state *
 xkb_state_new(struct xkb_keymap *keymap)
 {
     struct xkb_state *ret;
@@ -705,14 +705,14 @@ xkb_state_new(struct xkb_keymap *keymap)
     return ret;
 }
 
-XKB_EXPORT struct xkb_state *
+struct xkb_state *
 xkb_state_ref(struct xkb_state *state)
 {
     state->refcnt++;
     return state;
 }
 
-XKB_EXPORT void
+void
 xkb_state_unref(struct xkb_state *state)
 {
     if (!state || --state->refcnt > 0)
@@ -723,7 +723,7 @@ xkb_state_unref(struct xkb_state *state)
     free(state);
 }
 
-XKB_EXPORT struct xkb_keymap *
+struct xkb_keymap *
 xkb_state_get_keymap(struct xkb_state *state)
 {
     return state->keymap;
@@ -868,7 +868,7 @@ get_state_component_changes(const struct state_components *a,
  * Given a particular key event, updates the state structure to reflect the
  * new modifiers.
  */
-XKB_EXPORT enum xkb_state_component
+enum xkb_state_component
 xkb_state_update_key(struct xkb_state *state, xkb_keycode_t kc,
                      enum xkb_key_direction direction)
 {
@@ -918,7 +918,7 @@ xkb_state_update_key(struct xkb_state *state, xkb_keycode_t kc,
  * lossy, and should only be used to update a slave state mirroring the
  * master, e.g. in a client/server window system.
  */
-XKB_EXPORT enum xkb_state_component
+enum xkb_state_component
 xkb_state_update_mask(struct xkb_state *state,
                       xkb_mod_mask_t base_mods,
                       xkb_mod_mask_t latched_mods,
@@ -974,7 +974,7 @@ xkb_state_update_mask(struct xkb_state *state,
  * Provides the symbols to use for the given key and state.  Returns the
  * number of symbols pointed to in syms_out.
  */
-XKB_EXPORT int
+int
 xkb_state_key_get_syms(struct xkb_state *state, xkb_keycode_t kc,
                        const xkb_keysym_t **syms_out)
 {
@@ -1073,7 +1073,7 @@ XkbToControl(char ch)
 /**
  * Provides either exactly one symbol, or XKB_KEY_NoSymbol.
  */
-XKB_EXPORT xkb_keysym_t
+xkb_keysym_t
 xkb_state_key_get_one_sym(struct xkb_state *state, xkb_keycode_t kc)
 {
     const xkb_keysym_t *syms;
@@ -1145,7 +1145,7 @@ get_one_sym_for_string(struct xkb_state *state, xkb_keycode_t kc)
     return sym;
 }
 
-XKB_EXPORT int
+int
 xkb_state_key_get_utf8(struct xkb_state *state, xkb_keycode_t kc,
                        char *buffer, size_t size)
 {
@@ -1200,7 +1200,7 @@ err_bad:
     return 0;
 }
 
-XKB_EXPORT uint32_t
+uint32_t
 xkb_state_key_get_utf32(struct xkb_state *state, xkb_keycode_t kc)
 {
     xkb_keysym_t sym;
@@ -1219,7 +1219,7 @@ xkb_state_key_get_utf32(struct xkb_state *state, xkb_keycode_t kc)
  * Serialises the requested modifier state into an xkb_mod_mask_t, with all
  * the same disclaimers as in xkb_state_update_mask.
  */
-XKB_EXPORT xkb_mod_mask_t
+xkb_mod_mask_t
 xkb_state_serialize_mods(struct xkb_state *state,
                          enum xkb_state_component type)
 {
@@ -1242,7 +1242,7 @@ xkb_state_serialize_mods(struct xkb_state *state,
  * Serialises the requested group state, with all the same disclaimers as
  * in xkb_state_update_mask.
  */
-XKB_EXPORT xkb_layout_index_t
+xkb_layout_index_t
 xkb_state_serialize_layout(struct xkb_state *state,
                            enum xkb_state_component type)
 {
@@ -1298,7 +1298,7 @@ mod_mapping(struct xkb_mod *mod, xkb_mod_index_t idx)
  * Returns 1 if the given modifier is active with the specified type(s), 0 if
  * not, or -1 if the modifier is invalid.
  */
-XKB_EXPORT int
+int
 xkb_state_mod_index_is_active(struct xkb_state *state,
                               xkb_mod_index_t idx,
                               enum xkb_state_component type)
@@ -1340,7 +1340,7 @@ match_mod_masks(struct xkb_state *state,
  * Returns 1 if the modifiers are active with the specified type(s), 0 if
  * not, or -1 if any of the modifiers are invalid.
  */
-XKB_EXPORT int
+int
 xkb_state_mod_indices_are_active(struct xkb_state *state,
                                  enum xkb_state_component type,
                                  enum xkb_state_match match,
@@ -1379,7 +1379,7 @@ xkb_state_mod_indices_are_active(struct xkb_state *state,
  * Returns 1 if the given modifier is active with the specified type(s), 0 if
  * not, or -1 if the modifier is invalid.
  */
-XKB_EXPORT int
+int
 xkb_state_mod_name_is_active(struct xkb_state *state, const char *name,
                              enum xkb_state_component type)
 {
@@ -1395,7 +1395,7 @@ xkb_state_mod_name_is_active(struct xkb_state *state, const char *name,
  * Returns 1 if the modifiers are active with the specified type(s), 0 if
  * not, or -1 if any of the modifiers are invalid.
  */
-XKB_EXPORT ATTR_NULL_SENTINEL int
+ATTR_NULL_SENTINEL int
 xkb_state_mod_names_are_active(struct xkb_state *state,
                                enum xkb_state_component type,
                                enum xkb_state_match match,
@@ -1435,7 +1435,7 @@ xkb_state_mod_names_are_active(struct xkb_state *state,
  * Returns 1 if the given group is active with the specified type(s), 0 if
  * not, or -1 if the group is invalid.
  */
-XKB_EXPORT int
+int
 xkb_state_layout_index_is_active(struct xkb_state *state,
                                  xkb_layout_index_t idx,
                                  enum xkb_state_component type)
@@ -1461,7 +1461,7 @@ xkb_state_layout_index_is_active(struct xkb_state *state,
  * Returns 1 if the given modifier is active with the specified type(s), 0 if
  * not, or -1 if the modifier is invalid.
  */
-XKB_EXPORT int
+int
 xkb_state_layout_name_is_active(struct xkb_state *state, const char *name,
                                 enum xkb_state_component type)
 {
@@ -1476,7 +1476,7 @@ xkb_state_layout_name_is_active(struct xkb_state *state, const char *name,
 /**
  * Returns 1 if the given LED is active, 0 if not, or -1 if the LED is invalid.
  */
-XKB_EXPORT int
+int
 xkb_state_led_index_is_active(struct xkb_state *state, xkb_led_index_t idx)
 {
     if (idx >= state->keymap->num_leds ||
@@ -1489,7 +1489,7 @@ xkb_state_led_index_is_active(struct xkb_state *state, xkb_led_index_t idx)
 /**
  * Returns 1 if the given LED is active, 0 if not, or -1 if the LED is invalid.
  */
-XKB_EXPORT int
+int
 xkb_state_led_name_is_active(struct xkb_state *state, const char *name)
 {
     xkb_led_index_t idx = xkb_keymap_led_get_index(state->keymap, name);
@@ -1558,7 +1558,7 @@ key_get_consumed(struct xkb_state *state, const struct xkb_key *key,
     return consumed & ~preserve;
 }
 
-XKB_EXPORT int
+int
 xkb_state_mod_index_is_consumed2(struct xkb_state *state, xkb_keycode_t kc,
                                  xkb_mod_index_t idx,
                                  enum xkb_consumed_mode mode)
@@ -1576,7 +1576,7 @@ xkb_state_mod_index_is_consumed2(struct xkb_state *state, xkb_keycode_t kc,
     return !!((mapping & key_get_consumed(state, key, mode)) == mapping);
 }
 
-XKB_EXPORT int
+int
 xkb_state_mod_index_is_consumed(struct xkb_state *state, xkb_keycode_t kc,
                                 xkb_mod_index_t idx)
 {
@@ -1584,7 +1584,7 @@ xkb_state_mod_index_is_consumed(struct xkb_state *state, xkb_keycode_t kc,
                                             XKB_CONSUMED_MODE_XKB);
 }
 
-XKB_EXPORT xkb_mod_mask_t
+xkb_mod_mask_t
 xkb_state_mod_mask_remove_consumed(struct xkb_state *state, xkb_keycode_t kc,
                                    xkb_mod_mask_t mask)
 {
@@ -1597,7 +1597,7 @@ xkb_state_mod_mask_remove_consumed(struct xkb_state *state, xkb_keycode_t kc,
            ~key_get_consumed(state, key, XKB_CONSUMED_MODE_XKB);
 }
 
-XKB_EXPORT xkb_mod_mask_t
+xkb_mod_mask_t
 xkb_state_key_get_consumed_mods2(struct xkb_state *state, xkb_keycode_t kc,
                                  enum xkb_consumed_mode mode)
 {
@@ -1620,7 +1620,7 @@ xkb_state_key_get_consumed_mods2(struct xkb_state *state, xkb_keycode_t kc,
     return key_get_consumed(state, key, mode);
 }
 
-XKB_EXPORT xkb_mod_mask_t
+xkb_mod_mask_t
 xkb_state_key_get_consumed_mods(struct xkb_state *state, xkb_keycode_t kc)
 {
     return xkb_state_key_get_consumed_mods2(state, kc, XKB_CONSUMED_MODE_XKB);

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -26,6 +26,7 @@
 
 #include "config.h"
 
+#include "utils.h"
 #include "utf8.h"
 
 /* Conformant encoding form conversion from UTF-32 to UTF-8.

--- a/src/utf8.h
+++ b/src/utf8.h
@@ -31,10 +31,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
-int
+#include "utils.h"
+
+XKB_EXPORT_PRIVATE int
 utf32_to_utf8(uint32_t unichar, char *buffer);
 
-bool
+XKB_EXPORT_PRIVATE bool
 is_valid_utf8(const char *ss, size_t len);
 
 #endif

--- a/src/utils-paths.h
+++ b/src/utils-paths.h
@@ -13,7 +13,7 @@
 #define is_path_separator(s) ((s) == PATH_SEPARATOR)
 #endif
 
-bool
+XKB_EXPORT_PRIVATE bool
 is_absolute(const char *path);
 
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -285,6 +285,19 @@ open_file(const char *path);
 
 /* Compiler Attributes */
 
+/* Private functions only exposed in tests. */
+#ifdef ENABLE_PRIVATE_APIS
+# if defined(__GNUC__) && !defined(__CYGWIN__)
+#  define XKB_EXPORT_PRIVATE __attribute__((visibility("default")))
+# elif defined(_WIN32)
+#  define XKB_EXPORT_PRIVATE __declspec(dllexport)
+# else
+#  define XKB_EXPORT_PRIVATE
+# endif
+#else
+# define XKB_EXPORT_PRIVATE
+#endif
+
 #if defined(__MINGW32__)
 # define ATTR_PRINTF(x,y) __attribute__((__format__(__MINGW_PRINTF_FORMAT, x, y)))
 #elif defined(__GNUC__)
@@ -318,10 +331,10 @@ open_file(const char *path);
 #endif
 
 #if !(defined(HAVE_ASPRINTF) && HAVE_ASPRINTF)
-int asprintf(char **strp, const char *fmt, ...) ATTR_PRINTF(2, 3);
+XKB_EXPORT_PRIVATE int asprintf(char **strp, const char *fmt, ...) ATTR_PRINTF(2, 3);
 # if !(defined(HAVE_VASPRINTF) && HAVE_VASPRINTF)
 #  include <stdarg.h>
-int vasprintf(char **strp, const char *fmt, va_list ap);
+XKB_EXPORT_PRIVATE int vasprintf(char **strp, const char *fmt, va_list ap);
 # endif /* !HAVE_VASPRINTF */
 #endif /* !HAVE_ASPRINTF */
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -285,12 +285,6 @@ open_file(const char *path);
 
 /* Compiler Attributes */
 
-#if defined(__GNUC__) && !defined(__CYGWIN__)
-# define XKB_EXPORT      __attribute__((visibility("default")))
-#else
-# define XKB_EXPORT
-#endif
-
 #if defined(__MINGW32__)
 # define ATTR_PRINTF(x,y) __attribute__((__format__(__MINGW_PRINTF_FORMAT, x, y)))
 #elif defined(__GNUC__)

--- a/src/utils.h
+++ b/src/utils.h
@@ -285,42 +285,39 @@ open_file(const char *path);
 
 /* Compiler Attributes */
 
-#if defined(__GNUC__) && (__GNUC__ >= 4) && !defined(__CYGWIN__)
+#if defined(__GNUC__) && !defined(__CYGWIN__)
 # define XKB_EXPORT      __attribute__((visibility("default")))
-#elif defined(__SUNPRO_C) && (__SUNPRO_C >= 0x550)
-# define XKB_EXPORT      __global
-#else /* not gcc >= 4 and not Sun Studio >= 8 */
+#else
 # define XKB_EXPORT
 #endif
 
 #if defined(__MINGW32__)
 # define ATTR_PRINTF(x,y) __attribute__((__format__(__MINGW_PRINTF_FORMAT, x, y)))
-#elif defined(__GNUC__) && ((__GNUC__ * 100 + __GNUC_MINOR__) >= 203)
+#elif defined(__GNUC__)
 # define ATTR_PRINTF(x,y) __attribute__((__format__(__printf__, x, y)))
-#else /* not gcc >= 2.3 */
+#else
 # define ATTR_PRINTF(x,y)
 #endif
 
-#if (defined(__GNUC__) && ((__GNUC__ * 100 + __GNUC_MINOR__) >= 205)) \
-    || (defined(__SUNPRO_C) && (__SUNPRO_C >= 0x590))
+#if defined(__GNUC__)
 # define ATTR_NORETURN __attribute__((__noreturn__))
 #else
 # define ATTR_NORETURN
 #endif /* GNUC  */
 
-#if (defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__) >= 296)
+#if defined(__GNUC__)
 #define ATTR_MALLOC  __attribute__((__malloc__))
 #else
 #define ATTR_MALLOC
 #endif
 
-#if defined(__GNUC__) && (__GNUC__ >= 4)
+#if defined(__GNUC__)
 # define ATTR_NULL_SENTINEL __attribute__((__sentinel__))
 #else
 # define ATTR_NULL_SENTINEL
-#endif /* GNUC >= 4 */
+#endif
 
-#if (defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__) >= 295)
+#if defined(__GNUC__)
 #define ATTR_PACKED  __attribute__((__packed__))
 #else
 #define ATTR_PACKED

--- a/src/utils.h
+++ b/src/utils.h
@@ -330,6 +330,12 @@ open_file(const char *path);
 #define ATTR_PACKED
 #endif
 
+#if defined(__GNUC__)
+#define ATTR_NOINLINE  __attribute__((__noinline__))
+#else
+#define ATTR_NOINLINE
+#endif
+
 #if !(defined(HAVE_ASPRINTF) && HAVE_ASPRINTF)
 XKB_EXPORT_PRIVATE int asprintf(char **strp, const char *fmt, ...) ATTR_PRINTF(2, 3);
 # if !(defined(HAVE_VASPRINTF) && HAVE_VASPRINTF)

--- a/src/utils.h
+++ b/src/utils.h
@@ -336,6 +336,12 @@ open_file(const char *path);
 #define ATTR_NOINLINE
 #endif
 
+#if defined(__GNUC__)
+#define ATTR_ALLOC_ALIGN(position)  __attribute__((alloc_align(position)))
+#else
+#define ATTR_ALLOC_ALIGN(position)
+#endif
+
 #if !(defined(HAVE_ASPRINTF) && HAVE_ASPRINTF)
 XKB_EXPORT_PRIVATE int asprintf(char **strp, const char *fmt, ...) ATTR_PRINTF(2, 3);
 # if !(defined(HAVE_VASPRINTF) && HAVE_VASPRINTF)

--- a/src/x11/keymap.c
+++ b/src/x11/keymap.c
@@ -1156,7 +1156,7 @@ fail:
     return false;
 }
 
-XKB_EXPORT struct xkb_keymap *
+struct xkb_keymap *
 xkb_x11_keymap_new_from_device(struct xkb_context *ctx,
                                xcb_connection_t *conn,
                                int32_t device_id,

--- a/src/x11/state.c
+++ b/src/x11/state.c
@@ -49,7 +49,7 @@ update_initial_state(struct xkb_state *state, xcb_connection_t *conn,
     return true;
 }
 
-XKB_EXPORT struct xkb_state *
+struct xkb_state *
 xkb_x11_state_new_from_device(struct xkb_keymap *keymap,
                               xcb_connection_t *conn, int32_t device_id)
 {

--- a/src/x11/util.c
+++ b/src/x11/util.c
@@ -25,7 +25,7 @@
 
 #include "x11-priv.h"
 
-XKB_EXPORT int
+int
 xkb_x11_setup_xkb_extension(xcb_connection_t *conn,
                             uint16_t major_xkb_version,
                             uint16_t minor_xkb_version,
@@ -106,7 +106,7 @@ xkb_x11_setup_xkb_extension(xcb_connection_t *conn,
     return 1;
 }
 
-XKB_EXPORT int32_t
+int32_t
 xkb_x11_get_core_keyboard_device_id(xcb_connection_t *conn)
 {
     int32_t device_id;

--- a/src/xkbcomp/ast-build.c
+++ b/src/xkbcomp/ast-build.c
@@ -216,55 +216,15 @@ ExprCreateKeysymList(xkb_keysym_t sym)
     ExprDef *expr = ExprCreate(EXPR_KEYSYM_LIST, EXPR_TYPE_SYMBOLS, sizeof(ExprKeysymList));
     if (!expr)
         return NULL;
-
     darray_init(expr->keysym_list.syms);
-    darray_init(expr->keysym_list.symsMapIndex);
-    darray_init(expr->keysym_list.symsNumEntries);
-
     darray_append(expr->keysym_list.syms, sym);
-    darray_append(expr->keysym_list.symsMapIndex, 0);
-    darray_append(expr->keysym_list.symsNumEntries, 1);
-
-    return expr;
-}
-
-ExprDef *
-ExprCreateMultiKeysymList(ExprDef *expr)
-{
-    unsigned nLevels = darray_size(expr->keysym_list.symsMapIndex);
-
-    darray_resize(expr->keysym_list.symsMapIndex, 1);
-    darray_resize(expr->keysym_list.symsNumEntries, 1);
-    darray_item(expr->keysym_list.symsMapIndex, 0) = 0;
-    darray_item(expr->keysym_list.symsNumEntries, 0) = nLevels;
-
     return expr;
 }
 
 ExprDef *
 ExprAppendKeysymList(ExprDef *expr, xkb_keysym_t sym)
 {
-    unsigned nSyms = darray_size(expr->keysym_list.syms);
-
-    darray_append(expr->keysym_list.symsMapIndex, nSyms);
-    darray_append(expr->keysym_list.symsNumEntries, 1);
     darray_append(expr->keysym_list.syms, sym);
-
-    return expr;
-}
-
-ExprDef *
-ExprAppendMultiKeysymList(ExprDef *expr, ExprDef *append)
-{
-    unsigned nSyms = darray_size(expr->keysym_list.syms);
-    unsigned numEntries = darray_size(append->keysym_list.syms);
-
-    darray_append(expr->keysym_list.symsMapIndex, nSyms);
-    darray_append(expr->keysym_list.symsNumEntries, numEntries);
-    darray_concat(expr->keysym_list.syms, append->keysym_list.syms);
-
-    FreeStmt((ParseCommon *) append);
-
     return expr;
 }
 
@@ -635,8 +595,6 @@ FreeExpr(ExprDef *expr)
 
     case EXPR_KEYSYM_LIST:
         darray_free(expr->keysym_list.syms);
-        darray_free(expr->keysym_list.symsMapIndex);
-        darray_free(expr->keysym_list.symsNumEntries);
         break;
 
     default:

--- a/src/xkbcomp/ast-build.c
+++ b/src/xkbcomp/ast-build.c
@@ -51,6 +51,7 @@
  *         Ran Benita <ran234@gmail.com>
  */
 
+#include "bump.h"
 #include "config.h"
 
 #include "xkbcomp-priv.h"
@@ -58,9 +59,9 @@
 #include "include.h"
 
 static ExprDef *
-ExprCreate(enum expr_op_type op, enum expr_value_type type, size_t size)
+ExprCreate(struct bump *bump, enum expr_op_type op, enum expr_value_type type, size_t size)
 {
-    ExprDef *expr = malloc(size);
+    ExprDef *expr = bump_alloc(bump, size);
     if (!expr)
         return NULL;
 
@@ -73,9 +74,9 @@ ExprCreate(enum expr_op_type op, enum expr_value_type type, size_t size)
 }
 
 ExprDef *
-ExprCreateString(xkb_atom_t str)
+ExprCreateString(struct bump *bump, xkb_atom_t str)
 {
-    ExprDef *expr = ExprCreate(EXPR_VALUE, EXPR_TYPE_STRING, sizeof(ExprString));
+    ExprDef *expr = ExprCreate(bump, EXPR_VALUE, EXPR_TYPE_STRING, sizeof(ExprString));
     if (!expr)
         return NULL;
     expr->string.str = str;
@@ -83,9 +84,9 @@ ExprCreateString(xkb_atom_t str)
 }
 
 ExprDef *
-ExprCreateInteger(int ival)
+ExprCreateInteger(struct bump *bump, int ival)
 {
-    ExprDef *expr = ExprCreate(EXPR_VALUE, EXPR_TYPE_INT, sizeof(ExprInteger));
+    ExprDef *expr = ExprCreate(bump, EXPR_VALUE, EXPR_TYPE_INT, sizeof(ExprInteger));
     if (!expr)
         return NULL;
     expr->integer.ival = ival;
@@ -93,18 +94,18 @@ ExprCreateInteger(int ival)
 }
 
 ExprDef *
-ExprCreateFloat(void)
+ExprCreateFloat(struct bump *bump)
 {
-    ExprDef *expr = ExprCreate(EXPR_VALUE, EXPR_TYPE_FLOAT, sizeof(ExprFloat));
+    ExprDef *expr = ExprCreate(bump, EXPR_VALUE, EXPR_TYPE_FLOAT, sizeof(ExprFloat));
     if (!expr)
         return NULL;
     return expr;
 }
 
 ExprDef *
-ExprCreateBoolean(bool set)
+ExprCreateBoolean(struct bump *bump, bool set)
 {
-    ExprDef *expr = ExprCreate(EXPR_VALUE, EXPR_TYPE_BOOLEAN, sizeof(ExprBoolean));
+    ExprDef *expr = ExprCreate(bump, EXPR_VALUE, EXPR_TYPE_BOOLEAN, sizeof(ExprBoolean));
     if (!expr)
         return NULL;
     expr->boolean.set = set;
@@ -112,9 +113,9 @@ ExprCreateBoolean(bool set)
 }
 
 ExprDef *
-ExprCreateKeyName(xkb_atom_t key_name)
+ExprCreateKeyName(struct bump *bump, xkb_atom_t key_name)
 {
-    ExprDef *expr = ExprCreate(EXPR_VALUE, EXPR_TYPE_KEYNAME, sizeof(ExprKeyName));
+    ExprDef *expr = ExprCreate(bump, EXPR_VALUE, EXPR_TYPE_KEYNAME, sizeof(ExprKeyName));
     if (!expr)
         return NULL;
     expr->key_name.key_name = key_name;
@@ -122,9 +123,9 @@ ExprCreateKeyName(xkb_atom_t key_name)
 }
 
 ExprDef *
-ExprCreateIdent(xkb_atom_t ident)
+ExprCreateIdent(struct bump *bump, xkb_atom_t ident)
 {
-    ExprDef *expr = ExprCreate(EXPR_IDENT, EXPR_TYPE_UNKNOWN, sizeof(ExprIdent));
+    ExprDef *expr = ExprCreate(bump, EXPR_IDENT, EXPR_TYPE_UNKNOWN, sizeof(ExprIdent));
     if (!expr)
         return NULL;
     expr->ident.ident = ident;
@@ -132,10 +133,10 @@ ExprCreateIdent(xkb_atom_t ident)
 }
 
 ExprDef *
-ExprCreateUnary(enum expr_op_type op, enum expr_value_type type,
+ExprCreateUnary(struct bump *bump, enum expr_op_type op, enum expr_value_type type,
                 ExprDef *child)
 {
-    ExprDef *expr = ExprCreate(op, type, sizeof(ExprUnary));
+    ExprDef *expr = ExprCreate(bump, op, type, sizeof(ExprUnary));
     if (!expr)
         return NULL;
     expr->unary.child = child;
@@ -143,9 +144,9 @@ ExprCreateUnary(enum expr_op_type op, enum expr_value_type type,
 }
 
 ExprDef *
-ExprCreateBinary(enum expr_op_type op, ExprDef *left, ExprDef *right)
+ExprCreateBinary(struct bump *bump, enum expr_op_type op, ExprDef *left, ExprDef *right)
 {
-    ExprDef *expr = ExprCreate(op, EXPR_TYPE_UNKNOWN, sizeof(ExprBinary));
+    ExprDef *expr = ExprCreate(bump, op, EXPR_TYPE_UNKNOWN, sizeof(ExprBinary));
     if (!expr)
         return NULL;
 
@@ -161,9 +162,9 @@ ExprCreateBinary(enum expr_op_type op, ExprDef *left, ExprDef *right)
 }
 
 ExprDef *
-ExprCreateFieldRef(xkb_atom_t element, xkb_atom_t field)
+ExprCreateFieldRef(struct bump *bump, xkb_atom_t element, xkb_atom_t field)
 {
-    ExprDef *expr = ExprCreate(EXPR_FIELD_REF, EXPR_TYPE_UNKNOWN, sizeof(ExprFieldRef));
+    ExprDef *expr = ExprCreate(bump, EXPR_FIELD_REF, EXPR_TYPE_UNKNOWN, sizeof(ExprFieldRef));
     if (!expr)
         return NULL;
     expr->field_ref.element = element;
@@ -172,9 +173,9 @@ ExprCreateFieldRef(xkb_atom_t element, xkb_atom_t field)
 }
 
 ExprDef *
-ExprCreateArrayRef(xkb_atom_t element, xkb_atom_t field, ExprDef *entry)
+ExprCreateArrayRef(struct bump *bump, xkb_atom_t element, xkb_atom_t field, ExprDef *entry)
 {
-    ExprDef *expr = ExprCreate(EXPR_ARRAY_REF, EXPR_TYPE_UNKNOWN, sizeof(ExprArrayRef));
+    ExprDef *expr = ExprCreate(bump, EXPR_ARRAY_REF, EXPR_TYPE_UNKNOWN, sizeof(ExprArrayRef));
     if (!expr)
         return NULL;
     expr->array_ref.element = element;
@@ -184,15 +185,15 @@ ExprCreateArrayRef(xkb_atom_t element, xkb_atom_t field, ExprDef *entry)
 }
 
 ExprDef *
-ExprEmptyList(void)
+ExprEmptyList(struct bump *bump)
 {
-    return ExprCreate(EXPR_EMPTY_LIST, EXPR_TYPE_UNKNOWN, sizeof(ExprCommon));
+    return ExprCreate(bump, EXPR_EMPTY_LIST, EXPR_TYPE_UNKNOWN, sizeof(ExprCommon));
 }
 
 ExprDef *
-ExprCreateAction(xkb_atom_t name, ExprDef *args)
+ExprCreateAction(struct bump *bump, xkb_atom_t name, ExprDef *args)
 {
-    ExprDef *expr = ExprCreate(EXPR_ACTION_DECL, EXPR_TYPE_UNKNOWN, sizeof(ExprAction));
+    ExprDef *expr = ExprCreate(bump, EXPR_ACTION_DECL, EXPR_TYPE_UNKNOWN, sizeof(ExprAction));
     if (!expr)
         return NULL;
     expr->action.name = name;
@@ -201,9 +202,9 @@ ExprCreateAction(xkb_atom_t name, ExprDef *args)
 }
 
 ExprDef *
-ExprCreateActionList(ExprDef *actions)
+ExprCreateActionList(struct bump *bump, ExprDef *actions)
 {
-    ExprDef *expr = ExprCreate(EXPR_ACTION_LIST, EXPR_TYPE_ACTIONS, sizeof(ExprActionList));
+    ExprDef *expr = ExprCreate(bump, EXPR_ACTION_LIST, EXPR_TYPE_ACTIONS, sizeof(ExprActionList));
     if (!expr)
         return NULL;
     expr->actions.actions = actions;
@@ -211,14 +212,13 @@ ExprCreateActionList(ExprDef *actions)
 }
 
 ExprDef *
-ExprCreateKeysymList(xkb_keysym_t sym)
+ExprCreateKeysymList(struct bump *bump, xkb_keysym_t sym)
 {
-    ExprDef *expr = ExprCreate(EXPR_KEYSYM_LIST, EXPR_TYPE_SYMBOLS, sizeof(ExprKeysymList));
+    ExprDef *expr = ExprCreate(bump, EXPR_KEYSYM_LIST, EXPR_TYPE_SYMBOLS, sizeof(ExprKeysymList));
     if (!expr)
         return NULL;
-    expr->keysym_list.syms = malloc(sizeof(*expr->keysym_list.syms));
+    expr->keysym_list.syms = bump_alloc(bump, sizeof(*expr->keysym_list.syms));
     if (!expr->keysym_list.syms) {
-        FreeStmt(&expr->common);
         return NULL;
     }
     expr->keysym_list.num_syms = 1;
@@ -227,18 +227,21 @@ ExprCreateKeysymList(xkb_keysym_t sym)
 }
 
 ExprDef *
-ExprAppendKeysymList(ExprDef *expr, xkb_keysym_t sym)
+ExprAppendKeysymList(struct bump *bump, ExprDef *expr, xkb_keysym_t sym)
 {
     ExprKeysymList *kl = &expr->keysym_list;
-    kl->syms = realloc(kl->syms, (kl->num_syms + 1) * sizeof(*kl->syms));
+    xkb_keysym_t *old = kl->syms;
+    kl->syms = bump_alloc(bump, (kl->num_syms + 1) * sizeof(*kl->syms));
+    for (unsigned i = 0; i < kl->num_syms; i++)
+        kl->syms[i] = old[i];
     kl->syms[kl->num_syms++] = sym;
     return expr;
 }
 
 KeycodeDef *
-KeycodeCreate(xkb_atom_t name, int64_t value)
+KeycodeCreate(struct bump *bump, xkb_atom_t name, int64_t value)
 {
-    KeycodeDef *def = malloc(sizeof(*def));
+    KeycodeDef *def = bump_alloc(bump, sizeof(*def));
     if (!def)
         return NULL;
 
@@ -251,9 +254,9 @@ KeycodeCreate(xkb_atom_t name, int64_t value)
 }
 
 KeyAliasDef *
-KeyAliasCreate(xkb_atom_t alias, xkb_atom_t real)
+KeyAliasCreate(struct bump *bump, xkb_atom_t alias, xkb_atom_t real)
 {
-    KeyAliasDef *def = malloc(sizeof(*def));
+    KeyAliasDef *def = bump_alloc(bump, sizeof(*def));
     if (!def)
         return NULL;
 
@@ -266,9 +269,9 @@ KeyAliasCreate(xkb_atom_t alias, xkb_atom_t real)
 }
 
 VModDef *
-VModCreate(xkb_atom_t name, ExprDef *value)
+VModCreate(struct bump *bump, xkb_atom_t name, ExprDef *value)
 {
-    VModDef *def = malloc(sizeof(*def));
+    VModDef *def = bump_alloc(bump, sizeof(*def));
     if (!def)
         return NULL;
 
@@ -281,9 +284,9 @@ VModCreate(xkb_atom_t name, ExprDef *value)
 }
 
 VarDef *
-VarCreate(ExprDef *name, ExprDef *value)
+VarCreate(struct bump *bump, ExprDef *name, ExprDef *value)
 {
-    VarDef *def = malloc(sizeof(*def));
+    VarDef *def = bump_alloc(bump, sizeof(*def));
     if (!def)
         return NULL;
 
@@ -296,29 +299,26 @@ VarCreate(ExprDef *name, ExprDef *value)
 }
 
 VarDef *
-BoolVarCreate(xkb_atom_t ident, bool set)
+BoolVarCreate(struct bump *bump, xkb_atom_t ident, bool set)
 {
     ExprDef *name, *value;
     VarDef *def;
-    if (!(name = ExprCreateIdent(ident))) {
+    if (!(name = ExprCreateIdent(bump, ident))) {
         return NULL;
     }
-    if (!(value = ExprCreateBoolean(set))) {
-        FreeStmt((ParseCommon *) name);
+    if (!(value = ExprCreateBoolean(bump, set))) {
         return NULL;
     }
-    if (!(def = VarCreate(name, value))) {
-        FreeStmt((ParseCommon *) name);
-        FreeStmt((ParseCommon *) value);
+    if (!(def = VarCreate(bump, name, value))) {
         return NULL;
     }
     return def;
 }
 
 InterpDef *
-InterpCreate(xkb_keysym_t sym, ExprDef *match)
+InterpCreate(struct bump *bump, xkb_keysym_t sym, ExprDef *match)
 {
-    InterpDef *def = malloc(sizeof(*def));
+    InterpDef *def = bump_alloc(bump, sizeof(*def));
     if (!def)
         return NULL;
 
@@ -332,9 +332,9 @@ InterpCreate(xkb_keysym_t sym, ExprDef *match)
 }
 
 KeyTypeDef *
-KeyTypeCreate(xkb_atom_t name, VarDef *body)
+KeyTypeCreate(struct bump *bump, xkb_atom_t name, VarDef *body)
 {
-    KeyTypeDef *def = malloc(sizeof(*def));
+    KeyTypeDef *def = bump_alloc(bump, sizeof(*def));
     if (!def)
         return NULL;
 
@@ -348,9 +348,9 @@ KeyTypeCreate(xkb_atom_t name, VarDef *body)
 }
 
 SymbolsDef *
-SymbolsCreate(xkb_atom_t keyName, VarDef *symbols)
+SymbolsCreate(struct bump *bump, xkb_atom_t keyName, VarDef *symbols)
 {
-    SymbolsDef *def = malloc(sizeof(*def));
+    SymbolsDef *def = bump_alloc(bump, sizeof(*def));
     if (!def)
         return NULL;
 
@@ -364,9 +364,9 @@ SymbolsCreate(xkb_atom_t keyName, VarDef *symbols)
 }
 
 GroupCompatDef *
-GroupCompatCreate(unsigned group, ExprDef *val)
+GroupCompatCreate(struct bump *bump, unsigned group, ExprDef *val)
 {
-    GroupCompatDef *def = malloc(sizeof(*def));
+    GroupCompatDef *def = bump_alloc(bump, sizeof(*def));
     if (!def)
         return NULL;
 
@@ -380,9 +380,9 @@ GroupCompatCreate(unsigned group, ExprDef *val)
 }
 
 ModMapDef *
-ModMapCreate(xkb_atom_t modifier, ExprDef *keys)
+ModMapCreate(struct bump *bump, xkb_atom_t modifier, ExprDef *keys)
 {
-    ModMapDef *def = malloc(sizeof(*def));
+    ModMapDef *def = bump_alloc(bump, sizeof(*def));
     if (!def)
         return NULL;
 
@@ -396,9 +396,9 @@ ModMapCreate(xkb_atom_t modifier, ExprDef *keys)
 }
 
 LedMapDef *
-LedMapCreate(xkb_atom_t name, VarDef *body)
+LedMapCreate(struct bump *bump, xkb_atom_t name, VarDef *body)
 {
-    LedMapDef *def = malloc(sizeof(*def));
+    LedMapDef *def = bump_alloc(bump, sizeof(*def));
     if (!def)
         return NULL;
 
@@ -412,9 +412,9 @@ LedMapCreate(xkb_atom_t name, VarDef *body)
 }
 
 LedNameDef *
-LedNameCreate(unsigned ndx, ExprDef *name, bool virtual)
+LedNameCreate(struct bump *bump, unsigned ndx, ExprDef *name, bool virtual)
 {
-    LedNameDef *def = malloc(sizeof(*def));
+    LedNameDef *def = bump_alloc(bump, sizeof(*def));
     if (!def)
         return NULL;
 
@@ -428,11 +428,8 @@ LedNameCreate(unsigned ndx, ExprDef *name, bool virtual)
     return def;
 }
 
-static void
-FreeInclude(IncludeStmt *incl);
-
 IncludeStmt *
-IncludeCreate(struct xkb_context *ctx, char *str, enum merge_mode merge)
+IncludeCreate(struct bump *bump, struct xkb_context *ctx, char *str, enum merge_mode merge)
 {
     IncludeStmt *incl, *first;
     char *stmt, *tmp;
@@ -440,12 +437,12 @@ IncludeCreate(struct xkb_context *ctx, char *str, enum merge_mode merge)
 
     incl = first = NULL;
     tmp = str;
-    stmt = strdup_safe(str);
+    stmt = str ? bump_strdup(bump, str) : NULL;
     while (tmp && *tmp)
     {
         char *file = NULL, *map = NULL, *extra_data = NULL;
 
-        if (!ParseIncludeMap(&tmp, &file, &map, &nextop, &extra_data))
+        if (!ParseIncludeMap(bump, &tmp, &file, &map, &nextop, &extra_data))
             goto err;
 
         /*
@@ -455,23 +452,17 @@ IncludeCreate(struct xkb_context *ctx, char *str, enum merge_mode merge)
          * appropriate section to deal with the empty group.
          */
         if (isempty(file)) {
-            free(file);
-            free(map);
-            free(extra_data);
             continue;
         }
 
         if (first == NULL) {
-            first = incl = malloc(sizeof(*first));
+            first = incl = bump_alloc(bump, sizeof(*first));
         } else {
-            incl->next_incl = malloc(sizeof(*first));
+            incl->next_incl = bump_alloc(bump, sizeof(*first));
             incl = incl->next_incl;
         }
 
         if (!incl) {
-            free(file);
-            free(map);
-            free(extra_data);
             break;
         }
 
@@ -492,32 +483,34 @@ IncludeCreate(struct xkb_context *ctx, char *str, enum merge_mode merge)
 
     if (first)
         first->stmt = stmt;
-    else
-        free(stmt);
 
     return first;
 
 err:
     log_err(ctx, XKB_ERROR_INVALID_INCLUDE_STATEMENT,
             "Illegal include statement \"%s\"; Ignored\n", stmt);
-    FreeInclude(first);
-    free(stmt);
     return NULL;
 }
 
 XkbFile *
-XkbFileCreate(enum xkb_file_type type, char *name, ParseCommon *defs,
-              enum xkb_map_flags flags)
+XkbFileCreate(struct bump *bump, enum xkb_file_type type, char *name,
+              ParseCommon *defs, enum xkb_map_flags flags)
 {
     XkbFile *file;
 
-    file = calloc(1, sizeof(*file));
+    file = bump_alloc(bump, sizeof(*file));
     if (!file)
         return NULL;
+    memset(file, 0, sizeof(*file));
 
     XkbEscapeMapName(name);
+    file->bump = bump;
     file->file_type = type;
-    file->name = name ? name : strdup("(unnamed)");
+    if (name) {
+        file->name = name;
+    } else {
+        file->name = bump_strdup(bump, "(unnamed)");
+    }
     file->defs = defs;
     file->flags = flags;
 
@@ -525,7 +518,7 @@ XkbFileCreate(enum xkb_file_type type, char *name, ParseCommon *defs,
 }
 
 XkbFile *
-XkbFileFromComponents(struct xkb_context *ctx,
+XkbFileFromComponents(struct bump *bump, struct xkb_context *ctx,
                       const struct xkb_component_names *kkctgs)
 {
     char *const components[] = {
@@ -538,13 +531,12 @@ XkbFileFromComponents(struct xkb_context *ctx,
     ParseCommon *defs = NULL, *defsLast = NULL;
 
     for (type = FIRST_KEYMAP_FILE_TYPE; type <= LAST_KEYMAP_FILE_TYPE; type++) {
-        include = IncludeCreate(ctx, components[type], MERGE_DEFAULT);
+        include = IncludeCreate(bump, ctx, components[type], MERGE_DEFAULT);
         if (!include)
             goto err;
 
-        file = XkbFileCreate(type, NULL, (ParseCommon *) include, 0);
+        file = XkbFileCreate(bump, type, NULL, (ParseCommon *) include, 0);
         if (!file) {
-            FreeInclude(include);
             goto err;
         }
 
@@ -554,166 +546,14 @@ XkbFileFromComponents(struct xkb_context *ctx,
             defsLast = defsLast->next = &file->common;
     }
 
-    file = XkbFileCreate(FILE_TYPE_KEYMAP, NULL, defs, 0);
+    file = XkbFileCreate(bump, FILE_TYPE_KEYMAP, NULL, defs, 0);
     if (!file)
         goto err;
 
     return file;
 
 err:
-    FreeXkbFile((XkbFile *) defs);
     return NULL;
-}
-
-static void
-FreeExpr(ExprDef *expr)
-{
-    if (!expr)
-        return;
-
-    switch (expr->expr.op) {
-    case EXPR_NEGATE:
-    case EXPR_UNARY_PLUS:
-    case EXPR_NOT:
-    case EXPR_INVERT:
-        FreeStmt((ParseCommon *) expr->unary.child);
-        break;
-
-    case EXPR_DIVIDE:
-    case EXPR_ADD:
-    case EXPR_SUBTRACT:
-    case EXPR_MULTIPLY:
-    case EXPR_ASSIGN:
-        FreeStmt((ParseCommon *) expr->binary.left);
-        FreeStmt((ParseCommon *) expr->binary.right);
-        break;
-
-    case EXPR_ACTION_DECL:
-        FreeStmt((ParseCommon *) expr->action.args);
-        break;
-
-    case EXPR_ACTION_LIST:
-        FreeStmt((ParseCommon *) expr->actions.actions);
-        break;
-
-    case EXPR_ARRAY_REF:
-        FreeStmt((ParseCommon *) expr->array_ref.entry);
-        break;
-
-    case EXPR_KEYSYM_LIST:
-        free(expr->keysym_list.syms);
-        break;
-
-    default:
-        break;
-    }
-}
-
-static void
-FreeInclude(IncludeStmt *incl)
-{
-    IncludeStmt *next;
-
-    while (incl)
-    {
-        next = incl->next_incl;
-
-        free(incl->file);
-        free(incl->map);
-        free(incl->modifier);
-        free(incl->stmt);
-
-        free(incl);
-        incl = next;
-    }
-}
-
-void
-FreeStmt(ParseCommon *stmt)
-{
-    ParseCommon *next;
-
-    while (stmt)
-    {
-        next = stmt->next;
-
-        switch (stmt->type) {
-        case STMT_INCLUDE:
-            FreeInclude((IncludeStmt *) stmt);
-            /* stmt is already free'd here. */
-            stmt = NULL;
-            break;
-        case STMT_EXPR:
-            FreeExpr((ExprDef *) stmt);
-            break;
-        case STMT_VAR:
-            FreeStmt((ParseCommon *) ((VarDef *) stmt)->name);
-            FreeStmt((ParseCommon *) ((VarDef *) stmt)->value);
-            break;
-        case STMT_TYPE:
-            FreeStmt((ParseCommon *) ((KeyTypeDef *) stmt)->body);
-            break;
-        case STMT_INTERP:
-            FreeStmt((ParseCommon *) ((InterpDef *) stmt)->match);
-            FreeStmt((ParseCommon *) ((InterpDef *) stmt)->def);
-            break;
-        case STMT_VMOD:
-            FreeStmt((ParseCommon *) ((VModDef *) stmt)->value);
-            break;
-        case STMT_SYMBOLS:
-            FreeStmt((ParseCommon *) ((SymbolsDef *) stmt)->symbols);
-            break;
-        case STMT_MODMAP:
-            FreeStmt((ParseCommon *) ((ModMapDef *) stmt)->keys);
-            break;
-        case STMT_GROUP_COMPAT:
-            FreeStmt((ParseCommon *) ((GroupCompatDef *) stmt)->def);
-            break;
-        case STMT_LED_MAP:
-            FreeStmt((ParseCommon *) ((LedMapDef *) stmt)->body);
-            break;
-        case STMT_LED_NAME:
-            FreeStmt((ParseCommon *) ((LedNameDef *) stmt)->name);
-            break;
-        default:
-            break;
-        }
-
-        free(stmt);
-        stmt = next;
-    }
-}
-
-void
-FreeXkbFile(XkbFile *file)
-{
-    XkbFile *next;
-
-    while (file)
-    {
-        next = (XkbFile *) file->common.next;
-
-        switch (file->file_type) {
-        case FILE_TYPE_KEYMAP:
-            FreeXkbFile((XkbFile *) file->defs);
-            break;
-
-        case FILE_TYPE_TYPES:
-        case FILE_TYPE_COMPAT:
-        case FILE_TYPE_SYMBOLS:
-        case FILE_TYPE_KEYCODES:
-        case FILE_TYPE_GEOMETRY:
-            FreeStmt(file->defs);
-            break;
-
-        default:
-            break;
-        }
-
-        free(file->name);
-        free(file);
-        file = next;
-    }
 }
 
 static const char *xkb_file_type_strings[_FILE_TYPE_NUM_ENTRIES] = {

--- a/src/xkbcomp/ast-build.c
+++ b/src/xkbcomp/ast-build.c
@@ -54,6 +54,7 @@
 #include "bump.h"
 #include "config.h"
 
+#include "xkbcommon/xkbcommon.h"
 #include "xkbcomp-priv.h"
 #include "ast-build.h"
 #include "include.h"
@@ -61,7 +62,7 @@
 static ExprDef *
 ExprCreate(struct bump *bump, enum expr_op_type op, enum expr_value_type type, size_t size)
 {
-    ExprDef *expr = bump_aligned_alloc(bump, alignof(*expr), size);
+    ExprDef *expr = bump_aligned_alloc(bump, alignof(ExprDef), size);
     if (!expr)
         return NULL;
 
@@ -231,7 +232,7 @@ ExprAppendKeysymList(struct bump *bump, ExprDef *expr, xkb_keysym_t sym)
 {
     ExprKeysymList *kl = &expr->keysym_list;
     xkb_keysym_t *old = kl->syms;
-    kl->syms = bump_aligned_alloc(bump, alignof(*kl->syms), (kl->num_syms + 1) * sizeof(*kl->syms));
+    kl->syms = bump_aligned_alloc(bump, alignof(xkb_keysym_t), (kl->num_syms + 1) * sizeof(*kl->syms));
     for (unsigned i = 0; i < kl->num_syms; i++)
         kl->syms[i] = old[i];
     kl->syms[kl->num_syms++] = sym;

--- a/src/xkbcomp/ast-build.c
+++ b/src/xkbcomp/ast-build.c
@@ -61,7 +61,7 @@
 static ExprDef *
 ExprCreate(struct bump *bump, enum expr_op_type op, enum expr_value_type type, size_t size)
 {
-    ExprDef *expr = bump_alloc(bump, size);
+    ExprDef *expr = bump_aligned_alloc(bump, alignof(*expr), size);
     if (!expr)
         return NULL;
 
@@ -217,7 +217,7 @@ ExprCreateKeysymList(struct bump *bump, xkb_keysym_t sym)
     ExprDef *expr = ExprCreate(bump, EXPR_KEYSYM_LIST, EXPR_TYPE_SYMBOLS, sizeof(ExprKeysymList));
     if (!expr)
         return NULL;
-    expr->keysym_list.syms = bump_alloc(bump, sizeof(*expr->keysym_list.syms));
+    expr->keysym_list.syms = bump_alloc(bump, *expr->keysym_list.syms);
     if (!expr->keysym_list.syms) {
         return NULL;
     }
@@ -231,7 +231,7 @@ ExprAppendKeysymList(struct bump *bump, ExprDef *expr, xkb_keysym_t sym)
 {
     ExprKeysymList *kl = &expr->keysym_list;
     xkb_keysym_t *old = kl->syms;
-    kl->syms = bump_alloc(bump, (kl->num_syms + 1) * sizeof(*kl->syms));
+    kl->syms = bump_aligned_alloc(bump, alignof(*kl->syms), (kl->num_syms + 1) * sizeof(*kl->syms));
     for (unsigned i = 0; i < kl->num_syms; i++)
         kl->syms[i] = old[i];
     kl->syms[kl->num_syms++] = sym;
@@ -241,7 +241,7 @@ ExprAppendKeysymList(struct bump *bump, ExprDef *expr, xkb_keysym_t sym)
 KeycodeDef *
 KeycodeCreate(struct bump *bump, xkb_atom_t name, int64_t value)
 {
-    KeycodeDef *def = bump_alloc(bump, sizeof(*def));
+    KeycodeDef *def = bump_alloc(bump, *def);
     if (!def)
         return NULL;
 
@@ -256,7 +256,7 @@ KeycodeCreate(struct bump *bump, xkb_atom_t name, int64_t value)
 KeyAliasDef *
 KeyAliasCreate(struct bump *bump, xkb_atom_t alias, xkb_atom_t real)
 {
-    KeyAliasDef *def = bump_alloc(bump, sizeof(*def));
+    KeyAliasDef *def = bump_alloc(bump, *def);
     if (!def)
         return NULL;
 
@@ -271,7 +271,7 @@ KeyAliasCreate(struct bump *bump, xkb_atom_t alias, xkb_atom_t real)
 VModDef *
 VModCreate(struct bump *bump, xkb_atom_t name, ExprDef *value)
 {
-    VModDef *def = bump_alloc(bump, sizeof(*def));
+    VModDef *def = bump_alloc(bump, *def);
     if (!def)
         return NULL;
 
@@ -286,7 +286,7 @@ VModCreate(struct bump *bump, xkb_atom_t name, ExprDef *value)
 VarDef *
 VarCreate(struct bump *bump, ExprDef *name, ExprDef *value)
 {
-    VarDef *def = bump_alloc(bump, sizeof(*def));
+    VarDef *def = bump_alloc(bump, *def);
     if (!def)
         return NULL;
 
@@ -318,7 +318,7 @@ BoolVarCreate(struct bump *bump, xkb_atom_t ident, bool set)
 InterpDef *
 InterpCreate(struct bump *bump, xkb_keysym_t sym, ExprDef *match)
 {
-    InterpDef *def = bump_alloc(bump, sizeof(*def));
+    InterpDef *def = bump_alloc(bump, *def);
     if (!def)
         return NULL;
 
@@ -334,7 +334,7 @@ InterpCreate(struct bump *bump, xkb_keysym_t sym, ExprDef *match)
 KeyTypeDef *
 KeyTypeCreate(struct bump *bump, xkb_atom_t name, VarDef *body)
 {
-    KeyTypeDef *def = bump_alloc(bump, sizeof(*def));
+    KeyTypeDef *def = bump_alloc(bump, *def);
     if (!def)
         return NULL;
 
@@ -350,7 +350,7 @@ KeyTypeCreate(struct bump *bump, xkb_atom_t name, VarDef *body)
 SymbolsDef *
 SymbolsCreate(struct bump *bump, xkb_atom_t keyName, VarDef *symbols)
 {
-    SymbolsDef *def = bump_alloc(bump, sizeof(*def));
+    SymbolsDef *def = bump_alloc(bump, *def);
     if (!def)
         return NULL;
 
@@ -366,7 +366,7 @@ SymbolsCreate(struct bump *bump, xkb_atom_t keyName, VarDef *symbols)
 GroupCompatDef *
 GroupCompatCreate(struct bump *bump, unsigned group, ExprDef *val)
 {
-    GroupCompatDef *def = bump_alloc(bump, sizeof(*def));
+    GroupCompatDef *def = bump_alloc(bump, *def);
     if (!def)
         return NULL;
 
@@ -382,7 +382,7 @@ GroupCompatCreate(struct bump *bump, unsigned group, ExprDef *val)
 ModMapDef *
 ModMapCreate(struct bump *bump, xkb_atom_t modifier, ExprDef *keys)
 {
-    ModMapDef *def = bump_alloc(bump, sizeof(*def));
+    ModMapDef *def = bump_alloc(bump, *def);
     if (!def)
         return NULL;
 
@@ -398,7 +398,7 @@ ModMapCreate(struct bump *bump, xkb_atom_t modifier, ExprDef *keys)
 LedMapDef *
 LedMapCreate(struct bump *bump, xkb_atom_t name, VarDef *body)
 {
-    LedMapDef *def = bump_alloc(bump, sizeof(*def));
+    LedMapDef *def = bump_alloc(bump, *def);
     if (!def)
         return NULL;
 
@@ -414,7 +414,7 @@ LedMapCreate(struct bump *bump, xkb_atom_t name, VarDef *body)
 LedNameDef *
 LedNameCreate(struct bump *bump, unsigned ndx, ExprDef *name, bool virtual)
 {
-    LedNameDef *def = bump_alloc(bump, sizeof(*def));
+    LedNameDef *def = bump_alloc(bump, *def);
     if (!def)
         return NULL;
 
@@ -456,9 +456,9 @@ IncludeCreate(struct bump *bump, struct xkb_context *ctx, char *str, enum merge_
         }
 
         if (first == NULL) {
-            first = incl = bump_alloc(bump, sizeof(*first));
+            first = incl = bump_alloc(bump, *first);
         } else {
-            incl->next_incl = bump_alloc(bump, sizeof(*first));
+            incl->next_incl = bump_alloc(bump, *first);
             incl = incl->next_incl;
         }
 
@@ -498,7 +498,7 @@ XkbFileCreate(struct bump *bump, enum xkb_file_type type, char *name,
 {
     XkbFile *file;
 
-    file = bump_alloc(bump, sizeof(*file));
+    file = bump_alloc(bump, *file);
     if (!file)
         return NULL;
     memset(file, 0, sizeof(*file));

--- a/src/xkbcomp/ast-build.c
+++ b/src/xkbcomp/ast-build.c
@@ -216,15 +216,22 @@ ExprCreateKeysymList(xkb_keysym_t sym)
     ExprDef *expr = ExprCreate(EXPR_KEYSYM_LIST, EXPR_TYPE_SYMBOLS, sizeof(ExprKeysymList));
     if (!expr)
         return NULL;
-    darray_init(expr->keysym_list.syms);
-    darray_append(expr->keysym_list.syms, sym);
+    expr->keysym_list.syms = malloc(sizeof(*expr->keysym_list.syms));
+    if (!expr->keysym_list.syms) {
+        FreeStmt(&expr->common);
+        return NULL;
+    }
+    expr->keysym_list.num_syms = 1;
+    expr->keysym_list.syms[0] = sym;
     return expr;
 }
 
 ExprDef *
 ExprAppendKeysymList(ExprDef *expr, xkb_keysym_t sym)
 {
-    darray_append(expr->keysym_list.syms, sym);
+    ExprKeysymList *kl = &expr->keysym_list;
+    kl->syms = realloc(kl->syms, (kl->num_syms + 1) * sizeof(*kl->syms));
+    kl->syms[kl->num_syms++] = sym;
     return expr;
 }
 
@@ -594,7 +601,7 @@ FreeExpr(ExprDef *expr)
         break;
 
     case EXPR_KEYSYM_LIST:
-        darray_free(expr->keysym_list.syms);
+        free(expr->keysym_list.syms);
         break;
 
     default:

--- a/src/xkbcomp/ast-build.h
+++ b/src/xkbcomp/ast-build.h
@@ -27,98 +27,97 @@
 #ifndef XKBCOMP_AST_BUILD_H
 #define XKBCOMP_AST_BUILD_H
 
+#include "bump.h"
 #include "ast.h"
 
 ExprDef *
-ExprCreateString(xkb_atom_t str);
+ExprCreateString(struct bump *bump, xkb_atom_t str);
 
 ExprDef *
-ExprCreateInteger(int ival);
+ExprCreateInteger(struct bump *bump, int ival);
 
 ExprDef *
-ExprCreateFloat(void);
+ExprCreateFloat(struct bump *bump);
 
 ExprDef *
-ExprCreateBoolean(bool set);
+ExprCreateBoolean(struct bump *bump, bool set);
 
 ExprDef *
-ExprCreateKeyName(xkb_atom_t key_name);
+ExprCreateKeyName(struct bump *bump, xkb_atom_t key_name);
 
 ExprDef *
-ExprCreateIdent(xkb_atom_t ident);
+ExprCreateIdent(struct bump *bump, xkb_atom_t ident);
 
 ExprDef *
-ExprCreateUnary(enum expr_op_type op, enum expr_value_type type,
+ExprCreateUnary(struct bump *bump, enum expr_op_type op, enum expr_value_type type,
                 ExprDef *child);
 
 ExprDef *
-ExprCreateBinary(enum expr_op_type op, ExprDef *left, ExprDef *right);
+ExprCreateBinary(struct bump *bump, enum expr_op_type op, ExprDef *left, ExprDef *right);
 
 ExprDef *
-ExprCreateFieldRef(xkb_atom_t element, xkb_atom_t field);
+ExprCreateFieldRef(struct bump *bump, xkb_atom_t element, xkb_atom_t field);
 
 ExprDef *
-ExprCreateArrayRef(xkb_atom_t element, xkb_atom_t field, ExprDef *entry);
+ExprCreateArrayRef(struct bump *bump, xkb_atom_t element, xkb_atom_t field, ExprDef *entry);
 
 ExprDef *
-ExprEmptyList(void);
+ExprEmptyList(struct bump *bump);
 
 ExprDef *
-ExprCreateAction(xkb_atom_t name, ExprDef *args);
+ExprCreateAction(struct bump *bump, xkb_atom_t name, ExprDef *args);
 
 ExprDef *
-ExprCreateActionList(ExprDef *actions);
+ExprCreateActionList(struct bump *bump, ExprDef *actions);
 
 ExprDef *
-ExprCreateKeysymList(xkb_keysym_t sym);
+ExprCreateKeysymList(struct bump *bump, xkb_keysym_t sym);
 
 ExprDef *
-ExprAppendKeysymList(ExprDef *list, xkb_keysym_t sym);
+ExprAppendKeysymList(struct bump *bump, ExprDef *list, xkb_keysym_t sym);
 
 KeycodeDef *
-KeycodeCreate(xkb_atom_t name, int64_t value);
+KeycodeCreate(struct bump *bump, xkb_atom_t name, int64_t value);
 
 KeyAliasDef *
-KeyAliasCreate(xkb_atom_t alias, xkb_atom_t real);
+KeyAliasCreate(struct bump *bump, xkb_atom_t alias, xkb_atom_t real);
 
 VModDef *
-VModCreate(xkb_atom_t name, ExprDef *value);
+VModCreate(struct bump *bump, xkb_atom_t name, ExprDef *value);
 
 VarDef *
-VarCreate(ExprDef *name, ExprDef *value);
+VarCreate(struct bump *bump, ExprDef *name, ExprDef *value);
 
 VarDef *
-BoolVarCreate(xkb_atom_t ident, bool set);
+BoolVarCreate(struct bump *bump, xkb_atom_t ident, bool set);
 
 InterpDef *
-InterpCreate(xkb_keysym_t sym, ExprDef *match);
+InterpCreate(struct bump *bump, xkb_keysym_t sym, ExprDef *match);
 
 KeyTypeDef *
-KeyTypeCreate(xkb_atom_t name, VarDef *body);
+KeyTypeCreate(struct bump *bump, xkb_atom_t name, VarDef *body);
 
 SymbolsDef *
-SymbolsCreate(xkb_atom_t keyName, VarDef *symbols);
+SymbolsCreate(struct bump *bump, xkb_atom_t keyName, VarDef *symbols);
 
 GroupCompatDef *
-GroupCompatCreate(unsigned group, ExprDef *def);
+GroupCompatCreate(struct bump *bump, unsigned group, ExprDef *def);
 
 ModMapDef *
-ModMapCreate(xkb_atom_t modifier, ExprDef *keys);
+ModMapCreate(struct bump *bump, xkb_atom_t modifier, ExprDef *keys);
 
 LedMapDef *
-LedMapCreate(xkb_atom_t name, VarDef *body);
+LedMapCreate(struct bump *bump, xkb_atom_t name, VarDef *body);
 
 LedNameDef *
-LedNameCreate(unsigned ndx, ExprDef *name, bool virtual);
+LedNameCreate(struct bump *bump, unsigned ndx, ExprDef *name, bool virtual);
 
 IncludeStmt *
-IncludeCreate(struct xkb_context *ctx, char *str, enum merge_mode merge);
+IncludeCreate(struct bump *bump, struct xkb_context *ctx, char *str,
+              enum merge_mode merge);
 
 XkbFile *
-XkbFileCreate(enum xkb_file_type type, char *name, ParseCommon *defs,
-              enum xkb_map_flags flags);
-
-void
-FreeStmt(ParseCommon *stmt);
+XkbFileCreate(struct bump *bump, enum xkb_file_type type, char *name,
+              ParseCommon *defs, enum xkb_map_flags flags);
 
 #endif

--- a/src/xkbcomp/ast-build.h
+++ b/src/xkbcomp/ast-build.h
@@ -70,13 +70,7 @@ ExprDef *
 ExprCreateActionList(ExprDef *actions);
 
 ExprDef *
-ExprCreateMultiKeysymList(ExprDef *list);
-
-ExprDef *
 ExprCreateKeysymList(xkb_keysym_t sym);
-
-ExprDef *
-ExprAppendMultiKeysymList(ExprDef *list, ExprDef *append);
 
 ExprDef *
 ExprAppendKeysymList(ExprDef *list, xkb_keysym_t sym);

--- a/src/xkbcomp/ast-build.h
+++ b/src/xkbcomp/ast-build.h
@@ -70,15 +70,6 @@ ExprDef *
 ExprCreateActionList(ExprDef *actions);
 
 ExprDef *
-ExprCreateMultiActionList(ExprDef *expr);
-
-ExprDef *
-ExprAppendActionList(ExprDef *expr, ExprDef *action);
-
-ExprDef *
-ExprAppendMultiActionList(ExprDef *expr, ExprDef *append);
-
-ExprDef *
 ExprCreateMultiKeysymList(ExprDef *list);
 
 ExprDef *

--- a/src/xkbcomp/ast.h
+++ b/src/xkbcomp/ast.h
@@ -53,7 +53,6 @@
 #include "xkbcommon/xkbcommon.h"
 
 #include "atom.h"
-#include "darray.h"
 
 enum xkb_file_type {
     /* Component files, by order of compilation. */
@@ -245,7 +244,8 @@ typedef struct {
 typedef struct {
     ExprCommon expr;
     /* List of keysym for a single level. */
-    darray(xkb_keysym_t) syms;
+    uint32_t num_syms;
+    xkb_keysym_t *syms;
 } ExprKeysymList;
 
 union ExprDef {

--- a/src/xkbcomp/ast.h
+++ b/src/xkbcomp/ast.h
@@ -358,6 +358,7 @@ enum xkb_map_flags {
 
 typedef struct {
     ParseCommon common;
+    struct bump *bump;
     enum xkb_file_type file_type;
     char *name;
     ParseCommon *defs;

--- a/src/xkbcomp/ast.h
+++ b/src/xkbcomp/ast.h
@@ -244,12 +244,8 @@ typedef struct {
 
 typedef struct {
     ExprCommon expr;
-    /* List of keysym for all levels, flattened */
+    /* List of keysym for a single level. */
     darray(xkb_keysym_t) syms;
-    /* List of start index in `syms`, per level */
-    darray(unsigned int) symsMapIndex;
-    /* List of number of keysyms, per level */
-    darray(unsigned int) symsNumEntries;
 } ExprKeysymList;
 
 union ExprDef {

--- a/src/xkbcomp/ast.h
+++ b/src/xkbcomp/ast.h
@@ -238,12 +238,8 @@ typedef struct {
 
 typedef struct {
     ExprCommon expr;
-    /* List of actions for all levels, flattened */
-    darray(ExprDef*) actions;
-    /* List of start index in `actions`, per level */
-    darray(unsigned int) actionsMapIndex;
-    /* List of number of actions, per level */
-    darray(unsigned int) actionsNumEntries;
+    /* List of actions for a single level. */
+    ExprDef *actions;
 } ExprActionList;
 
 typedef struct {

--- a/src/xkbcomp/include.h
+++ b/src/xkbcomp/include.h
@@ -28,6 +28,7 @@
 #define XKBCOMP_INCLUDE_H
 
 #include "ast.h"
+#include "bump.h"
 
 /* Reasonable threshold, with plenty of margin for keymaps in the wild */
 #define INCLUDE_MAX_DEPTH 15
@@ -39,8 +40,8 @@
     ((ch) == MERGE_OVERRIDE_PREFIX || (ch) == MERGE_AUGMENT_PREFIX)
 
 bool
-ParseIncludeMap(char **str_inout, char **file_rtrn, char **map_rtrn,
-                char *nextop_rtrn, char **extra_data);
+ParseIncludeMap(struct bump *bump, char **str_inout, char **file_rtrn,
+                char **map_rtrn, char *nextop_rtrn, char **extra_data);
 
 FILE *
 FindFileInXkbPath(struct xkb_context *ctx, const char *name,
@@ -51,7 +52,7 @@ bool
 ExceedsIncludeMaxDepth(struct xkb_context *ctx, unsigned int include_depth);
 
 XkbFile *
-ProcessIncludeFile(struct xkb_context *ctx, IncludeStmt *stmt,
-                   enum xkb_file_type file_type);
+ProcessIncludeFile(struct bump *bump, struct xkb_context *ctx,
+                   IncludeStmt *stmt, enum xkb_file_type file_type);
 
 #endif

--- a/src/xkbcomp/parser-priv.h
+++ b/src/xkbcomp/parser-priv.h
@@ -36,7 +36,7 @@ int
 _xkbcommon_lex(YYSTYPE *yylval, struct scanner *scanner);
 
 XkbFile *
-parse(struct xkb_context *ctx, struct scanner *scanner, const char *map);
+parse(struct bump *bump, struct xkb_context *ctx, struct scanner *scanner, const char *map);
 
 int
 keyword_to_token(const char *string, size_t len);

--- a/src/xkbcomp/parser-priv.h
+++ b/src/xkbcomp/parser-priv.h
@@ -33,7 +33,7 @@ struct scanner;
 #include "parser.h"
 
 int
-_xkbcommon_lex(YYSTYPE *yylval, struct scanner *scanner);
+_xkbcommon_lex(YYSTYPE *yylval, struct scanner *s, struct bump *bump);
 
 XkbFile *
 parse(struct bump *bump, struct xkb_context *ctx, struct scanner *scanner, const char *map);

--- a/src/xkbcomp/parser.y
+++ b/src/xkbcomp/parser.y
@@ -86,10 +86,11 @@ resolve_keysym(struct parser_param *param, const char *name, xkb_keysym_t *sym_r
 }
 
 #define param_scanner param->scanner
+#define param_bump param->bump
 %}
 
 %define api.pure
-%lex-param      { struct scanner *param_scanner }
+%lex-param      { struct scanner *param_scanner } { struct bump *param_bump }
 %parse-param    { struct parser_param *param }
 
 %token

--- a/src/xkbcomp/parser.y
+++ b/src/xkbcomp/parser.y
@@ -231,8 +231,6 @@ resolve_keysym(struct parser_param *param, const char *name, xkb_keysym_t *sym_r
 %type <fileList> XkbMapConfigList
 %type <file>    XkbCompositeMap
 
-%destructor { free($$); } <str>
-
 %%
 
 /*
@@ -390,7 +388,6 @@ Decl            :       OptMergeMode VarDecl
                 |       MergeMode STRING
                         {
                             $$ = (ParseCommon *) IncludeCreate(param->bump, param->ctx, $2, $1);
-                            free($2);
                         }
                 ;
 
@@ -763,7 +760,6 @@ KeySym          :       IDENT
                                 );
                                 $$ = XKB_KEY_NoSymbol;
                             }
-                            free($1);
                         }
                         /* Handle keysym that is also a keyword  */
                 |       SECTION { $$ = XKB_KEY_section; }
@@ -822,18 +818,18 @@ Integer         :       INTEGER { $$ = $1; }
 KeyCode         :       INTEGER { $$ = $1; }
                 ;
 
-Ident           :       IDENT   { $$ = xkb_atom_intern(param->ctx, $1, strlen($1)); free($1); }
+Ident           :       IDENT   { $$ = xkb_atom_intern(param->ctx, $1, strlen($1)); }
                 |       DEFAULT { $$ = xkb_atom_intern_literal(param->ctx, "default"); }
                 ;
 
-String          :       STRING  { $$ = xkb_atom_intern(param->ctx, $1, strlen($1)); free($1); }
+String          :       STRING  { $$ = xkb_atom_intern(param->ctx, $1, strlen($1)); }
                 ;
 
 OptMapName      :       MapName { $$ = $1; }
                 |               { $$ = NULL; }
                 ;
 
-MapName         :       STRING  { $$ = bump_strdup(param->bump, $1); free($1); }
+MapName         :       STRING  { $$ = bump_strdup(param->bump, $1); }
                 ;
 
 %%

--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -408,7 +408,7 @@ matcher_include(struct matcher *m, struct scanner *parent_scanner,
 {
     struct scanner s; /* parses the !include value */
 
-    scanner_init(&s, m->ctx, inc.start, inc.len,
+    scanner_init(&s, m->ctx, NULL, inc.start, inc.len,
                  parent_scanner->file_name, NULL);
     s.token_line = parent_scanner->token_line;
     s.token_column = parent_scanner->token_column;
@@ -1514,7 +1514,7 @@ read_rules_file(struct xkb_context *ctx,
         return false;
     }
 
-    scanner_init(&scanner, matcher->ctx, string, size, path, NULL);
+    scanner_init(&scanner, matcher->ctx, NULL, string, size, path, NULL);
 
     /* Basic detection of wrong character encoding.
        The first character relevant to the grammar must be ASCII:

--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -408,7 +408,7 @@ matcher_include(struct matcher *m, struct scanner *parent_scanner,
 {
     struct scanner s; /* parses the !include value */
 
-    scanner_init(&s, m->ctx, NULL, inc.start, inc.len,
+    scanner_init(&s, m->ctx, inc.start, inc.len,
                  parent_scanner->file_name, NULL);
     s.token_line = parent_scanner->token_line;
     s.token_column = parent_scanner->token_column;
@@ -1514,7 +1514,7 @@ read_rules_file(struct xkb_context *ctx,
         return false;
     }
 
-    scanner_init(&scanner, matcher->ctx, NULL, string, size, path, NULL);
+    scanner_init(&scanner, matcher->ctx, string, size, path, NULL);
 
     /* Basic detection of wrong character encoding.
        The first character relevant to the grammar must be ASCII:

--- a/src/xkbcomp/rules.h
+++ b/src/xkbcomp/rules.h
@@ -28,7 +28,7 @@
 
 #include "xkbcomp-priv.h"
 
-bool
+XKB_EXPORT_PRIVATE bool
 xkb_components_from_rules(struct xkb_context *ctx,
                           const struct xkb_rule_names *rmlvo,
                           struct xkb_component_names *out,

--- a/src/xkbcomp/scanner.c
+++ b/src/xkbcomp/scanner.c
@@ -23,6 +23,7 @@
 
 #include "config.h"
 
+#include "bump.h"
 #include "xkbcomp-priv.h"
 #include "parser-priv.h"
 #include "scanner-utils.h"
@@ -123,7 +124,7 @@ skip_more_whitespace_and_comments:
                         "unterminated string literal");
             return ERROR_TOK;
         }
-        yylval->str = strdup(s->buf);
+        yylval->str = s->bump ? bump_strdup(s->bump, s->buf) : strdup(s->buf);
         if (!yylval->str)
             return ERROR_TOK;
         return STRING;
@@ -176,7 +177,7 @@ skip_more_whitespace_and_comments:
         tok = keyword_to_token(s->buf, s->buf_pos - 1);
         if (tok != -1) return tok;
 
-        yylval->str = strdup(s->buf);
+        yylval->str = s->bump ? bump_strdup(s->bump, s->buf) : strdup(s->buf);
         if (!yylval->str)
             return ERROR_TOK;
         return IDENT;
@@ -203,7 +204,7 @@ XkbParseString(struct bump *bump, struct xkb_context *ctx,
                const char *file_name, const char *map)
 {
     struct scanner scanner;
-    scanner_init(&scanner, ctx, string, len, file_name, NULL);
+    scanner_init(&scanner, ctx, bump, string, len, file_name, NULL);
 
     /* Basic detection of wrong character encoding.
        The first character relevant to the grammar must be ASCII:

--- a/src/xkbcomp/scanner.c
+++ b/src/xkbcomp/scanner.c
@@ -198,7 +198,8 @@ skip_more_whitespace_and_comments:
 }
 
 XkbFile *
-XkbParseString(struct xkb_context *ctx, const char *string, size_t len,
+XkbParseString(struct bump *bump, struct xkb_context *ctx,
+               const char *string, size_t len,
                const char *file_name, const char *map)
 {
     struct scanner scanner;
@@ -217,11 +218,11 @@ XkbParseString(struct xkb_context *ctx, const char *string, size_t len,
         return NULL;
     }
 
-    return parse(ctx, &scanner, map);
+    return parse(bump, ctx, &scanner, map);
 }
 
 XkbFile *
-XkbParseFile(struct xkb_context *ctx, FILE *file,
+XkbParseFile(struct bump *bump, struct xkb_context *ctx, FILE *file,
              const char *file_name, const char *map)
 {
     bool ok;
@@ -237,7 +238,7 @@ XkbParseFile(struct xkb_context *ctx, FILE *file,
         return NULL;
     }
 
-    xkb_file = XkbParseString(ctx, string, size, file_name, map);
+    xkb_file = XkbParseString(bump, ctx, string, size, file_name, map);
     unmap_file(string, size);
     return xkb_file;
 }

--- a/src/xkbcomp/scanner.c
+++ b/src/xkbcomp/scanner.c
@@ -64,7 +64,7 @@ number(struct scanner *s, int64_t *out, int *out_tok)
 }
 
 int
-_xkbcommon_lex(YYSTYPE *yylval, struct scanner *s)
+_xkbcommon_lex(YYSTYPE *yylval, struct scanner *s, struct bump *bump)
 {
     int tok;
 
@@ -124,7 +124,7 @@ skip_more_whitespace_and_comments:
                         "unterminated string literal");
             return ERROR_TOK;
         }
-        yylval->str = s->bump ? bump_strdup(s->bump, s->buf) : strdup(s->buf);
+        yylval->str = bump_strdup(bump, s->buf);
         if (!yylval->str)
             return ERROR_TOK;
         return STRING;
@@ -177,7 +177,7 @@ skip_more_whitespace_and_comments:
         tok = keyword_to_token(s->buf, s->buf_pos - 1);
         if (tok != -1) return tok;
 
-        yylval->str = s->bump ? bump_strdup(s->bump, s->buf) : strdup(s->buf);
+        yylval->str = bump_strdup(bump, s->buf);
         if (!yylval->str)
             return ERROR_TOK;
         return IDENT;
@@ -204,7 +204,7 @@ XkbParseString(struct bump *bump, struct xkb_context *ctx,
                const char *file_name, const char *map)
 {
     struct scanner scanner;
-    scanner_init(&scanner, ctx, bump, string, len, file_name, NULL);
+    scanner_init(&scanner, ctx, string, len, file_name, NULL);
 
     /* Basic detection of wrong character encoding.
        The first character relevant to the grammar must be ASCII:

--- a/src/xkbcomp/symbols.c
+++ b/src/xkbcomp/symbols.c
@@ -862,7 +862,7 @@ AddSymbolsToKey(SymbolsInfo *info, KeyInfo *keyi, ExprDef *arrayNdx,
         struct xkb_level *leveli = &darray_item(groupi->levels, level);
 
         if (leveli->num_syms == 0) {
-            leveli->num_syms = darray_size(keysymList->syms);
+            leveli->num_syms = keysymList->num_syms;
             if (leveli->num_syms > 1) {
                 /* Allocate keysyms */
                 leveli->s.syms =
@@ -876,24 +876,24 @@ AddSymbolsToKey(SymbolsInfo *info, KeyInfo *keyi, ExprDef *arrayNdx,
                     leveli->a.actions[j] = dummy;
                 }
             }
-        } else if (leveli->num_syms != darray_size(keysymList->syms))
+        } else if (leveli->num_syms != keysymList->num_syms)
         {
             log_err(info->ctx, XKB_ERROR_INCOMPATIBLE_ACTIONS_AND_KEYSYMS_COUNT,
                     "Symbols for key %s, group %u, level %u must have the same "
                     "number of keysyms than the corresponding actions. "
                     "Expected %u, got: %u. Ignoring duplicate definition\n",
                     KeyInfoText(info, keyi), ndx + 1, level + 1, leveli->num_syms,
-                    darray_size(keysymList->syms));
+                    keysymList->num_syms);
             continue;
         }
 
         if (leveli->num_syms <= 1) {
-            leveli->s.sym = darray_item(keysymList->syms, 0);
+            leveli->s.sym = keysymList->syms[0];
             if (leveli->s.sym == XKB_KEY_NoSymbol)
                 leveli->num_syms = 0;
         } else {
             for (unsigned j = 0; j < leveli->num_syms; j++) {
-                leveli->s.syms[j] = darray_item(keysymList->syms, j);
+                leveli->s.syms[j] = keysymList->syms[j];
             }
         }
     }

--- a/src/xkbcomp/xkbcomp-priv.h
+++ b/src/xkbcomp/xkbcomp-priv.h
@@ -29,6 +29,7 @@
 
 #include "keymap.h"
 #include "ast.h"
+#include "bump.h"
 
 struct xkb_component_names {
     char *keycodes;
@@ -41,19 +42,16 @@ char *
 text_v1_keymap_get_as_string(struct xkb_keymap *keymap);
 
 XkbFile *
-XkbParseFile(struct xkb_context *ctx, FILE *file,
+XkbParseFile(struct bump *bump, struct xkb_context *ctx, FILE *file,
              const char *file_name, const char *map);
 
 XkbFile *
-XkbParseString(struct xkb_context *ctx,
+XkbParseString(struct bump *bump, struct xkb_context *ctx,
                const char *string, size_t len,
                const char *file_name, const char *map);
 
-void
-FreeXkbFile(XkbFile *file);
-
 XkbFile *
-XkbFileFromComponents(struct xkb_context *ctx,
+XkbFileFromComponents(struct bump *bump, struct xkb_context *ctx,
                       const struct xkb_component_names *kkctgs);
 
 bool

--- a/test/compose-iter.c
+++ b/test/compose-iter.c
@@ -65,7 +65,7 @@ for_each_helper(struct xkb_compose_table *table,
     for_each_helper(table, iter, data, syms, nsyms, node->hikid);
 }
 
-XKB_EXPORT void
+void
 xkb_compose_table_for_each(struct xkb_compose_table *table,
                            xkb_compose_table_iter_t iter,
                            void *data)

--- a/test/symbols-leak-test.py
+++ b/test/symbols-leak-test.py
@@ -34,9 +34,8 @@ exit = 0
 left, right = diff(
     top_srcdir / "xkbcommon.map",
     [
-        *(top_srcdir / "src").glob("*.c"),
-        *(top_srcdir / "src" / "xkbcomp").glob("*.c"),
-        *(top_srcdir / "src" / "compose").glob("*.c"),
+        top_srcdir / "include/xkbcommon/xkbcommon.h",
+        top_srcdir / "include/xkbcommon/xkbcommon-compose.h",
     ],
 )
 if left:
@@ -50,7 +49,7 @@ if right:
 left, right = diff(
     top_srcdir / "xkbcommon-x11.map",
     [
-        *(top_srcdir / "src" / "x11").glob("*.c"),
+        top_srcdir / "include/xkbcommon/xkbcommon-x11.h",
     ],
 )
 if left:

--- a/test/symbols-leak-test.py
+++ b/test/symbols-leak-test.py
@@ -19,7 +19,7 @@ def symbols_from_map(path):
 
 
 def symbols_from_src(path):
-    return re.findall(r"XKB_EXPORT.*\n(xkb_.*)\(", path.read_text("utf-8"))
+    return re.findall(r"\bXKB_EXPORT\b.*\n(xkb_.*)\(", path.read_text("utf-8"))
 
 
 def diff(map_path, src_paths):

--- a/test/test.h
+++ b/test/test.h
@@ -27,6 +27,7 @@
 #define TEST_H
 
 #include <assert.h>
+#include <stdbool.h>
 
 /* Don't use compat names in internal code. */
 #define _XKBCOMMON_COMPAT_H


### PR DESCRIPTION
Note: only last 2 commits are relevant.

This is a proof of concept I quickly hacked together to switch the AST allocation to use a bump allocator. This means we just allocate AST nodes in big chunks and then free it all together once done.

This is just a proof of concept, will need more work if we want to merge it. But enough to benchmark:

bench/rulescomp
before:
total heap usage: 10,980,536 allocs, 10,980,536 frees, 490,563,213 bytes allocated
compiled 1000 keymaps in 2.300165s

after:
total heap usage: 4,647,536 allocs, 4,647,536 frees, 538,021,213 bytes allocated
compiled 1000 keymaps in 1.949309s

The reduction in allocs is very nice, but the speedup is less than I hoped.