### PR TITLE
xkbcomp/scanner: avoid unneeded strdup of IDENT tokens

### DIFF
--- a/src/scanner-utils.h
+++ b/src/scanner-utils.h
@@ -29,10 +29,20 @@ svaleq(struct sval s1, struct sval s2)
 }
 
 static inline bool
+isvaleq(struct sval s1, struct sval s2)
+{
+    return s1.len == s2.len && istrncmp(s1.start, s2.start, s1.len) == 0;
+}
+
+static inline bool
 svaleq_prefix(struct sval s1, struct sval s2)
 {
     return s1.len <= s2.len && memcmp(s1.start, s2.start, s1.len) == 0;
 }
+
+#define SVAL(start, len) (struct sval){(start), len}
+#define SVAL_LIT(literal) SVAL(literal, sizeof(literal) - 1)
+#define SVAL_INIT(literal) { literal, sizeof(literal) - 1 }
 
 /* A line:column location in the input string (1-based). */
 struct scanner_loc {

--- a/src/xkbcomp/parser-priv.h
+++ b/src/xkbcomp/parser-priv.h
@@ -7,6 +7,7 @@
 struct parser_param;
 struct scanner;
 
+#include "scanner-utils.h"
 #include "parser.h"
 
 int

--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -133,13 +133,11 @@ enum rules_mlvo {
     _MLVO_NUM_ENTRIES
 };
 
-#define SVAL_LIT(literal) { literal, sizeof(literal) - 1 }
-
 static const struct sval rules_mlvo_svals[_MLVO_NUM_ENTRIES] = {
-    [MLVO_MODEL] = SVAL_LIT("model"),
-    [MLVO_LAYOUT] = SVAL_LIT("layout"),
-    [MLVO_VARIANT] = SVAL_LIT("variant"),
-    [MLVO_OPTION] = SVAL_LIT("option"),
+    [MLVO_MODEL] = SVAL_INIT("model"),
+    [MLVO_LAYOUT] = SVAL_INIT("layout"),
+    [MLVO_VARIANT] = SVAL_INIT("variant"),
+    [MLVO_OPTION] = SVAL_INIT("option"),
 };
 
 enum rules_kccgst {
@@ -152,11 +150,11 @@ enum rules_kccgst {
 };
 
 static const struct sval rules_kccgst_svals[_KCCGST_NUM_ENTRIES] = {
-    [KCCGST_KEYCODES] = SVAL_LIT("keycodes"),
-    [KCCGST_TYPES] = SVAL_LIT("types"),
-    [KCCGST_COMPAT] = SVAL_LIT("compat"),
-    [KCCGST_SYMBOLS] = SVAL_LIT("symbols"),
-    [KCCGST_GEOMETRY] = SVAL_LIT("geometry"),
+    [KCCGST_KEYCODES] = SVAL_INIT("keycodes"),
+    [KCCGST_TYPES] = SVAL_INIT("types"),
+    [KCCGST_COMPAT] = SVAL_INIT("compat"),
+    [KCCGST_SYMBOLS] = SVAL_INIT("symbols"),
+    [KCCGST_GEOMETRY] = SVAL_INIT("geometry"),
 };
 
 /* We use this to keep score whether an mlvo was matched or not; if not,

--- a/src/xkbcomp/scanner.c
+++ b/src/xkbcomp/scanner.c
@@ -7,7 +7,6 @@
 
 #include "xkbcomp-priv.h"
 #include "parser-priv.h"
-#include "scanner-utils.h"
 
 static bool
 number(struct scanner *s, int64_t *out, int *out_tok)
@@ -156,9 +155,7 @@ skip_more_whitespace_and_comments:
         tok = keyword_to_token(start, len);
         if (tok >= 0) return tok;
 
-        yylval->str = strndup(start, len);
-        if (!yylval->str)
-            return ERROR_TOK;
+        yylval->sval = SVAL(start, len);
         return IDENT;
     }
 


### PR DESCRIPTION
The allocation is immediately discarded, either turned into a keysym or
an atom. So use an sval slice into the input string instead strdup'ing.

memusage ./release/bench-compile-keymap --iter=1000 --layout us,de --variant ,neo

Before:

    Memory usage summary: heap total: 534063576, heap peak: 581022, stack peak: 18848
            total calls   total memory   failed calls
     malloc|   11240525      291897104              0
    realloc|    1447657      192307328              0  (nomove:37629, dec:0, free:0)
     calloc|     430573       49859144              0
       free|   13993903      534063576

After:

    Memory usage summary: heap total: 506839909, heap peak: 581022, stack peak: 18960
            total calls   total memory   failed calls
     malloc|    8016419      264673437              0
    realloc|    1447657      192307328              0  (nomove:37278, dec:0, free:0)
     calloc|     430573       49859144              0
       free|    0769797      506839909