### PR TITLE
Rules: KcCGST public API

### DIFF
--- a/bench/rules.c
+++ b/bench/rules.c
@@ -7,8 +7,8 @@
 
 #include <time.h>
 
+#include "xkbcommon/xkbcommon.h"
 #include "../test/test.h"
-#include "xkbcomp/xkbcomp-priv.h"
 #include "xkbcomp/rules.h"
 #include "bench.h"
 
@@ -38,8 +38,9 @@ main(int argc, char *argv[])
         assert(xkb_components_from_rules(ctx, &rmlvo, &kccgst, NULL));
         free(kccgst.keycodes);
         free(kccgst.types);
-        free(kccgst.compat);
+        free(kccgst.compatibility);
         free(kccgst.symbols);
+        free(kccgst.geometry);
     }
     bench_stop(&bench);
 

--- a/changes/api/669.feature.md
+++ b/changes/api/669.feature.md
@@ -1,0 +1,5 @@
+Added function `xkb_components_names_from_rules()` to compute
+<abbr title="Keycodes, Compatibility, Geometry, Symbols, Types">KcCGST</abbr>
+keymap components from
+<abbr title="Rules, Model, Layout, Variant, Options">RMLVO</abbr> names resolution.
+This mainly for *debugging* purposes and to enable the `--kccgst` option in the tools.

--- a/changes/tools/669.feature.md
+++ b/changes/tools/669.feature.md
@@ -1,0 +1,6 @@
+`xkbcli compile-keymap`: Added `--kccgst` option to display the result of
+<abbr title="Rules, Model, Layout, Variant, Options">RMLVO</abbr> names resolution to
+<abbr title="Keycodes, Compatibility, Geometry, Symbols, Types">KcCGST</abbr> components.
+
+This option has the same function than `setxkbmap -print`. This is particularly
+useful for debugging issues with the rules.

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -20,6 +20,7 @@
 #ifndef _XKBCOMMON_H_
 #define _XKBCOMMON_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdarg.h>
@@ -281,13 +282,26 @@ typedef uint32_t xkb_led_mask_t;
 #define xkb_keycode_is_legal_x11(key) ((key) >= 8 && (key) <= 255)
 
 /**
- * Names to compile a keymap with, also known as RMLVO.
+ * @defgroup rules-api Rules
+ * Utility functions related to *rules*, whose purpose is introduced in:
+ * @ref xkb-the-config "".
+ *
+ * @{
+ */
+
+/**
+ * Names to compile a keymap with, also known as [RMLVO].
  *
  * The names are the common configuration values by which a user picks
  * a keymap.
  *
  * If the entire struct is NULL, then each field is taken to be NULL.
  * You should prefer passing NULL instead of choosing your own defaults.
+ *
+ * @see [Introduction to RMLVO][RMLVO]
+ * @see @ref rules-api ""
+ *
+ * [RMLVO]: @ref RMLVO-intro
  */
 struct xkb_rule_names {
     /**
@@ -342,6 +356,67 @@ struct xkb_rule_names {
      */
     const char *options;
 };
+
+/**
+ * Keymap components, also known as [KcCGST].
+ *
+ * The components are the result of the [RMLVO] resolution.
+ *
+ * @see [Introduction to RMLVO][RMLVO]
+ * @see [Introduction to KcCGST][KcCGST]
+ * @see @ref rules-api ""
+ *
+ * [RMLVO]: @ref RMLVO-intro
+ * [KcCGST]: @ref KcCGST-intro
+ */
+struct xkb_component_names {
+    char *keycodes;
+    char *compatibility;
+    char *geometry;
+    char *symbols;
+    char *types;
+};
+
+/**
+ * Resolve [RMLVO] names to [KcCGST] components.
+ *
+ * This function is used primarily for *debugging*. See
+ * xkb_keymap::xkb_keymap_new_from_names() for creating keymaps from
+ * [RMLVO] names.
+ *
+ * @param[in]  context    The context in which to resolve the names.
+ * @param[in]  rmlvo_in   The [RMLVO] names to use.
+ * @param[out] rmlvo_out  The [RMLVO] names actually used after resolving
+ * missing values.
+ * @param[out] components_out The [KcCGST] components resulting of the [RMLVO]
+ * resolution.
+ *
+ * @c rmlvo_out and @c components can be omitted by using `NULL`, but not both.
+ *
+ * If @c components is not `NULL`, it is filled with dynamically-allocated
+ * strings that should be freed by the caller.
+ *
+ * @returns `true` if the [RMLVO] names could be resolved, `false` otherwise.
+ *
+ * @see [Introduction to RMLVO][RMLVO]
+ * @see [Introduction to KcCGST][KcCGST]
+ * @see xkb_rule_names
+ * @see xkb_component_names
+ * @see xkb_keymap::xkb_keymap_new_from_names()
+ *
+ * @since 1.9.0
+ * @memberof xkb_component_names
+ *
+ * [RMLVO]: @ref RMLVO-intro
+ * [KcCGST]: @ref KcCGST-intro
+ */
+XKB_EXPORT bool
+xkb_components_names_from_rules(struct xkb_context *context,
+                                const struct xkb_rule_names *rmlvo_in,
+                                struct xkb_rule_names *rmlvo_out,
+                                struct xkb_component_names *components_out);
+
+/** @} */
 
 /**
  * @defgroup keysyms Keysyms

--- a/meson.build
+++ b/meson.build
@@ -510,14 +510,6 @@ if build_tools
                                        install_dir: dir_libexec)
     install_man('tools/xkbcli-compile-keymap.1')
     configh_data.set10('HAVE_XKBCLI_COMPILE_KEYMAP', true)
-    # The same tool again, but with access to some private APIs.
-    executable('compile-keymap',
-               'tools/compile-keymap.c',
-               libxkbcommon_sources,
-               dependencies: [tools_dep],
-               c_args: ['-DENABLE_PRIVATE_APIS'],
-               include_directories: [include_directories('src', 'include')],
-               install: false)
 
     # Tool: compose
     executable('xkbcli-compile-compose',

--- a/src/xkbcomp/ast-build.c
+++ b/src/xkbcomp/ast-build.c
@@ -484,7 +484,7 @@ XkbFileFromComponents(struct xkb_context *ctx,
 {
     char *const components[] = {
         kkctgs->keycodes, kkctgs->types,
-        kkctgs->compat, kkctgs->symbols,
+        kkctgs->compatibility, kkctgs->symbols,
     };
     enum xkb_file_type type;
     IncludeStmt *include = NULL;

--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -1529,9 +1529,9 @@ xkb_components_from_rules(struct xkb_context *ctx,
 
     darray_steal(matcher->kccgst[KCCGST_KEYCODES], &out->keycodes, NULL);
     darray_steal(matcher->kccgst[KCCGST_TYPES], &out->types, NULL);
-    darray_steal(matcher->kccgst[KCCGST_COMPAT], &out->compat, NULL);
+    darray_steal(matcher->kccgst[KCCGST_COMPAT], &out->compatibility, NULL);
     darray_steal(matcher->kccgst[KCCGST_SYMBOLS], &out->symbols, NULL);
-    darray_free(matcher->kccgst[KCCGST_GEOMETRY]);
+    darray_steal(matcher->kccgst[KCCGST_GEOMETRY], &out->geometry, NULL);
 
     mval = &matcher->rmlvo.model;
     if (!mval->matched && mval->sval.len > 0)

--- a/src/xkbcomp/xkbcomp-priv.h
+++ b/src/xkbcomp/xkbcomp-priv.h
@@ -7,13 +7,6 @@
 #include "keymap.h"
 #include "ast.h"
 
-struct xkb_component_names {
-    char *keycodes;
-    char *types;
-    char *compat;
-    char *symbols;
-};
-
 char *
 text_v1_keymap_get_as_string(struct xkb_keymap *keymap);
 

--- a/test/tool-option-parsing.py
+++ b/test/tool-option-parsing.py
@@ -12,6 +12,10 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from abc import ABCMeta, abstractmethod
+from collections.abc import Generator
+from dataclasses import dataclass
+from pathlib import Path
 
 try:
     top_builddir = os.environ["top_builddir"]
@@ -35,6 +39,18 @@ except KeyError:
 
 TIMEOUT = 10.0  # seconds
 
+# Unset some environment variables, so that testing --enable-environment-names
+# does not actually depend on the current environment.
+for key in (
+    "XKB_DEFAULT_RULES",
+    "XKB_DEFAULT_MODEL",
+    "XKB_DEFAULT_LAYOUT",
+    "XKB_DEFAULT_VARIANT",
+    "XKB_DEFAULT_OPTIONS",
+):
+    if key in os.environ:
+        del os.environ[key]
+
 # Ensure locale is C, so we can check error messages in English
 os.environ["LC_ALL"] = "C.UTF-8"
 
@@ -42,20 +58,118 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger("test")
 logger.setLevel(logging.DEBUG)
 
-# Permutation of RMLVO that we use in multiple tests
-rmlvos = [
-    list(x)
-    for x in itertools.permutations(
-        ["--rules=evdev", "--model=pc104", "--layout=ch", "--options=eurosign:5"]
+
+def powerset(iterable):
+    "Subsequences of the iterable from shortest to longest."
+    # powerset([1,2,3]) → () (1,) (2,) (3,) (1,2) (1,3) (2,3) (1,2,3)
+    s = tuple(iterable)
+    return itertools.chain.from_iterable(
+        itertools.combinations(s, r) for r in range(len(s) + 1)
     )
-]
+
+
+# Permutation of RMLVO that we use in multiple tests
+rmlvo_options = (
+    "--rules=evdev",
+    "--model=pc104",
+    "--layout=ch",
+    "--options=eurosign:5",
+    "--enable-environment-names",
+)
+rmlvos = tuple(
+    map(
+        list,
+        itertools.chain(
+            itertools.permutations(rmlvo_options[:-1]),
+            powerset(rmlvo_options),
+        ),
+    )
+)
+
+
+@dataclass
+class RMLVO:
+    rules: str | None = None
+    model: str | None = None
+    layout: str | None = None
+    variant: str | None = None
+    options: str | None = None
+    env: bool = False
+
+    def __iter__(self) -> Generator[tuple[str, ...]]:
+        if self.rules is not None:
+            yield "--rules", self.rules
+        if self.model is not None:
+            yield "--model", self.model
+        if self.layout is not None:
+            yield "--layout", self.layout
+        if self.variant is not None:
+            yield "--variant", self.variant
+        if self.options is not None:
+            yield "--options", self.options
+        if self.env:
+            yield ("--enable-environment-names",)
+
+    @property
+    def args(self) -> list[str]:
+        return list(itertools.chain.from_iterable(self))
+
+
+class Target(metaclass=ABCMeta):
+    @property
+    @abstractmethod
+    def args(self) -> list[str]: ...
+
+    @property
+    def stdin(self) -> str | None:
+        return None
+
+
+class RmlvoTarget(Target):
+    @property
+    def args(self) -> list[str]:
+        return ["--rmlvo"]
+
+
+@dataclass
+class KeymapTarget(Target, RMLVO):
+    arg: bool = False
+    path: Path | None = None
+    stdin: str | None = None
+
+    def _args(self) -> Generator[str]:
+        yield from itertools.chain.from_iterable(self)
+        if self.arg:
+            yield "--keymap"
+        if self.path:
+            yield str(self.path)
+
+    @property
+    def args(self) -> list[str]:
+        return list(self._args())
+
+    @property
+    def use_rmlvo(self) -> bool:
+        return (
+            not self.arg
+            and not self.path
+            and (
+                bool(self.rules)
+                or bool(self.model)
+                or bool(self.layout)
+                or bool(self.variant)
+                or bool(self.options)
+                or bool(self.env)
+                or not self.stdin
+            )
+        )
 
 
 def _disable_coredump():
     resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
 
 
-def run_command(args):
+def run_command(args, input: str | None = None):
     logger.debug("run command: {}".format(" ".join(args)))
 
     try:
@@ -63,6 +177,7 @@ def run_command(args):
             args,
             preexec_fn=_disable_coredump,
             capture_output=True,
+            input=input,
             text=True,
             timeout=0.7,
         )
@@ -81,7 +196,7 @@ class XkbcliTool:
         self.skipIf = skipIf
         self.skipError = skipError
 
-    def run_command(self, args):
+    def run_command(self, args, input: str | None = None):
         for condition, reason in self.skipIf:
             if condition:
                 raise unittest.SkipTest(reason)
@@ -91,10 +206,10 @@ class XkbcliTool:
             tool = self.xkbcli_tool
         args = [os.path.join(self.tool_path, tool)] + args
 
-        return run_command(args)
+        return run_command(args, input=input)
 
-    def run_command_success(self, args):
-        rc, stdout, stderr = self.run_command(args)
+    def run_command_success(self, args, input: str | None = None):
+        rc, stdout, stderr = self.run_command(args, input=input)
         if rc != 0:
             for testfunc, reason in self.skipError:
                 if testfunc(rc, stdout, stderr):
@@ -102,8 +217,8 @@ class XkbcliTool:
         assert rc == 0, (rc, stdout, stderr)
         return stdout, stderr
 
-    def run_command_invalid(self, args):
-        rc, stdout, stderr = self.run_command(args)
+    def run_command_invalid(self, args, input: str | None = None):
+        rc, stdout, stderr = self.run_command(args, input=input)
         assert rc == 2, (rc, stdout, stderr)
         return rc, stdout, stderr
 
@@ -214,25 +329,61 @@ class TestXkbcli(unittest.TestCase):
         self.xkbcli.run_command_invalid(["a"] * 64)
 
     def test_compile_keymap_args(self):
-        for args in (
-            ["--verbose"],
-            ["--rmlvo"],
-            # ['--kccgst'],
-            ["--verbose", "--rmlvo"],
-            # ['--verbose', '--kccgst'],
+        xkb_root = Path(os.environ["XKB_CONFIG_ROOT"])
+        keymap_path = xkb_root / "keymaps/masks.xkb"
+        keymap_string = keymap_path.read_text(encoding="utf-8")
+        test_option = "--test"
+        target: Target
+        for target in (
+            RmlvoTarget(),
+            # TODO: --kccgst
+            # Keymap from RMLVO
+            KeymapTarget(),
+            # Keymap from RMLVO (stdin ignored)
+            KeymapTarget(layout="us", stdin=keymap_string),
+            KeymapTarget(env=True, stdin=keymap_string),
+            # Keymap parsed from keymap file
+            KeymapTarget(arg=False, path=keymap_path),
+            KeymapTarget(arg=True, path=keymap_path),
+            # Keymap parsed from stdin
+            KeymapTarget(arg=False, stdin=keymap_string),
+            KeymapTarget(arg=True, stdin=keymap_string),
         ):
-            with self.subTest(args=args):
-                self.xkbcli_compile_keymap.run_command_success(args)
+            for options in powerset(("--verbose", test_option)):
+                args = list(options) + target.args
+                with self.subTest(args=args):
+                    stdout, stderr = self.xkbcli_compile_keymap.run_command_success(
+                        args, input=target.stdin
+                    )
+                    if test_option in options:
+                        # Expect no output
+                        assert stdout == "", (target, stdout)
+                    if isinstance(target, KeymapTarget) and test_option not in options:
+                        # Check keymap output for excepted bits:
+                        # - <AB01> is not defined in mask.xkb
+                        # - virtual_modifiers Test01 is only defined in masks.xkb
+                        assert ("<AB01>" in stdout) ^ (not target.use_rmlvo), (
+                            target,
+                            stdout,
+                            stderr,
+                        )
+                        assert ("virtual_modifiers Test01" in stdout) ^ (
+                            target.use_rmlvo
+                        ), (target, stdout, stderr)
 
     def test_compile_keymap_rmlvo(self):
-        def run(rmlvo):
-            return self.xkbcli_compile_keymap.run_command_success(rmlvo)
+        def run(target, rmlvo):
+            return self.xkbcli_compile_keymap.run_command_success(target + rmlvo)
 
         with concurrent.futures.ThreadPoolExecutor() as executor:
-            futures = {executor.submit(run, rmlvo): rmlvo for rmlvo in rmlvos}
+            futures = {
+                executor.submit(run, target.args, rmlvo): (target, rmlvo)
+                for target in (RmlvoTarget(), KeymapTarget())
+                for rmlvo in rmlvos
+            }
             for future in concurrent.futures.as_completed(futures, TIMEOUT):
-                rmlvo = futures[future]
-                with self.subTest(rmlvo=rmlvo):
+                target, rmlvo = futures[future]
+                with self.subTest(target=target, rmlvo=rmlvo):
                     future.result()
 
     def test_compile_keymap_include(self):

--- a/test/tool-option-parsing.py
+++ b/test/tool-option-parsing.py
@@ -132,6 +132,12 @@ class RmlvoTarget(Target):
         return ["--rmlvo"]
 
 
+class KccgstTarget(Target):
+    @property
+    def args(self) -> list[str]:
+        return ["--kccgst"]
+
+
 @dataclass
 class KeymapTarget(Target, RMLVO):
     arg: bool = False
@@ -337,7 +343,7 @@ class TestXkbcli(unittest.TestCase):
         target: Target
         for target in (
             RmlvoTarget(),
-            # TODO: --kccgst
+            KccgstTarget(),
             # Keymap from RMLVO
             KeymapTarget(),
             # Keymap from RMLVO (stdin ignored)
@@ -380,6 +386,7 @@ class TestXkbcli(unittest.TestCase):
         keymap_from_path1 = KeymapTarget(arg=True, path=Path(keymap_path))
         keymap_from_path2 = KeymapTarget(arg=False, path=Path(keymap_path))
         rmlvo = RmlvoTarget()
+        kccgst = KccgstTarget()
         for args in (
             # --keymap does not use RMLVO options
             ("--rules", "some-rules", keymap_from_stdin),
@@ -402,6 +409,13 @@ class TestXkbcli(unittest.TestCase):
             (rmlvo, keymap_from_stdin),
             (rmlvo, keymap_from_path1),
             (rmlvo, keymap_from_path2),
+            [kccgst, keymap_from_stdin],
+            [kccgst, keymap_from_path1],
+            [kccgst, keymap_from_path2],
+            [kccgst, rmlvo],
+            [kccgst, rmlvo, keymap_from_stdin],
+            [kccgst, rmlvo, keymap_from_path1],
+            [kccgst, rmlvo, keymap_from_path2],
         ):
             with self.subTest(args=args):
                 args = list(
@@ -424,7 +438,7 @@ class TestXkbcli(unittest.TestCase):
         with concurrent.futures.ThreadPoolExecutor() as executor:
             futures = {
                 executor.submit(run, target.args, rmlvo): (target, rmlvo)
-                for target in (RmlvoTarget(), KeymapTarget())
+                for target in (RmlvoTarget(), KccgstTarget(), KeymapTarget())
                 for rmlvo in rmlvos
             }
             for future in concurrent.futures.as_completed(futures, TIMEOUT):

--- a/tools/compile-keymap.c
+++ b/tools/compile-keymap.c
@@ -347,11 +347,12 @@ print_kccgst(struct xkb_context *ctx, struct xkb_rule_names *rmlvo)
                "  xkb_compat { include \"%s\" };\n"
                "  xkb_symbols { include \"%s\" };\n"
                "};\n",
-               kccgst.keycodes, kccgst.types, kccgst.compat, kccgst.symbols);
+               kccgst.keycodes, kccgst.types, kccgst.compatibility,
+               kccgst.symbols);
 out:
         free(kccgst.keycodes);
         free(kccgst.types);
-        free(kccgst.compat);
+        free(kccgst.compatibility);
         free(kccgst.symbols);
 
         return EXIT_SUCCESS;

--- a/tools/xkbcli-compile-keymap.1
+++ b/tools/xkbcli-compile-keymap.1
@@ -33,6 +33,10 @@ Test compilation but do not print the keymap
 .It Fl \-rmlvo
 Print the full RMLVO with the defaults filled in for missing elements
 .
+.It Fl \-kccgst
+Print a keymap which only includes the KcCGST component names instead
+of the full keymap
+.
 .It Fl \-keymap Oo Ar PATH Oc , Fl \-from\-xkb Oo Ar PATH Oc
 Load the XKB file from a file, ignore RMLVO options. If
 .Ar PATH

--- a/xkbcommon.map
+++ b/xkbcommon.map
@@ -119,3 +119,7 @@ global:
     xkb_compose_table_iterator_free;
     xkb_compose_table_iterator_next;
 } V_1.0.0;
+
+V_1.9.0 {
+    xkb_components_names_from_rules;
+} V_1.6.0;


### PR DESCRIPTION
- rules: Added `xkb_components_names_from_rules()`

  This is mainly for debugging purposes and to enable displaying KcCGST values from RMLVO resolution in `xkbcli compile-keymap --kccgst`.
- tools: Make `--kccgst` `compile-keymap` option public

  The new public option `--kccgst` enables to display the result of RMLVO resolution to KcCGST components.

  This option has the same function than `setxkbmap -print`. This is particularly useful for debugging issues with the rules.

  Before this commit it was a private API. This commit enables us to remove the *internal* version of `xkbcli-compile-keymap`.

Fixes #669