### PR TITLE
xkbcomp: Fix keycodes bounds

### DIFF
--- a/src/registry.c
+++ b/src/registry.c
@@ -1210,7 +1210,7 @@ validate(struct rxkb_context *ctx, xmlDoc *doc)
                                       XML_CHAR_ENCODING_NONE);
     if (!buf)
         goto dtd_error;
-    xmlDtd *dtd = dtd = xmlIOParseDTD(NULL, buf, XML_CHAR_ENCODING_UTF8);
+    xmlDtd *dtd = xmlIOParseDTD(NULL, buf, XML_CHAR_ENCODING_UTF8);
 #endif
 
     if (!dtd) {

--- a/test/data/keymaps/keycodes-bounds-multiple-1.xkb
+++ b/test/data/keymaps/keycodes-bounds-multiple-1.xkb
@@ -1,0 +1,23 @@
+xkb_keymap {
+xkb_keycodes "(unnamed)" {
+	minimum = 1;
+	maximum = 300;
+	<A>                  = 1;
+	<B>                  = 300;
+};
+
+xkb_types "(unnamed)" {
+	type "default" {
+		modifiers= none;
+	};
+};
+
+xkb_compatibility "(unnamed)" {
+	interpret.useModMapMods= AnyLevel;
+	interpret.repeat= False;
+};
+
+xkb_symbols "(unnamed)" {
+};
+
+};

--- a/test/data/keymaps/keycodes-bounds-single-1.xkb
+++ b/test/data/keymaps/keycodes-bounds-single-1.xkb
@@ -1,0 +1,22 @@
+xkb_keymap {
+xkb_keycodes "(unnamed)" {
+	minimum = 1;
+	maximum = 255;
+	<A>                  = 1;
+};
+
+xkb_types "(unnamed)" {
+	type "default" {
+		modifiers= none;
+	};
+};
+
+xkb_compatibility "(unnamed)" {
+	interpret.useModMapMods= AnyLevel;
+	interpret.repeat= False;
+};
+
+xkb_symbols "(unnamed)" {
+};
+
+};

--- a/test/data/keymaps/keycodes-bounds-single-2.xkb
+++ b/test/data/keymaps/keycodes-bounds-single-2.xkb
@@ -1,0 +1,22 @@
+xkb_keymap {
+xkb_keycodes "(unnamed)" {
+	minimum = 8;
+	maximum = 300;
+	<A>                  = 300;
+};
+
+xkb_types "(unnamed)" {
+	type "default" {
+		modifiers= none;
+	};
+};
+
+xkb_compatibility "(unnamed)" {
+	interpret.useModMapMods= AnyLevel;
+	interpret.repeat= False;
+};
+
+xkb_symbols "(unnamed)" {
+};
+
+};


### PR DESCRIPTION
- Refactor to check conflicts first for the key names and then for the keycodes. This seems more usefull for the user and enable further memory optimizations.
- Do not allocate until we are sure to add the keycode. The bounds are only updated afterwards, so the call to `FindKeyByName` should be more efficient.
- Fixed keycodes bounds not shrunk correctly when an existing keycode is overridden.
- Do not prepare keyname strings for logging if we are not going to use them.

The bug is really minor. Do not expect much perf improvement in usual cases. 

*However*, this fix is mandatory for testing #592.