### PR TITLE
ci: fix link to NEWS file in releases

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -27,4 +27,4 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
           body: |
-            See the [NEWS](https://github.com/xkbcommon/libxkbcommon/blob/master/NEWS) file for the changes.
+            See the [NEWS](https://github.com/xkbcommon/libxkbcommon/blob/master/NEWS.md) file for the changes.


### PR DESCRIPTION
Fixes 737706fe83f2 doc: Use towncrier to handle release notes