### PR TITLE
keymap: fix modular arithmetic

### DIFF
--- a/changes/api/+group-wrap.bugfix.md
+++ b/changes/api/+group-wrap.bugfix.md
@@ -1,0 +1,7 @@
+Fixed segfault due to invalid arithmetic to bring *negative* layout indexes
+into range. It triggers with the following settings:
+
+- layouts count (per key or total) N: `N > 0`, and
+- layout index n: `n = - k * N` (`k > 0`)
+
+Note that these settings are unlikely in usual use cases.


### PR DESCRIPTION
Consider num_groups = 1.

Fixes: 67b03cea ("state: correctly wrap state->locked_group and ->group")

-----

This should be backported.