### PR TITLE
xkbcomp: Fix whichGroupState serialization

### DIFF
--- a/changes/api/+whichGroupState.bugfix.md
+++ b/changes/api/+whichGroupState.bugfix.md
@@ -1,0 +1,1 @@
+Fixed the serialization of the `whichGroupState` indicator field.

--- a/src/text.c
+++ b/src/text.c
@@ -282,7 +282,8 @@ ModMaskText(struct xkb_context *ctx, enum mod_type type,
 }
 
 const char *
-LedStateMaskText(struct xkb_context *ctx, enum xkb_state_component mask)
+LedStateMaskText(struct xkb_context *ctx, const LookupEntry *lookup,
+                 enum xkb_state_component mask)
 {
     char buf[1024];
     size_t pos = 0;
@@ -298,9 +299,10 @@ LedStateMaskText(struct xkb_context *ctx, enum xkb_state_component mask)
 
         mask &= ~(1u << i);
 
+        const char* const maskText = LookupValue(lookup, 1u << i);
+        assert(maskText != NULL);
         ret = snprintf(buf + pos, sizeof(buf) - pos, "%s%s",
-                       pos == 0 ? "" : "+",
-                       LookupValue(modComponentMaskNames, 1u << i));
+                       pos == 0 ? "" : "+", maskText);
         if (ret <= 0 || pos + ret >= sizeof(buf))
             break;
         else
@@ -331,9 +333,10 @@ ControlMaskText(struct xkb_context *ctx, enum xkb_action_controls mask)
 
         mask &= ~(1u << i);
 
+        const char* const maskText = LookupValue(ctrlMaskNames, 1u << i);
+        assert(maskText != NULL);
         ret = snprintf(buf + pos, sizeof(buf) - pos, "%s%s",
-                       pos == 0 ? "" : "+",
-                       LookupValue(ctrlMaskNames, 1u << i));
+                       pos == 0 ? "" : "+", maskText);
         if (ret <= 0 || pos + ret >= sizeof(buf))
             break;
         else

--- a/src/text.h
+++ b/src/text.h
@@ -54,7 +54,8 @@ const char *
 SIMatchText(enum xkb_match_operation type);
 
 const char *
-LedStateMaskText(struct xkb_context *ctx, enum xkb_state_component mask);
+LedStateMaskText(struct xkb_context *ctx, const LookupEntry *lookup,
+                 enum xkb_state_component mask);
 
 const char *
 ControlMaskText(struct xkb_context *ctx, enum xkb_action_controls mask);

--- a/src/xkbcomp/keymap-dump.c
+++ b/src/xkbcomp/keymap-dump.c
@@ -230,7 +230,8 @@ write_led_map(struct xkb_keymap *keymap, struct buf *buf,
     if (led->which_groups) {
         if (led->which_groups != XKB_STATE_LAYOUT_EFFECTIVE) {
             write_buf(buf, "\t\twhichGroupState= %s;\n",
-                      LedStateMaskText(keymap->ctx, led->which_groups));
+                      LedStateMaskText(keymap->ctx, groupComponentMaskNames,
+                                       led->which_groups));
         }
         write_buf(buf, "\t\tgroups= 0x%02x;\n",
                   led->groups);
@@ -239,7 +240,8 @@ write_led_map(struct xkb_keymap *keymap, struct buf *buf,
     if (led->which_mods) {
         if (led->which_mods != XKB_STATE_MODS_EFFECTIVE) {
             write_buf(buf, "\t\twhichModState= %s;\n",
-                      LedStateMaskText(keymap->ctx, led->which_mods));
+                      LedStateMaskText(keymap->ctx, modComponentMaskNames,
+                                       led->which_mods));
         }
         write_buf(buf, "\t\tmodifiers= %s;\n",
                   ModMaskText(keymap->ctx, MOD_BOTH, &keymap->mods,


### PR DESCRIPTION
This indicator field was previously looked up in the wrong table, resulting the erroneous serialization `(null)`.