### PR TITLE
Add clangd configuration file

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,8 @@
+CompileFlags:
+  # Treat files as C, not C++.
+  Add: [-xc]
+Diagnostics:
+  Includes:
+    # config.h should be included at the top of files, even if not needed.
+    # Don't consider it unused.
+    IgnoreHeader: config\.h


### PR DESCRIPTION
It mostly works by default, as long as the meson build directory is called "build". Just needs a couple of project-specific tweaks.
