### PR TITLE
Doc/doxygen enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # libxkbcommon
 
-libxkbcommon is a keyboard keymap compiler and support library which
+**libxkbcommon** is a keyboard keymap compiler and support library which
 processes a reduced subset of keymaps as defined by the [XKB] \(X Keyboard
-Extension) specification.  It also contains a module for handling Compose
-and dead keys and a separate library for listing available keyboard layouts.
+Extension) specification.  It also contains a module for handling *Compose*
+and dead keys and a separate *registry* library for listing available keyboard
+layouts.
 
 [XKB]: doc/introduction-to-xkb.md
 
@@ -18,22 +19,31 @@ and dead keys and a separate library for listing available keyboard layouts.
 
 libxkbcommon is built with [Meson](http://mesonbuild.com/):
 
-    meson setup build
-    meson compile -C build
-    meson test -C build # Run the tests.
+```bash
+meson setup build
+meson compile -C build
+meson test -C build # Run the tests.
+```
 
 To build for use with Wayland, you can disable X11 support while still
 using the X11 keyboard configuration resource files thusly:
 
-    meson setup build \
-        -Denable-x11=false \
-        -Dxkb-config-root=/usr/share/X11/xkb \
-        -Dx-locale-root=/usr/share/X11/locale
-    meson compile -C build
+```bash
+meson setup build \
+    -Denable-x11=false \
+    -Dxkb-config-root=/usr/share/X11/xkb \
+    -Dx-locale-root=/usr/share/X11/locale
+meson compile -C build
+```
+
+<details>
+<summary>Complete list of user options</summary>
+@include meson_options.txt
+</details>
 
 ## API
 
-While libxkbcommon's API is somewhat derived from the classic XKB API as found
+While libxkbcommon’s API is somewhat derived from the classic XKB API as found
 in `X11/extensions/XKB.h` and friends, it has been substantially reworked to
 expose fewer internal details to clients.
 
@@ -41,14 +51,18 @@ See the [API Documentation](https://xkbcommon.org/doc/current/modules.html).
 
 ## Dataset
 
-libxkbcommon does not distribute a keymap dataset itself, other than for
-testing purposes.  The most common dataset is xkeyboard-config, which is used
-by all current distributions for their X11 XKB data.  More information on
-xkeyboard-config is available here:
-    https://www.freedesktop.org/wiki/Software/XKeyboardConfig
+libxkbcommon *does not distribute a keyboard layout dataset itself*, other than
+for testing purposes.  The most common dataset is **xkeyboard-config**, which is
+used by all current distributions for their X11 XKB data.  Further information
+on xkeyboard-config is available at its [homepage][xkeyboard-config-home] and at
+its [repository][xkeyboard-config-repo].
 
-The dataset for Compose is distributed in libX11, as part of the X locale
+The dataset for *Compose* is distributed in [libX11], as part of the X locale
 data.
+
+[xkeyboard-config-home]: https://www.freedesktop.org/wiki/Software/XKeyboardConfig
+[xkeyboard-config-repo]: https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config
+[libX11]: https://gitlab.freedesktop.org/xorg/lib/libx11
 
 ## Relation to X11
 
@@ -63,15 +77,16 @@ xkbcommon is maintained in git at
     https://github.com/xkbcommon/libxkbcommon
 
 Patches are always welcome, and may be sent to either
-    <xorg-devel@lists.x.org> or <wayland-devel@lists.freedesktop.org>
+<xorg-devel@lists.x.org> or <wayland-devel@lists.freedesktop.org>
 or in a [GitHub](https://github.com/xkbcommon/libxkbcommon) pull request.
 
 Bug reports (and usage questions) are also welcome, and may be filed at
 [GitHub](https://github.com/xkbcommon/libxkbcommon/issues).
 
-The maintainers are
-- Daniel Stone <daniel@fooishbar.org>
-- Ran Benita <ran@unusedvar.com>
+The maintainers are:
+- [Daniel Stone](mailto:daniel@fooishbar.org)
+- [Ran Benita](mailto:ran@unusedvar.com)
+- [Pierre Le Marre](mailto:dev@wismill.eu)
 
 ## Credits
 

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -2,7 +2,12 @@ PROJECT_NAME           = @PACKAGE_NAME@
 
 PROJECT_NUMBER         = @PACKAGE_VERSION@
 
+PROJECT_BRIEF          = Library implementing the XKB specification for parsing \
+                         keyboard descriptions and handling keyboard state
+
 OUTPUT_DIRECTORY       = @OUTPUT_DIRECTORY@
+
+SITEMAP_URL            = https://xkbcommon.org/doc/@PACKAGE_VERSION@/
 
 BRIEF_MEMBER_DESC      = NO
 
@@ -31,6 +36,8 @@ USE_MDFILE_AS_MAINPAGE = README.md
 
 VERBATIM_HEADERS       = NO
 
+MARKDOWN_ID_STYLE      = GITHUB
+
 ALPHABETICAL_INDEX     = NO
 
 IGNORE_PREFIX          = xkb_ \
@@ -38,13 +45,19 @@ IGNORE_PREFIX          = xkb_ \
                          rxkb_ \
                          RXKB_
 
+DISABLE_INDEX          = NO
+
+GENERATE_TREEVIEW      = NO
+
+FULL_SIDEBAR           = NO
+
 HTML_EXTRA_STYLESHEET  = doc/doxygen-extra.css
 
 TIMESTAMP              = NO
 
 ENUM_VALUES_PER_LINE   = 1
 
-SEARCHENGINE           = NO
+SEARCHENGINE           = YES
 
 GENERATE_LATEX         = NO
 

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -15,7 +15,8 @@ JAVADOC_AUTOBRIEF      = YES
 
 OPTIMIZE_OUTPUT_FOR_C  = YES
 
-EXTENSION_MAPPING      = no_extension=md
+EXTENSION_MAPPING      = no_extension=md \
+                         txt=md
 
 SORT_MEMBER_DOCS       = NO
 
@@ -52,6 +53,8 @@ GENERATE_TREEVIEW      = NO
 FULL_SIDEBAR           = NO
 
 HTML_EXTRA_STYLESHEET  = doc/doxygen-extra.css
+
+HTML_EXTRA_FILES       = meson_options.txt
 
 TIMESTAMP              = NO
 

--- a/doc/doxygen-extra.css
+++ b/doc/doxygen-extra.css
@@ -1,7 +1,7 @@
 div#top, div.header, div.contents {
     margin-left: auto;
     margin-right: auto;
-    width: 960px;
+    max-width: 960px;
 }
 
 .footer {

--- a/doc/keymap-format-text-v1.md
+++ b/doc/keymap-format-text-v1.md
@@ -54,7 +54,7 @@ Some additional resources are:
 -->
 
 [terminology]: @ref terminology
-[introduction]: @ref introduction
+[introduction]: @ref introduction-to-the-xkb-text-format
 [xkb_keymap]: @ref the-xkb_keymap-block
 [xkb_keycodes]: @ref the-xkb_keycodes-section
 [xkb_types]: @ref the-xkb_types-section
@@ -350,7 +350,7 @@ Some additional resources are:
 [ISO9995]: https://en.wikipedia.org/wiki/ISO/IEC_9995
 
 
-## Introduction to the XKB text format {#introduction}
+## Introduction to the XKB text format
 
 The XKB text format uses a syntax similar to the [C programming language][C].
 Note that the similarity with C stops here: the XKB text format is only a

--- a/meson.build
+++ b/meson.build
@@ -1044,6 +1044,7 @@ You can disable the documentation with -Denable-docs=false.''')
 
     doxygen_input = [
         'README.md',
+        'meson_options.txt',
         'doc/debugging.md',
         'doc/diagrams/xkb-configuration.dot',
         'doc/diagrams/xkb-keymap-components.dot',


### PR DESCRIPTION
- Use classical layout without a side bar, which is the default in
  recent Doxygen versions.
- Enable the Javascript-base search engine.
- Use Github-style heading IDs: more user-friendly and stable.
- Generate `sitemaps.xml`.
- Fix CSS width incompatible with small devices.
- Improve README