### PR TITLE
tools: Do not load names from the environment by default

### DIFF
--- a/changes/tools/+enable-environment-names.breaking.md
+++ b/changes/tools/+enable-environment-names.breaking.md
@@ -1,0 +1,3 @@
+The tools do not load the *default* RMLVO (rules, model, layout, variant, options)
+values from the environment anymore. The previous behavior may be restored by using
+the new `--enable-environment-names` option.

--- a/test/tool-option-parsing.py
+++ b/test/tool-option-parsing.py
@@ -33,19 +33,6 @@ except KeyError:
         file=sys.stderr,
     )
 
-
-# Unset some environment variables, so that tools that rely on them for missing
-# arguments default have the expected behavior.
-for key in (
-    "XKB_DEFAULT_RULES",
-    "XKB_DEFAULT_MODEL",
-    "XKB_DEFAULT_LAYOUT",
-    "XKB_DEFAULT_VARIANT",
-    "XKB_DEFAULT_OPTIONS",
-):
-    if key in os.environ:
-        del os.environ[key]
-
 # Ensure locale is C, so we can check error messages in English
 os.environ["LC_ALL"] = "C.UTF-8"
 

--- a/tools/xkbcli-compile-keymap.1
+++ b/tools/xkbcli-compile-keymap.1
@@ -66,6 +66,23 @@ The XKB layout variant
 .
 .It Fl \-options Ar options
 The XKB options
+.
+.It Fl \-enable\-environment\-names
+Allow to set the default RMLVO values via the following environment variables:
+.Bl -dash -compact -hang
+.It
+.Ev XKB_DEFAULT_RULES
+.It
+.Ev XKB_DEFAULT_MODEL
+.It
+.Ev XKB_DEFAULT_LAYOUT
+.It
+.Ev XKB_DEFAULT_VARIANT
+.It
+.Ev XKB_DEFAULT_OPTIONS
+.El
+Note that this option may affect the default values of the previous options.
+.
 .El
 .
 .Sh SEE ALSO

--- a/tools/xkbcli-how-to-type.1
+++ b/tools/xkbcli-how-to-type.1
@@ -89,6 +89,22 @@ The XKB layout variant
 .It Fl \-options Ar options
 The XKB options
 .
+.It Fl \-enable\-environment\-names
+Allow to set the default RMLVO values via the following environment variables:
+.Bl -dash -compact -hang
+.It
+.Ev XKB_DEFAULT_RULES
+.It
+.Ev XKB_DEFAULT_MODEL
+.It
+.Ev XKB_DEFAULT_LAYOUT
+.It
+.Ev XKB_DEFAULT_VARIANT
+.It
+.Ev XKB_DEFAULT_OPTIONS
+.El
+Note that this option may affect the default values of the previous options.
+.
 .It Fl \-help
 Print a help message and exit.
 .El

--- a/tools/xkbcli-interactive-evdev.1
+++ b/tools/xkbcli-interactive-evdev.1
@@ -70,6 +70,22 @@ The XKB layout variant
 .It Fl \-option Ar options
 The XKB options
 .
+.It Fl \-enable\-environment\-names
+Allow to set the default RMLVO values via the following environment variables:
+.Bl -dash -compact -hang
+.It
+.Ev XKB_DEFAULT_RULES
+.It
+.Ev XKB_DEFAULT_MODEL
+.It
+.Ev XKB_DEFAULT_LAYOUT
+.It
+.Ev XKB_DEFAULT_VARIANT
+.It
+.Ev XKB_DEFAULT_OPTIONS
+.El
+Note that this option may affect the default values of the previous options.
+.
 .It Fl \-keymap Ar file
 Specify a keymap path.
 This option is mutually exclusive with the RMLVO options.


### PR DESCRIPTION
Our tools are debugging tools and as such we need to have complete control to be able to reproduce setups. This is not currently the case, as we do not use `XKB_CONTEXT_NO_ENVIRONMENT_NAMES` by default nor can we set it.

So it is very easy to forget about the various `XKB_DEFAULT_*` environement variables for the default RMLVO values, then to get puzzled by unexpected results.

Added to that, these environment variables do not work correctly in `xkbcli-compile-xeymap`: calling the tool without RMLVO values will use these variables only if the RMLVO values are set explicitly empty or if the various *constants* `DEFAULT_XKB_*` are empty. This is unexpected, as the environment variables should *always* be used unless:

- `XKB_CONTEXT_NO_ENVIRONMENT_NAMES` is used (not the case here);
- the variable is empty; in this case the constants `DEFAULT_XKB_*` are used.

Fixed by the following *breaking change*: make the tools use `XKB_CONTEXT_NO_ENVIRONMENT_NAMES` *by default*, unless the new `--enable-environment-names` option is used.