### PR TITLE
symbols: Enable writing keysyms list as UTF-8 strings

### DIFF
--- a/changes/+keysyms-string.feature.md
+++ b/changes/+keysyms-string.feature.md
@@ -1,0 +1,7 @@
+Enable to write keysyms as UTF-8-encoded strings:
+- *Single* Unicode code point `U+1F3BA` (TRUMPET) `"🎺"` is converted into a
+  single keysym: `U1F3BA`.
+- *Multiple* Unicode code points are converted to a keysym *list* where it is
+  allowed (i.e. in key symbols). E.g. `"J́"` is converted to U+004A LATIN CAPITAL
+  LETTER J plus U+0301 COMBINING ACUTE ACCENT: `{J, U0301}`.
+- An empty string `""` denotes the keysym `NoSymbol`.

--- a/changes/api/+bidi.feature.md
+++ b/changes/api/+bidi.feature.md
@@ -1,0 +1,4 @@
+Enable displaying bidirectional text in XKB files using the following Unicode
+code points, wherever a white space can be used:
+- U+200E LEFT-TO-RIGHT MARK
+- U+200F RIGHT-TO-LEFT MARK

--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -58,9 +58,13 @@ On the other hand, some features and extensions were added.
 - 32-bit keycodes
 - extended number of modifiers (planned)
 - extended number of groups (planned)
-- multiple keysyms per level
+- multiple keysyms and actions per level
   + such levels are ignored by x11/xkbcomp.
 - key names (e.g. `<AE11>`) can be longer than 4 characters.
+- keysyms can be written as their corresponding string, e.g. `udiaeresis`
+  can be written `"ü"`. A string with multiple Unicode code points denotes
+  a list of the corresponding keysyms. An empty string denotes the keysym
+  `NoSymbol`.
 
 ## Rules support {#rules-support}
 

--- a/meson.build
+++ b/meson.build
@@ -253,6 +253,8 @@ libxkbcommon_sources = [
     'src/text.h',
     'src/utf8.c',
     'src/utf8.h',
+    'src/utf8-decoding.c',
+    'src/utf8-decoding.h',
     'src/utils.c',
     'src/utils.h',
     'src/util-mem.h',

--- a/meson.build
+++ b/meson.build
@@ -47,6 +47,7 @@ cflags = [
     '-Wwrite-strings',
     '-Wno-documentation-deprecated-sync',
     '-Wno-pedantic',
+    '/utf-8',
     '/wd4100', # Disable MSVC C4100: unreferenced formal parameter
 ]
 add_project_arguments(cc.get_supported_arguments(cflags), language: 'c')

--- a/src/xkbcomp/ast-build.h
+++ b/src/xkbcomp/ast-build.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ast.h"
+#include "scanner-utils.h"
 
 ExprDef *
 ExprCreateString(xkb_atom_t str);
@@ -53,6 +54,13 @@ ExprCreateKeySymList(xkb_keysym_t sym);
 
 ExprDef *
 ExprAppendKeySymList(ExprDef *list, xkb_keysym_t sym);
+
+ExprDef *
+ExprKeySymListAppendString(struct scanner *param,
+                           ExprDef *expr, const char *string);
+
+xkb_keysym_t
+KeysymParseString(struct scanner *scanner, const char *string);
 
 KeycodeDef *
 KeycodeCreate(xkb_atom_t name, int64_t value);

--- a/src/xkbcomp/scanner.c
+++ b/src/xkbcomp/scanner.c
@@ -70,6 +70,14 @@ skip_more_whitespace_and_comments:
     /* Skip spaces. */
     while (is_space(scanner_peek(s))) scanner_next(s);
 
+    /*
+     * Skip U+200E LEFT-TO-RIGHT MARK and U+200F RIGHT-TO-LEFT MARK, assuming
+     * UTF-8 encoding. These Unicode code points are useful for forcing the text
+     * directionality when displaying/editing an XKB file.
+     */
+    if (scanner_lit(s, u8"\u200E") || scanner_lit(s, u8"\u200F"))
+        goto skip_more_whitespace_and_comments;
+
     /* Skip comments. */
     if (scanner_lit(s, "//") || scanner_chr(s, '#')) {
         scanner_skip_to_eol(s);

--- a/test/data/keymaps/bidi.xkb
+++ b/test/data/keymaps/bidi.xkb
@@ -1,0 +1,22 @@
+xkb_keymap {
+xkb_keycodes {
+	minimum = 1;
+	maximum = 255;
+	<>                   = 1;
+};
+
+xkb_types {
+	type "default" {
+		modifiers= none;
+	};
+};
+
+xkb_compatibility {
+	interpret.useModMapMods= AnyLevel;
+	interpret.repeat= False;
+};
+
+xkb_symbols {
+};
+
+};

--- a/test/data/keymaps/compat-interpret.xkb
+++ b/test/data/keymaps/compat-interpret.xkb
@@ -1,0 +1,28 @@
+xkb_keymap {
+xkb_keycodes {
+	minimum = 8;
+	maximum = 255;
+};
+
+xkb_types {
+	type "default" {
+		modifiers= none;
+	};
+};
+
+xkb_compatibility {
+	interpret.useModMapMods= AnyLevel;
+	interpret.repeat= False;
+	interpret 1+AnyOfOrNone(all) {};
+	interpret 0x0000000b+AnyOfOrNone(all) {};
+	interpret Shift_L+AnyOfOrNone(all) {};
+	interpret a+AnyOfOrNone(all) {};
+	interpret adiaeresis+AnyOfOrNone(all) {};
+	interpret U2728+AnyOfOrNone(all) {};
+	interpret U1F3BA+AnyOfOrNone(all) {};
+};
+
+xkb_symbols {
+};
+
+};

--- a/test/data/keymaps/string-as-keysyms.xkb
+++ b/test/data/keymaps/string-as-keysyms.xkb
@@ -1,0 +1,179 @@
+xkb_keymap {
+xkb_keycodes {
+	minimum = 8;
+	maximum = 255;
+	<10>                 = 10;
+	<11>                 = 11;
+	<12>                 = 12;
+	<20>                 = 20;
+	<21>                 = 21;
+	<22>                 = 22;
+	<23>                 = 23;
+	<24>                 = 24;
+	<25>                 = 25;
+	<30>                 = 30;
+	<31>                 = 31;
+	<32>                 = 32;
+	<33>                 = 33;
+	<34>                 = 34;
+	<35>                 = 35;
+	<40>                 = 40;
+	<41>                 = 41;
+	<42>                 = 42;
+	<50>                 = 50;
+	<51>                 = 51;
+	<52>                 = 52;
+	<60>                 = 60;
+	<61>                 = 61;
+	<62>                 = 62;
+	<63>                 = 63;
+	<64>                 = 64;
+	<65>                 = 65;
+	<66>                 = 66;
+	<67>                 = 67;
+	<68>                 = 68;
+	<69>                 = 69;
+	<70>                 = 70;
+	<71>                 = 71;
+	<72>                 = 72;
+	<73>                 = 73;
+	<74>                 = 74;
+	<AD08>               = 80;
+	<AC05>               = 81;
+	<AB05>               = 82;
+	<AD01>               = 83;
+};
+
+xkb_types "basic" {
+	virtual_modifiers NumLock;
+
+	type "ONE_LEVEL" {
+		modifiers= none;
+		level_name[1]= "Any";
+	};
+	type "TWO_LEVEL" {
+		modifiers= Shift;
+		map[Shift]= 2;
+		level_name[1]= "Base";
+		level_name[2]= "Shift";
+	};
+	type "ALPHABETIC" {
+		modifiers= Shift+Lock;
+		map[Shift]= 2;
+		map[Lock]= 2;
+		level_name[1]= "Base";
+		level_name[2]= "Caps";
+	};
+};
+
+xkb_compatibility {
+	virtual_modifiers NumLock;
+
+	interpret.useModMapMods= AnyLevel;
+	interpret.repeat= False;
+	interpret adiaeresis+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret U2728+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret U1F3BA+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret U1F54A+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret 0x01000001+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret Linefeed+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret 0x0100001f+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret space+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret asciitilde+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret Delete+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret 0x01000080+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret 0x0100009f+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret nobreakspace+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret ydiaeresis+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret UFDD0+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret UFDEF+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret UFFFE+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret UFFFF+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret U10000+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret U1FFFF+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret U10FFFF+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+};
+
+xkb_symbols {
+	key <10>                 {	[        NoSymbol,        { b, c } ] };
+	key <11>                 {	[               a,               b ] };
+	key <20>                 {	[               a,        { b, c } ] };
+	key <23>                 {	[           U2728,          U1F3BA ] };
+	key <24>                 {	[    { u, U0308 } ] };
+	key <25>                 {	[ { U2200, partialderivative, elementof, U211D, logicaland, union, identical, infinity, space, uparrow, U2197, U21A8, U21BB, U21E3, space, uprightcorner, crossinglines, U2554, U2558, U2591, U25BA, U263A, femalesymbol, space, UFB01, UFFFD, U2440, twosubscript, U1F20, Babovedot, U04E5, Wdiaeresis, U0250, U02D0, U234E, hebrew_aleph, Armenian_AYB, Georgian_an } ] };
+	key <30>                 {	[               a,        { b, c } ] };
+	key <31>                 {	[               a,        { b, c } ] };
+	key <32>                 {	[               a,        { b, c } ] };
+	key <33>                 {	[          U1F54A, { U1F3F3, UFE0F } ] };
+	key <34>                 {	[    { u, U0308 } ] };
+	key <35>                 {	[ { U2200, partialderivative, elementof, U211D, logicaland, union, identical, infinity, space, uparrow, U2197, U21A8, U21BB, U21E3, space, uprightcorner, crossinglines, U2554, U2558, U2591, U25BA, U263A, femalesymbol, space, UFB01, UFFFD, U2440, twosubscript, U1F20, Babovedot, U04E5, Wdiaeresis, U0250, U02D0, U234E, hebrew_aleph, Armenian_AYB, Georgian_an } ] };
+	key <40>                 {	[        { a, b },  { c, d, e, f } ] };
+	key <41>                 {	[        { a, b },  { c, d, e, f } ] };
+	key <42>                 {	[        { a, b },  { c, d, e, f } ] };
+	key <50>                 {	[        { a, b },  { c, d, e, f } ] };
+	key <51>                 {	[        { a, b },  { c, d, e, f } ] };
+	key <52>                 {	[        { a, b },  { c, d, e, f } ] };
+	key <60>                 {	[        { a, b },  { c, d, e, f } ] };
+	key <61>                 {	[        { a, b },  { c, d, e, f } ] };
+	key <63>                 {	[  { a, b, c, d },  { e, f, g, h } ] };
+	key <64>                 {	[  { a, b, c, d },  { e, f, g, h } ] };
+	key <65>                 {	[        NoSymbol,         U10FFFF ] };
+	key <66>                 {	[      0x01000001,        Linefeed ] };
+	key <67>                 {	[      0x0100001f,           space ] };
+	key <68>                 {	[      asciitilde,          Delete ] };
+	key <69>                 {	[      0x01000080,      0x0100009f ] };
+	key <70>                 {	[    nobreakspace,      ydiaeresis ] };
+	key <71>                 {	[           UFFFD,           UFFFD ] };
+	key <72>                 {	[           UFDD0,           UFDEF ] };
+	key <73>                 {	[           UFFFE,           UFFFF ] };
+	key <74>                 {	[          U10000,          U1FFFF ] };
+	key <AD08>               {	[        { i, j },           U0132 ] };
+	key <AC05>               {	[ { g, combining_tilde }, { G, combining_tilde } ] };
+	key <AB05>               {	[ { Arabic_lam, Arabic_alef }, { Arabic_lam, Arabic_maddaonalef } ] };
+	key <AD01>               {	[ { c, rightsinglequotemark, h }, { C, rightsinglequotemark, h } ] };
+	modifier_map Mod1 { <23>, <33> };
+};
+
+};

--- a/test/data/keymaps/symbols-modifier_map.xkb
+++ b/test/data/keymaps/symbols-modifier_map.xkb
@@ -6,9 +6,15 @@ xkb_keycodes {
 	<1>                  = 1;
 	<2>                  = 2;
 	<3>                  = 3;
+	<4>                  = 4;
+	<5>                  = 5;
+	<6>                  = 6;
+	<7>                  = 7;
 	<any>                = 10;
 	<none>               = 11;
 	<a>                  = 61;
+	<b>                  = 62;
+	<c>                  = 63;
 	<CAPS>               = 66;
 	<100>                = 100;
 	alias <LOCK>         = <CAPS>;
@@ -48,12 +54,18 @@ xkb_symbols {
 	key <1>                  {	[               1 ] };
 	key <2>                  {	[               2 ] };
 	key <3>                  {	[        NoSymbol,               3 ] };
+	key <4>                  {	[          U1F54A ] };
+	key <5>                  {	[           UFFFD,           UFFFD ] };
+	key <6>                  {	[           UFDD0,           UFDEF ] };
+	key <7>                  {	[           UFFFE,           UFFFF ] };
 	key <any>                {	[        NoSymbol,               A ] };
 	key <none>               {	[      VoidSymbol,               N ] };
 	key <a>                  {	[               a ] };
+	key <b>                  {	[               b ] };
+	key <c>                  {	[          U1F3BA ] };
 	key <CAPS>               {	[       Caps_Lock ] };
 	key <100>                {	[               C ] };
-	modifier_map Lock { <0>, <1>, <2>, <none>, <a>, <CAPS>, <100> };
+	modifier_map Lock { <0>, <1>, <2>, <4>, <5>, <6>, <7>, <none>, <a>, <b>, <c>, <CAPS>, <100> };
 };
 
 };

--- a/test/log.c
+++ b/test/log.c
@@ -151,11 +151,22 @@ test_keymaps(void)
         {
             .input =
                 "xkb_keymap \"\\j\"\n"
-                " { symbols = { };\n"
+                " { xkb_symbols = {};\n"
                 "};",
             .log =
                 "warning: [XKB-645] (input string):1:12: unknown escape sequence \"\\j\" in string literal\n"
-                "error: [XKB-769] (input string):2:4: syntax error\n"
+                "error: [XKB-769] (input string):2:16: syntax error\n"
+                "error: [XKB-822] Failed to parse input xkb string\n",
+            .error = true
+        },
+        {
+            .input =
+                "xkb_keymap {\n"
+                " xkb_keycodes { <> = 1; };\n"
+                " xkb_symbols { key <> { [\"\xC3\xBC\xff\"] }; };\n"
+                "};",
+            .log =
+                "error: [XKB-542] (input string):3:26: Cannot convert string to keysyms: Invalid UTF-8 encoding starting at byte position 3 (code point position: 2).\n"
                 "error: [XKB-822] Failed to parse input xkb string\n",
             .error = true
         },


### PR DESCRIPTION
Each Unicode code point of the string will be translated to their respective keysym, if possible. When such conversion is not possible, this will raise a syntax error.

This introduces the following syntax:

```c
// Single code point = single keysym
key <1> {["é"]}; // eacute
// String = translate each code point to their respective keysym
key <2> {["sßξك🎺"]}; // {s, ssharp, Greek_xi, Arabic_kaf, U1F3BA}
// Mix string and keysyms
key <3> {[{"ξ", Greek_kappa, "β"}]}; // { Greek_xi, Greek_kappa, Greek_beta}
```

Mixing string and keysyms would allow to mix keysyms with and without Unicode translation[^1].

Implements #636

TODO:
- [x] Tests
- [x] Doc
- [x] Changelog
- [x] Rebase on #717
- [ ] ~~enable also in Compose?~~

[^1]: Although right now I have no use case in mind. It’s more about the principle of least astonishment: since `"é"` translates to `eacute`, then `{"é", e}` and `{eacute, e}` should be both valid and result in the same keysym sequence. Then users may get creative and mix e.g. modifier or system keysyms with characters.