### PR TITLE
xkbcomp: Parse floats independently of the locale

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
     'libxkbcommon',
-    'c',
+    'c', 'cpp',
     version: '1.8.1',
     default_options: [
         'c_std=c11',
@@ -258,6 +258,8 @@ libxkbcommon_sources = [
     'src/util-mem.h',
     'src/utils-paths.c',
     'src/utils-paths.h',
+    'src/utils-numbers.cpp',
+    'src/utils-numbers.h',
 ]
 libxkbcommon_link_args = []
 libxkbcommon_link_deps = []
@@ -277,6 +279,7 @@ libxkbcommon = library(
     'xkbcommon',
     'include/xkbcommon/xkbcommon.h',
     libxkbcommon_sources,
+    link_language: 'c',
     link_args: libxkbcommon_link_args,
     link_depends: libxkbcommon_link_deps,
     gnu_symbol_visibility: 'hidden',

--- a/src/utils-numbers.cpp
+++ b/src/utils-numbers.cpp
@@ -1,0 +1,23 @@
+#include <charconv>
+#include <cctype>
+#include <string>
+#include <cerrno>
+
+#include "utils-numbers.h"
+
+long double
+strtold_lc(const char *first, const char *last, char **end_out) {
+    while (std::isspace(*first))
+        ++first;
+
+    if (*first == '+')
+        ++first;
+
+    long double d = 0.0;
+    auto result = std::from_chars(first, last, d, std::chars_format::fixed);
+
+    if (end_out)
+        *end_out = const_cast<char *>(result.ptr);
+    errno = static_cast<int>(result.ec);
+    return d;
+}

--- a/src/utils-numbers.h
+++ b/src/utils-numbers.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+long double
+strtold_lc(const char *first, const char *last, char **end_out);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/xkbcomp/scanner.c
+++ b/src/xkbcomp/scanner.c
@@ -7,6 +7,7 @@
 
 #include "xkbcomp-priv.h"
 #include "parser-priv.h"
+#include "utils-numbers.h"
 
 static bool
 number(struct scanner *s, int64_t *out, int *out_tok)
@@ -39,7 +40,7 @@ number(struct scanner *s, int64_t *out, int *out_tok)
         #pragma GCC diagnostic push
         #pragma GCC diagnostic ignored "-Wbad-function-cast"
         #endif
-        x = (long long int) strtold(start, &end);
+        x = (long long int) strtold_lc(start, s->s + s->pos, &end);
         #ifdef __GNUC__
         #pragma GCC diagnostic pop
         #endif


### PR DESCRIPTION
Before this commit we used `strtold`, which depends on the locale. But the XKB syntax is fixed and use a period as decimal separator. So ensure the syntax is correct without relying on `strtold`, using C++ `std::from_chars`.

This is an alternative to #680.