### PR TITLE
scanner: compute token line/column lazily on errors

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -245,6 +245,7 @@ libxkbcommon_sources = [
     'src/keymap.h',
     'src/keymap-priv.c',
     'src/messages-codes.h',
+    'src/scanner-utils.c',
     'src/scanner-utils.h',
     'src/state.c',
     'src/text.c',

--- a/src/compose/parser.c
+++ b/src/compose/parser.c
@@ -138,8 +138,7 @@ skip_more_whitespace_and_comments:
     if (scanner_eof(s)) return TOK_END_OF_FILE;
 
     /* New token. */
-    s->token_line = s->line;
-    s->token_column = s->column;
+    s->token_pos = s->pos;
     s->buf_pos = 0;
 
     /* LHS Keysym. */
@@ -267,8 +266,7 @@ lex_include_string(struct scanner *s, struct xkb_compose_table *table,
         if (scanner_next(s) == '\n')
             return TOK_END_OF_LINE;
 
-    s->token_line = s->line;
-    s->token_column = s->column;
+    s->token_pos = s->pos;
     s->buf_pos = 0;
 
     if (!scanner_chr(s, '\"')) {

--- a/src/scanner-utils.c
+++ b/src/scanner-utils.c
@@ -31,16 +31,32 @@ scanner_token_location(struct scanner *s)
      * https://lemire.me/blog/2017/02/14/how-fast-can-you-count-lines/
      * https://github.com/lemire/Code-used-on-Daniel-Lemire-s-blog/blob/master/2017/02/14/newlines.c
      * This is the fastest portable one for me, and it's simple.
+     *
+     * To avoid rescanning on each call, cache the previously found position
+     * and start from that on the next call. This is effective as long as the
+     * tokens go forward.
      */
-    size_t line = 1, column;
+    size_t line, column;
     size_t line_pos = 0;
-    const char *ptr = s->s;
+    if (s->cached_pos > s->token_pos) {
+        s->cached_pos = 0;
+        s->cached_loc.line = s->cached_loc.column = 1;
+    }
+    line = s->cached_loc.line;
+    const char *ptr = s->s + s->cached_pos;
     const char *last = s->s + s->token_pos;
     while ((ptr = memchr(ptr, '\n', last - ptr))) {
         line++;
         ptr++;
         line_pos = ptr - s->s;
     }
-    column = s->token_pos - line_pos + 1;
-    return (struct scanner_loc){.line = line, .column = column};
+    if (line == s->cached_loc.line) {
+        column = s->cached_loc.column + (s->token_pos - s->cached_pos);
+    } else {
+        column = s->token_pos - line_pos + 1;
+    }
+    struct scanner_loc loc = {.line = line, .column = column};
+    s->cached_pos = s->token_pos;
+    s->cached_loc = loc;
+    return loc;
 }

--- a/src/scanner-utils.c
+++ b/src/scanner-utils.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2025 Ran Benita <ran@unusedvar.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "scanner-utils.h"
+
+struct scanner_loc
+scanner_token_location(struct scanner *s)
+{
+    /*
+     * The following article and accompying code compares some algorithms:
+     * https://lemire.me/blog/2017/02/14/how-fast-can-you-count-lines/
+     * https://github.com/lemire/Code-used-on-Daniel-Lemire-s-blog/blob/master/2017/02/14/newlines.c
+     * This is the fastest portable one for me, and it's simple.
+     */
+    size_t line = 1, column;
+    size_t line_pos = 0;
+    const char *ptr = s->s;
+    const char *last = s->s + s->token_pos;
+    while ((ptr = memchr(ptr, '\n', last - ptr))) {
+        line++;
+        ptr++;
+        line_pos = ptr - s->s;
+    }
+    column = s->token_pos - line_pos + 1;
+    return (struct scanner_loc){.line = line, .column = column};
+}

--- a/src/scanner-utils.h
+++ b/src/scanner-utils.h
@@ -67,6 +67,9 @@ struct scanner {
     size_t buf_pos;
     /* The position of the start of the current token. */
     size_t token_pos;
+    /* Cached values used by scanner_token_location. */
+    size_t cached_pos;
+    struct scanner_loc cached_loc;
     const char *file_name;
     struct xkb_context *ctx;
     void *priv;
@@ -106,6 +109,8 @@ scanner_init(struct scanner *s, struct xkb_context *ctx,
     s->len = len;
     s->pos = 0;
     s->token_pos = 0;
+    s->cached_pos = 0;
+    s->cached_loc.line = s->cached_loc.column = 1;
     s->file_name = file_name;
     s->ctx = ctx;
     s->priv = priv;

--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -119,8 +119,7 @@ skip_more_whitespace_and_comments:
     if (scanner_eof(s)) return TOK_END_OF_FILE;
 
     /* New token. */
-    s->token_line = s->line;
-    s->token_column = s->column;
+    s->token_pos = s->pos;
 
     /* Operators and punctuation. */
     if (scanner_chr(s, '!')) return TOK_BANG;
@@ -410,8 +409,7 @@ matcher_include(struct matcher *m, struct scanner *parent_scanner,
 
     scanner_init(&s, m->ctx, inc.start, inc.len,
                  parent_scanner->file_name, NULL);
-    s.token_line = parent_scanner->token_line;
-    s.token_column = parent_scanner->token_column;
+    s.token_pos = s.pos;
     s.buf_pos = 0;
 
     if (include_depth >= MAX_INCLUDE_DEPTH) {

--- a/src/xkbcomp/scanner.c
+++ b/src/xkbcomp/scanner.c
@@ -81,8 +81,7 @@ skip_more_whitespace_and_comments:
     if (scanner_eof(s)) return END_OF_FILE;
 
     /* New token. */
-    s->token_line = s->line;
-    s->token_column = s->column;
+    s->token_pos = s->pos;
     s->buf_pos = 0;
 
     /* String literal. */


### PR DESCRIPTION
The scanner functions are hot, and the line/column location tracking is quite expensive. We only use it for errors, which don't need to be fast, because we bail if there are too many; and for warnings, which are usually not shown by default. So only keep the token start pos, and compute the line/column lazily from that. This will also allow some further improvements ahead.

bench/rulescomp
```
before: compiled 1000 keymaps in 1.669028s
after:  compiled 1000 keymaps in 1.550411s
```

bench/compose:
```
before: compiled 1000 compose tables in 2.145217s
after:  compiled 1000 compose tables in 2.016044s
```