### PR TITLE
Fix latch not broken by empty level

### DIFF
--- a/test/data/symbols/latch
+++ b/test/data/symbols/latch
@@ -1,0 +1,50 @@
+default partial alphanumeric_keys
+xkb_symbols "modifiers" {
+	name[Group1] = "Test latching behavior";
+
+	virtual_modifiers LevelThree;
+
+	key <AE01> { [ 1, exclam, onesuperior, exclamdown, plus ], type[Group1]="CTRL+ALT"};
+
+	key <AD01> { [ q, Q ], type[Group1] = "ALPHABETIC" };
+
+	key <LFSH> {
+		symbols[Group1] = [ Shift_L ],
+		actions[Group1] = [ LatchMods(modifiers=Shift,latchToLock=true,clearLocks=true) ]
+	};
+
+	key <RTSH> {
+		symbols[Group1] = [ Shift_R ],
+		actions[Group1] = [ LatchMods(modifiers=Shift,latchToLock=false,clearLocks=false) ]
+	};
+
+	key <LCTL> {
+		symbols[Group1] = [ Control_L ],
+		actions[Group1] = [ LatchMods(modifiers=Control) ]
+	};
+
+	key <LALT> {
+		type[Group1] = "ONE_LEVEL",
+		symbols[Group1] = [ Alt_L ],
+		actions[Group1] = [ LatchMods(modifiers=Alt) ]
+	};
+
+	key <RALT> {
+		type[Group1] = "ONE_LEVEL",
+		symbols[Group1] = [ ISO_Level3_Latch ],
+		actions[Group1] = [ LatchMods(modifiers=LevelThree,latchToLock=true,clearLocks=true) ]
+	};
+
+	key <MENU> {
+		type[Group1] = "ONE_LEVEL",
+		symbols[Group1] = [ ISO_Level3_Latch ],
+		actions[Group1] = [ LatchMods(modifiers=LevelThree,latchToLock=false,clearLocks=false) ]
+	};
+
+	key <FK01> { [XF86_Switch_VT_1], type[Group1] = "ONE_LEVEL" };
+	key <FK02> { [ISO_Group_Shift], type[Group1] = "ONE_LEVEL" };
+
+	key <LSGT> { [ ISO_Level3_Lock ], type[Group1] = "ONE_LEVEL" };
+
+	key <CAPS> { [ ISO_Group_Latch ] };
+};

--- a/test/keyseq.c
+++ b/test/keyseq.c
@@ -71,6 +71,15 @@ test_group_latch(struct xkb_context *ctx)
                         KEY_COMPOSE,    BOTH,  XKB_KEY_ISO_Group_Latch, NEXT,  \
                         KEY_H,          BOTH,  XKB_KEY_hebrew_yod,      NEXT,  \
                         KEY_H,          BOTH,  XKB_KEY_h,               NEXT,  \
+                        /* Empty level breaks latches */                       \
+                        KEY_COMPOSE,    BOTH,  XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_YEN,        BOTH,  XKB_KEY_NoSymbol,        NEXT,  \
+                        KEY_H,          BOTH,  XKB_KEY_h,               NEXT,  \
+                        /* Unknown key does not break latches */               \
+                        KEY_COMPOSE,    BOTH,  XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        UINT32_MAX,     BOTH,  XKB_KEY_NoSymbol,        NEXT,  \
+                        KEY_H,          BOTH,  XKB_KEY_hebrew_yod,      NEXT,  \
+                        KEY_H,          BOTH,  XKB_KEY_h,               NEXT,  \
                         /* Lock the second group */                            \
                         KEY_SCROLLLOCK, BOTH,  XKB_KEY_ISO_Next_Group,  NEXT,  \
                         KEY_H,          BOTH,  XKB_KEY_hebrew_yod,      NEXT,  \
@@ -317,6 +326,15 @@ test_group_latch(struct xkb_context *ctx)
                         KEY_COMPOSE,    BOTH,  XKB_KEY_ISO_Group_Latch, NEXT,  \
                         KEY_H,          BOTH,  XKB_KEY_s,               NEXT,  \
                         KEY_H,          BOTH,  XKB_KEY_h,               NEXT,  \
+                        /* Empty level breaks latches */                       \
+                        KEY_COMPOSE,    BOTH,  XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        KEY_YEN,        BOTH,  XKB_KEY_NoSymbol,        NEXT,  \
+                        KEY_H,          BOTH,  XKB_KEY_h,               NEXT,  \
+                        /* Unknown key does not break latches */               \
+                        KEY_COMPOSE,    BOTH,  XKB_KEY_ISO_Group_Latch, NEXT,  \
+                        UINT32_MAX,     BOTH,  XKB_KEY_NoSymbol,        NEXT,  \
+                        KEY_H,          BOTH,  XKB_KEY_s,               NEXT,  \
+                        KEY_H,          BOTH,  XKB_KEY_h,               NEXT,  \
                         /* Lock the second group */                            \
                         KEY_SCROLLLOCK, BOTH,  XKB_KEY_ISO_Next_Group,  NEXT,  \
                         KEY_H,          BOTH,  XKB_KEY_hebrew_yod,      NEXT,  \
@@ -469,6 +487,19 @@ test_mod_latch(struct xkb_context *context)
     assert(test_key_seq(keymap,
         KEY_Q         , BOTH, XKB_KEY_q      , NEXT,
         KEY_1         , BOTH, XKB_KEY_1      , NEXT,
+
+        /* Empty level */
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L , NEXT,
+        KEY_YEN       , BOTH, XKB_KEY_NoSymbol, NEXT, /* Prevent latch */
+        KEY_LEFTSHIFT , UP,   XKB_KEY_Shift_L , NEXT,
+        KEY_Q         , BOTH, XKB_KEY_q       , NEXT,
+
+        /* Unknown key */
+        KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L , NEXT,
+        UINT32_MAX    , BOTH, XKB_KEY_NoSymbol, NEXT, /* Does not prevent latch */
+        KEY_LEFTSHIFT , UP,   XKB_KEY_Shift_L , NEXT,
+        KEY_1         , BOTH, XKB_KEY_exclam  , NEXT,
+        KEY_Q         , BOTH, XKB_KEY_q       , NEXT,
 
         KEY_LEFTSHIFT , DOWN, XKB_KEY_Shift_L, NEXT,
         KEY_Q         , BOTH, XKB_KEY_Q      , NEXT,  /* Prevent latch */


### PR DESCRIPTION
In essence empty levels are levels with just a `NoSymbol` keysym and a `NoAction()`, which breaks latches.

- Fixed regression introduced in #487.
- Added a bunch of tests that were previously in #611. The ambiguous cases are tested with the current behavior but I left the behavior introduced in #611 commented.
- Added tests also for the case where the keycode is unknown.

Fixes #613

TODO:
- [ ] Add tests with multiple actions per level

CC @mahkoh