### PR TITLE
xkbcomp: Add stricter bounds for keycodes and levels

### DIFF
--- a/src/darray.h
+++ b/src/darray.h
@@ -184,10 +184,12 @@ typedef darray (unsigned long)  darray_ulong;
                              ((arr).alloc = (arr).size) * sizeof(*(arr).item)); \
 } while (0)
 
+#define darray_max_alloc(itemSize) (UINT_MAX / (itemSize))
+
 static inline unsigned
 darray_next_alloc(unsigned alloc, unsigned need, unsigned itemSize)
 {
-    assert(need < UINT_MAX / itemSize / 2); /* Overflow. */
+    assert(need < darray_max_alloc(itemSize) / 2); /* Overflow. */
     if (alloc == 0)
         alloc = 4;
     while (alloc < need)

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -387,6 +387,36 @@ struct xkb_mod_set {
     xkb_mod_mask_t explicit_vmods;
 };
 
+/*
+ * Our current implementation with continuous arrays does not allow efficient
+ * mapping of keycodes. Allowing the API max valid keycode XKB_KEYCODE_MAX could
+ * result in memory exhaustion or memory waste (sparse arrays) with huge enough
+ * valid values. Let’s be more conservative for now, based on the existing Linux
+ * keycodes.
+ */
+#define XKB_KEYCODE_MAX_IMPL 0xfff
+static_assert(XKB_KEYCODE_MAX_IMPL < XKB_KEYCODE_MAX,
+              "Valid keycodes");
+static_assert(XKB_KEYCODE_MAX_IMPL < darray_max_alloc(sizeof(xkb_atom_t)),
+              "Max keycodes names");
+static_assert(XKB_KEYCODE_MAX_IMPL < darray_max_alloc(sizeof(struct xkb_key)),
+              "Max keymap keys");
+
+/*
+ * Our current implementation with continuous arrays does not allow efficient
+ * mapping of levels. Allowing the max valid level UINT32_MAX could result in
+ * memory exhaustion or memory waste (sparse arrays) with huge enough valid
+ * values. Let’s be more conservative for now. This value should be big enough
+ * to satisfy automatically generated keymaps.
+ */
+#define XKB_LEVEL_MAX_IMPL 2048
+static_assert(XKB_LEVEL_MAX_IMPL < XKB_LEVEL_INVALID,
+              "Valid levels");
+static_assert(XKB_LEVEL_MAX_IMPL < darray_max_alloc(sizeof(xkb_atom_t)),
+              "Max key types level names");
+static_assert(XKB_LEVEL_MAX_IMPL < darray_max_alloc(sizeof(struct xkb_level)),
+              "Max keys levels");
+
 /* Common keyboard description structure */
 struct xkb_keymap {
     struct xkb_context *ctx;

--- a/src/xkbcomp/expr.c
+++ b/src/xkbcomp/expr.c
@@ -445,9 +445,10 @@ ExprResolveLevel(struct xkb_context *ctx, const ExprDef *expr,
     if (!ok)
         return false;
 
-    if (result < 1) {
+    if (result < 1 || result > XKB_LEVEL_MAX_IMPL) {
         log_err(ctx, XKB_ERROR_UNSUPPORTED_SHIFT_LEVEL,
-                "Shift level %d is out of range\n", result);
+                "Shift level %d is out of range (1..%u)\n",
+                result, XKB_LEVEL_MAX_IMPL);
         return false;
     }
 

--- a/src/xkbcomp/keycodes.c
+++ b/src/xkbcomp/keycodes.c
@@ -191,6 +191,14 @@ AddKeyName(KeyNamesInfo *info, xkb_keycode_t kc, xkb_atom_t name,
 
     report = report && ((same_file && verbosity > 0) || verbosity > 7);
 
+    /* Check keycode is not too huge for our continuous array */
+    if (kc > XKB_KEYCODE_MAX_IMPL) {
+        log_err(info->ctx, XKB_LOG_MESSAGE_NO_ID,
+                "Keycode too big: must be < %#"PRIx32", got %#"PRIx32"; "
+                "Key ignored\n", XKB_KEYCODE_MAX_IMPL, kc);
+        return false;
+    }
+
     if (kc >= darray_size(info->key_names))
         darray_resize0(info->key_names, kc + 1);
 


### PR DESCRIPTION
Our current implementation uses continuous arrays indexed by keycodes and levels. This is simple and good enough for realistic keymaps. However, they are allowed to have big values that will lead to either memory exhaustion or a waste of memory (sparse arrays).

Added the much stricter upper bound `0xfff` that should still be plenty enough and provides stronger memory security.