### PR TITLE
xkbcomp/parser: enable Bison detailed syntax error

### DIFF
--- a/PACKAGING
+++ b/PACKAGING
@@ -19,8 +19,7 @@ libxkbregistry can be disabled with -Denable-xkbregistry=false (see
 Dependencies for libxkbcommon:
 - C compiler, meson, pkg-config, libc.
 
-- (build) bison (preferred), win_bison or byacc>=20141006.
-  byacc must be configured with --enable-btyacc.
+- (build) bison (preferred) or win_bison
 
 - (build optional, runtime required) xkeyboard-config.
   During build, for automatically detecting the value of

--- a/changes/api/644.feature.rst
+++ b/changes/api/644.feature.rst
@@ -1,0 +1,1 @@
+Improved syntax errors in XKB files to include the expected/got tokens.

--- a/changes/build/644.breaking.rst
+++ b/changes/build/644.breaking.rst
@@ -1,0 +1,1 @@
+Removed support for byacc -- use bison instead.

--- a/meson.build
+++ b/meson.build
@@ -176,29 +176,13 @@ have_version_script = cc.links(
 map_to_def = find_program('scripts/map-to-def')
 
 # libxkbcommon.
-# Note: we use some yacc extensions, which work with either GNU bison
-# (preferred) or byacc (with backtracking enabled).
-bison = find_program('bison', 'win_bison', required: false, version: '>= 2.3a')
-if bison.found()
-    yacc = bison
-    yacc_gen = generator(
-        bison,
-        output: ['@BASENAME@.c', '@BASENAME@.h'],
-        arguments: ['--defines=@OUTPUT1@', '-o', '@OUTPUT0@', '-p', '_xkbcommon_', '@INPUT@'],
-    )
-else
-    byacc = find_program('byacc', required: false)
-    if byacc.found()
-        yacc = byacc
-        yacc_gen = generator(
-            byacc,
-            output: ['@BASENAME@.c', '@BASENAME@.h'],
-            arguments: ['-H', '@OUTPUT1@', '-o', '@OUTPUT0@', '-p', '_xkbcommon_', '@INPUT@'],
-        )
-    else
-        error('Could not find a compatible YACC program (bison or byacc)')
-    endif
-endif
+bison = find_program('bison', 'win_bison', required: true, version: '>= 2.3a')
+yacc = bison
+yacc_gen = generator(
+    bison,
+    output: ['@BASENAME@.c', '@BASENAME@.h'],
+    arguments: ['--defines=@OUTPUT1@', '-o', '@OUTPUT0@', '-p', '_xkbcommon_', '@INPUT@'],
+)
 libxkbcommon_sources = [
     'src/compose/parser.c',
     'src/compose/parser.h',

--- a/src/xkbcomp/parser.y
+++ b/src/xkbcomp/parser.y
@@ -88,70 +88,72 @@ resolve_keysym(struct parser_param *param, struct sval name, xkb_keysym_t *sym_r
 %lex-param      { struct scanner *param_scanner }
 %parse-param    { struct parser_param *param }
 
+%define parse.error detailed
+
 %token
-        END_OF_FILE     0
-        ERROR_TOK       255
-        XKB_KEYMAP      1
-        XKB_KEYCODES    2
-        XKB_TYPES       3
-        XKB_SYMBOLS     4
-        XKB_COMPATMAP   5
-        XKB_GEOMETRY    6
-        XKB_SEMANTICS   7
-        XKB_LAYOUT      8
-        INCLUDE         10
-        OVERRIDE        11
-        AUGMENT         12
-        REPLACE         13
-        ALTERNATE       14
-        VIRTUAL_MODS    20
-        TYPE            21
-        INTERPRET       22
-        ACTION_TOK      23
-        KEY             24
-        ALIAS           25
-        GROUP           26
-        MODIFIER_MAP    27
-        INDICATOR       28
-        SHAPE           29
-        KEYS            30
-        ROW             31
-        SECTION         32
-        OVERLAY         33
-        TEXT            34
-        OUTLINE         35
-        SOLID           36
-        LOGO            37
-        VIRTUAL         38
-        EQUALS          40
-        PLUS            41
-        MINUS           42
-        DIVIDE          43
-        TIMES           44
-        OBRACE          45
-        CBRACE          46
-        OPAREN          47
-        CPAREN          48
-        OBRACKET        49
-        CBRACKET        50
-        DOT             51
-        COMMA           52
-        SEMI            53
-        EXCLAM          54
-        INVERT          55
-        STRING          60
-        INTEGER         61
-        FLOAT           62
-        IDENT           63
-        KEYNAME         64
-        PARTIAL         70
-        DEFAULT         71
-        HIDDEN          72
-        ALPHANUMERIC_KEYS       73
-        MODIFIER_KEYS           74
-        KEYPAD_KEYS             75
-        FUNCTION_KEYS           76
-        ALTERNATE_GROUP         77
+        END_OF_FILE     0 "end of file"
+        ERROR_TOK       255 "invalid token"
+        XKB_KEYMAP      1 "xkb_keymap"
+        XKB_KEYCODES    2 "xkb_keycodes"
+        XKB_TYPES       3 "xkb_types"
+        XKB_SYMBOLS     4 "xkb_symbols"
+        XKB_COMPATMAP   5 "xkb_compatibility"
+        XKB_GEOMETRY    6 "xkb_geometry"
+        XKB_SEMANTICS   7 "xkb_semantics"
+        XKB_LAYOUT      8 "xkb_layout"
+        INCLUDE         10 "include"
+        OVERRIDE        11 "override"
+        AUGMENT         12 "augment"
+        REPLACE         13 "replace"
+        ALTERNATE       14 "alternate"
+        VIRTUAL_MODS    20 "virtual_modifiers"
+        TYPE            21 "type"
+        INTERPRET       22 "interpret"
+        ACTION_TOK      23 "action"
+        KEY             24 "key"
+        ALIAS           25 "alias"
+        GROUP           26 "group"
+        MODIFIER_MAP    27 "modifier_map"
+        INDICATOR       28 "indicator"
+        SHAPE           29 "shape"
+        KEYS            30 "keys"
+        ROW             31 "row"
+        SECTION         32 "section"
+        OVERLAY         33 "overlay"
+        TEXT            34 "text"
+        OUTLINE         35 "outline"
+        SOLID           36 "solid"
+        LOGO            37 "logo"
+        VIRTUAL         38 "virtual"
+        EQUALS          40 "="
+        PLUS            41 "+"
+        MINUS           42 "-"
+        DIVIDE          43 "/"
+        TIMES           44 "*"
+        OBRACE          45 "{"
+        CBRACE          46 "}"
+        OPAREN          47 "("
+        CPAREN          48 ")"
+        OBRACKET        49 "["
+        CBRACKET        50 "]"
+        DOT             51 "."
+        COMMA           52 ","
+        SEMI            53 ";"
+        EXCLAM          54 "!"
+        INVERT          55 "~"
+        STRING          60 "string literal"
+        INTEGER         61 "integer literal"
+        FLOAT           62 "float literal"
+        IDENT           63 "identifier"
+        KEYNAME         64 "key name"
+        PARTIAL         70 "partial"
+        DEFAULT         71 "default"
+        HIDDEN          72 "hidden"
+        ALPHANUMERIC_KEYS       73 "alphanumeric_keys"
+        MODIFIER_KEYS           74 "modifier_keys"
+        KEYPAD_KEYS             75 "keypad_keys"
+        FUNCTION_KEYS           76 "function_keys"
+        ALTERNATE_GROUP         77 "alternate_group"
 
 %right  EQUALS
 %left   PLUS MINUS

--- a/src/xkbcomp/parser.y
+++ b/src/xkbcomp/parser.y
@@ -4,9 +4,10 @@
  */
 
 /*
- * The parser should work with reasonably recent versions of either
- * bison or byacc.  So if you make changes, try to make sure it works
- * in both!
+ * The parser should work with reasonably recent versions of bison.
+ *
+ * byacc support was dropped, because it does not support the following features:
+ * - `%define parse.error detailed`
  */
 
 /* The following goes in the header */

--- a/test/log.c
+++ b/test/log.c
@@ -144,7 +144,7 @@ test_keymaps(void)
         {
             .input = "xkb_keymap {\n",
             .log =
-                "error: [XKB-769] (input string):1:12: syntax error\n"
+                "error: [XKB-769] (input string):1:12: syntax error, unexpected end of file\n"
                 "error: [XKB-822] Failed to parse input xkb string\n",
             .error = true
         },
@@ -155,7 +155,7 @@ test_keymaps(void)
                 "};",
             .log =
                 "warning: [XKB-645] (input string):1:12: unknown escape sequence \"\\j\" in string literal\n"
-                "error: [XKB-769] (input string):2:16: syntax error\n"
+                "error: [XKB-769] (input string):2:16: syntax error, unexpected =, expecting {\n"
                 "error: [XKB-822] Failed to parse input xkb string\n",
             .error = true
         },


### PR DESCRIPTION
It's not much, but instead of

xkbcommon: ERROR: [XKB-769] (unknown file):5:25: syntax error

we get

xkbcommon: ERROR: [XKB-769] (unknown file):5:25: syntax error, unexpected +, expecting INTEGER

which is at least a little helpful.