### PR TITLE
tools: Fix compile-keymap default KcCGST values

### DIFF
--- a/tools/compile-keymap.c
+++ b/tools/compile-keymap.c
@@ -270,10 +270,13 @@ print_rmlvo(struct xkb_context *ctx, const struct xkb_rule_names *rmlvo)
 }
 
 static int
-print_kccgst(struct xkb_context *ctx, const struct xkb_rule_names *rmlvo)
+print_kccgst(struct xkb_context *ctx, struct xkb_rule_names *rmlvo)
 {
 #if ENABLE_PRIVATE_APIS
         struct xkb_component_names kccgst;
+
+        /* Resolve default RMLVO values */
+        xkb_context_sanitize_rule_names(ctx, rmlvo);
 
         if (!xkb_components_from_rules(ctx, rmlvo, &kccgst, NULL))
             return EXIT_FAILURE;


### PR DESCRIPTION
Values may be read from the environment!

While working on a xkbcomp MR I was very confused by `<BKSP>` being mapped differently with and without an option that does *not* affect it. It turns out it is just `compile-keymap` that replaces null options with my env variable `$XKB_DEFAULT_OPTIONS = terminate:ctrl_alt_bksp`, as expected.

But debugging with `--kccgst` did not help, because it does not take the environment into account.

Now I am wondering how we could document this better in the tool and if how to read the env to output `usage` with correct default values.
