### PR TITLE
doc: Fix link to modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ While libxkbcommon’s API is somewhat derived from the classic XKB API as found
 in `X11/extensions/XKB.h` and friends, it has been substantially reworked to
 expose fewer internal details to clients.
 
-See the [API Documentation](https://xkbcommon.org/doc/current/modules.html).
+See the [API Documentation](https://xkbcommon.org/doc/current/topics.html).
 
 ## Dataset
 


### PR DESCRIPTION
It’s a *breaking* change of Doxygen. Now it’s called “topics”.

I’m getting tired of fixing Doxygen’s lack of stability.

Fixes #666