### PR TITLE
xkbcomp: Fix parser failure on floats

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -33,9 +33,12 @@ jobs:
           python -m pip install --upgrade meson PyYAML ruff
           sudo apt update
           sudo apt install -y \
+            locales tzdata \
             doxygen libxcb-xkb-dev valgrind ninja-build \
             libwayland-dev wayland-protocols bison graphviz libicu-dev \
             ${{ matrix.sanitizers == 'sanitizers' && 'libasan8 libubsan1' || '' }}
+          # Generate locale for tests
+          sudo locale-gen fr_FR.UTF-8
       - name: Install xkeyboard-config
         run: |
           # Install master version of xkeyboard-config, in order to ensure
@@ -65,12 +68,15 @@ jobs:
         run: |
           meson compile -C build
       - name: Test
+        # Use a specific non-US locale
         run:
-          meson test -C build --print-errorlogs
+          LC_ALL=fr_FR.UTF-8 meson test -C build --print-errorlogs
       - name: Test with valgrind
         if: matrix.sanitizers != 'sanitizers'
-        run:
-          meson test -C build --print-errorlogs --setup=valgrind --no-suite python-tests
+        # Use a specific non-US locale
+        run: |
+          LC_ALL=fr_FR.UTF-8 meson test -C build --print-errorlogs --setup=valgrind \
+                                                 --no-suite python-tests
       - name: Upload test logs
         uses: actions/upload-artifact@v4
         if: failure()

--- a/changes/api/+locale-dependent-floats.bugfix.md
+++ b/changes/api/+locale-dependent-floats.bugfix.md
@@ -1,0 +1,16 @@
+Fixed floating-point number parsing failling on locales that use a decimal
+separator different than the period `.`.
+
+Note that the issue is unlikely to happen even with such locales, unless
+*parsing* a keymap with a *geometry* component which contains floating-point
+numbers.
+
+Affected API:
+- `xkb_keymap_new_from_file()`,
+- `xkb_keymap_new_from_buffer()`,
+- `xkb_keymap_new_from_string()`.
+
+Unaffected API:
+- `xkb_keymap_new_from_names()`: none of the components loaded use
+  floating-point number. libxkbcommon does not load *geometry* files.
+- `libxkbcommon-x11`: no such parsing is involved.

--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -41,6 +41,9 @@ unused in the standard dataset.
 - indicator behaviours such as LED-controls-key
   + the only supported LED behaviour is key-controls-LED; again this
     was never really used in current keymaps
+- xkbcommon has stronger type checks, so floating-point numbers cannot
+  be used where an integer is expected.
+- exponent syntax for floating-point numbers is not supported.
 
 On the other hand, some features and extensions were added.
 

--- a/test/common.c
+++ b/test/common.c
@@ -12,6 +12,7 @@
 #include "config.h"
 
 #include <limits.h>
+#include <locale.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <sys/types.h>
@@ -38,6 +39,10 @@ test_init(void)
 {
     /* Make stdout always unbuffered, to ensure we always get it entirely */
     setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+
+    /* Enable to use another locale than C or en_US, so we can catch
+     * locale-specific bugs */
+    setlocale(LC_ALL, "");
 }
 
 void

--- a/test/log.c
+++ b/test/log.c
@@ -5,6 +5,8 @@
 
 #include "config.h"
 
+#include <locale.h>
+
 #include "test.h"
 #include "context.h"
 #include "messages-codes.h"
@@ -315,6 +317,10 @@ int
 main(void)
 {
     test_init();
+
+    /* We really need to be locale-independent here */
+    setlocale(LC_ALL, "C");
+
     test_basic();
     test_keymaps();
     test_compose();


### PR DESCRIPTION
Before this commit we used `strtold`, which depends on the locale. But the XKB syntax is fixed and use a period as decimal separator. So ensure the syntax is correct without relying on `strtold` and truncate the result.

I encountered this issue parsing a keymap with a geometry which contains floats.

See #681 for an alternative fix.

TODO:
- [ ] Changelog entry
