### PR TITLE
xkbcomp: Improve logging of virtual modifiers

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,8 +43,14 @@ jobs:
           # HACK: We use meson to install, while it would be cleaner
           #       to create a proper package to install or use some PPA.
           pushd ~
-          git clone --depth=1 https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config.git
-          cd "xkeyboard-config"
+          # FIXME: gitlab.freedesktop.org is currently migrating.
+          #        Use latest release instead.
+          # git clone --depth=1 https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config.git
+          # pushd "xkeyboard-config"
+          XKEYBOARD_CONFIG_VERSION="2.44"
+          wget http://www.x.org/releases/individual/data/xkeyboard-config/xkeyboard-config-$XKEYBOARD_CONFIG_VERSION.tar.xz
+          tar -xf xkeyboard-config-$XKEYBOARD_CONFIG_VERSION.tar.xz
+          pushd "xkeyboard-config-$XKEYBOARD_CONFIG_VERSION"
           BUILDDIR=build
           meson setup $BUILDDIR -Dprefix=/usr
           meson install -C $BUILDDIR

--- a/src/text.h
+++ b/src/text.h
@@ -34,8 +34,8 @@ extern const LookupEntry actionTypeNames[];
 extern const LookupEntry symInterpretMatchMaskNames[];
 
 const char *
-ModMaskText(struct xkb_context *ctx, const struct xkb_mod_set *mods,
-            xkb_mod_mask_t mask);
+ModMaskText(struct xkb_context *ctx, enum mod_type type,
+            const struct xkb_mod_set *mods, xkb_mod_mask_t mask);
 
 const char *
 ModIndexText(struct xkb_context *ctx, const struct xkb_mod_set *mods,

--- a/src/xkbcomp/compat.c
+++ b/src/xkbcomp/compat.c
@@ -71,7 +71,7 @@ siText(SymInterpInfo *si, CompatInfo *info)
     snprintf(buf, 128, "%s+%s(%s)",
              KeysymText(info->ctx, si->interp.sym),
              SIMatchText(si->interp.match),
-             ModMaskText(info->ctx, &info->mods, si->interp.mods));
+             ModMaskText(info->ctx, MOD_BOTH, &info->mods, si->interp.mods));
 
     return buf;
 }

--- a/src/xkbcomp/types.c
+++ b/src/xkbcomp/types.c
@@ -46,7 +46,7 @@ typedef struct {
 static inline const char *
 MapEntryTxt(KeyTypesInfo *info, struct xkb_key_type_entry *entry)
 {
-    return ModMaskText(info->ctx, &info->mods, entry->mods.mods);
+    return ModMaskText(info->ctx, MOD_BOTH, &info->mods, entry->mods.mods);
 }
 
 static inline const char *
@@ -58,7 +58,7 @@ TypeTxt(KeyTypesInfo *info, KeyTypeInfo *type)
 static inline const char *
 TypeMaskTxt(KeyTypesInfo *info, KeyTypeInfo *type)
 {
-    return ModMaskText(info->ctx, &info->mods, type->mods);
+    return ModMaskText(info->ctx, MOD_BOTH, &info->mods, type->mods);
 }
 
 static inline bool
@@ -263,7 +263,7 @@ SetModifiers(KeyTypesInfo *info, KeyTypeInfo *type, ExprDef *arrayNdx,
                  "Using %s, ignoring %s\n",
                  xkb_atom_text(info->ctx, type->name),
                  TypeMaskTxt(info, type),
-                 ModMaskText(info->ctx, &info->mods, mods));
+                 ModMaskText(info->ctx, MOD_BOTH, &info->mods, mods));
         return false;
     }
 
@@ -344,7 +344,7 @@ SetMapEntry(KeyTypesInfo *info, KeyTypeInfo *type, ExprDef *arrayNdx,
                 "Map entry for modifiers not used by type %s; "
                 "Using %s instead of %s\n",
                 TypeTxt(info, type),
-                ModMaskText(info->ctx, &info->mods,
+                ModMaskText(info->ctx, MOD_BOTH, &info->mods,
                             entry.mods.mods & type->mods),
                 MapEntryTxt(info, &entry));
         entry.mods.mods &= type->mods;
@@ -386,7 +386,7 @@ AddPreserve(KeyTypesInfo *info, KeyTypeInfo *type,
             log_vrb(info->ctx, 10, XKB_WARNING_DUPLICATE_ENTRY,
                     "Identical definitions for preserve[%s] in %s; "
                     "Ignored\n",
-                    ModMaskText(info->ctx, &info->mods, mods),
+                    ModMaskText(info->ctx, MOD_BOTH, &info->mods, mods),
                     TypeTxt(info, type));
             return true;
         }
@@ -395,10 +395,11 @@ AddPreserve(KeyTypesInfo *info, KeyTypeInfo *type,
         log_vrb(info->ctx, 1, XKB_WARNING_CONFLICTING_KEY_TYPE_PRESERVE_ENTRIES,
                 "Multiple definitions for preserve[%s] in %s; "
                 "Using %s, ignoring %s\n",
-                ModMaskText(info->ctx, &info->mods, mods),
+                ModMaskText(info->ctx, MOD_BOTH, &info->mods, mods),
                 TypeTxt(info, type),
-                ModMaskText(info->ctx, &info->mods, preserve_mods),
-                ModMaskText(info->ctx, &info->mods, entry->preserve.mods));
+                ModMaskText(info->ctx, MOD_BOTH, &info->mods, preserve_mods),
+                ModMaskText(info->ctx, MOD_BOTH, &info->mods,
+                            entry->preserve.mods));
 
         entry->preserve.mods = preserve_mods;
         return true;
@@ -432,9 +433,9 @@ SetPreserve(KeyTypesInfo *info, KeyTypeInfo *type, ExprDef *arrayNdx,
     if (mods & ~type->mods) {
         const char *before, *after;
 
-        before = ModMaskText(info->ctx, &info->mods, mods);
+        before = ModMaskText(info->ctx, MOD_BOTH, &info->mods, mods);
         mods &= type->mods;
-        after = ModMaskText(info->ctx, &info->mods, mods);
+        after = ModMaskText(info->ctx, MOD_BOTH, &info->mods, mods);
 
         log_vrb(info->ctx, 1, XKB_WARNING_UNDECLARED_MODIFIERS_IN_KEY_TYPE,
                 "Preserve entry for modifiers not used by the %s type; "
@@ -448,7 +449,7 @@ SetPreserve(KeyTypesInfo *info, KeyTypeInfo *type, ExprDef *arrayNdx,
         log_err(info->ctx, XKB_ERROR_UNSUPPORTED_MODIFIER_MASK,
                 "Preserve value in a key type is not a modifier mask; "
                 "Ignoring preserve[%s] in type %s\n",
-                ModMaskText(info->ctx, &info->mods, mods),
+                ModMaskText(info->ctx, MOD_BOTH, &info->mods, mods),
                 TypeTxt(info, type));
         return false;
     }
@@ -456,14 +457,14 @@ SetPreserve(KeyTypesInfo *info, KeyTypeInfo *type, ExprDef *arrayNdx,
     if (preserve_mods & ~mods) {
         const char *before, *after;
 
-        before = ModMaskText(info->ctx, &info->mods, preserve_mods);
+        before = ModMaskText(info->ctx, MOD_BOTH, &info->mods, preserve_mods);
         preserve_mods &= mods;
-        after = ModMaskText(info->ctx, &info->mods, preserve_mods);
+        after = ModMaskText(info->ctx, MOD_BOTH, &info->mods, preserve_mods);
 
         log_vrb(info->ctx, 1, XKB_WARNING_ILLEGAL_KEY_TYPE_PRESERVE_RESULT,
                 "Illegal value for preserve[%s] in type %s; "
                 "Converted %s to %s\n",
-                ModMaskText(info->ctx, &info->mods, mods),
+                ModMaskText(info->ctx, MOD_BOTH, &info->mods, mods),
                 TypeTxt(info, type), before, after);
     }
 

--- a/src/xkbcomp/vmod.c
+++ b/src/xkbcomp/vmod.c
@@ -63,8 +63,8 @@ HandleVModDef(struct xkb_context *ctx, struct xkb_mod_set *mods,
                          "Virtual modifier %s defined multiple times; "
                          "Using %s, ignoring %s\n",
                          xkb_atom_text(ctx, stmt->name),
-                         ModMaskText(ctx, mods, use),
-                         ModMaskText(ctx, mods, ignore));
+                         ModMaskText(ctx, MOD_REAL, mods, use),
+                         ModMaskText(ctx, MOD_REAL, mods, ignore));
 
                 mapping = use;
             }


### PR DESCRIPTION
When logging about virtual modifier *explicit* mappings, we should always use only real modifiers or hexadecimal numbers to print the mask.

Consider:

```
virtual_modifiers M1, M2=0x200, M2=0x400;
```

Before this commit we would get the following warning:

```
WARNING: Virtual modifier M2 defined multiple times; Using M2, ignoring M1
```

while we would prefer the less confusing:

```
WARNING: Virtual modifier M2 defined multiple times; Using 0x400, ignoring 0x200
```