### PR TITLE
Enable merge mode “replace” in include statements

### DIFF
--- a/changes/api/+replace-include.feature.md
+++ b/changes/api/+replace-include.feature.md
@@ -1,0 +1,3 @@
+Enable using the merge mode *replace* in include statements using the prefix `^`,
+such as: `include "a^b"`. The main motivation is to enable this new syntax in
+*rules*, which previously could not handle this merge mode.

--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -44,6 +44,9 @@ unused in the standard dataset.
 - xkbcommon has stronger type checks, so floating-point numbers cannot
   be used where an integer is expected.
 - exponent syntax for floating-point numbers is not supported.
+- support the merge mode *replace* in include statements via the
+  prefix `^`, in addition to the standard *merge* `|` and *override*
+  `+` modes.
 
 On the other hand, some features and extensions were added.
 
@@ -61,6 +64,8 @@ On the other hand, some features and extensions were added.
 ### Additions
 
 - `! include` statement.
+- Support the merge mode *replace* via the prefix `^`, in addition to
+  the standard *merge* `|` and *override* `+` modes.
 - Additional wild cards:
   - `<none>` matches *empty* value;
   - `<some>` matches *non-empty* value in *every* context.

--- a/doc/keymap-format-text-v1.md
+++ b/doc/keymap-format-text-v1.md
@@ -1538,6 +1538,7 @@ located in an XKB include path.
 One can use a **merge mode** *prefix* to specify the merge mode of the file:
 - ‘+’ selects the **override** merge mode.
 - ‘|’ selects the **augment** merge mode.
+- ‘^’ selects the **replace** merge mode.
 
 @todo dedicated section for merge mode
 

--- a/doc/rules-format.md
+++ b/doc/rules-format.md
@@ -280,9 +280,9 @@ or %%H seems to do the job though.
         `%+v`, `%+v[1]`, `%+v[2]`, …
     </dt>
     <dd>
-        As above, but prefixed with ‘+’. Similarly, ‘|’, ‘-’, ‘_’ may be
+        As above, but prefixed with ‘+’. Similarly, ‘|’, ‘^’, ‘-’, ‘_’ may be
         used instead of ‘+’. See the [merge mode] documentation for the
-        special meaning of ‘+’ and ‘|’.
+        special meaning of ‘+’, ‘|’ and ‘^’.
     </dd>
     <dt>
         `%(m)`,
@@ -395,7 +395,8 @@ inside lists.
     The *KcCGST* value of the rule is used to update the [KcCGST]
     configuration, using the following instructions. Note that `foo`
     and `bar` are placeholders; ‘+’ specifies the *override* [merge mode]
-    and can be replaced by ‘|’ to specify the *augment* merge mode instead.
+    and can be replaced by ‘|’ or ‘^’ to specify respectively the *augment*
+    or *replace* merge mode instead.
 
     | Rule value        | Old KcCGST value | New KcCGST value      |
     | ----------------- | ---------------- | --------------------- |

--- a/src/xkbcomp/ast-build.c
+++ b/src/xkbcomp/ast-build.c
@@ -449,10 +449,16 @@ IncludeCreate(struct xkb_context *ctx, char *str, enum merge_mode merge)
         incl->modifier = extra_data;
         incl->next_incl = NULL;
 
-        if (nextop == MERGE_AUGMENT_PREFIX)
+        switch (nextop) {
+        case MERGE_AUGMENT_PREFIX:
             merge = MERGE_AUGMENT;
-        else
+            break;
+        case MERGE_REPLACE_PREFIX:
+            merge = MERGE_REPLACE;
+            break;
+        default:
             merge = MERGE_OVERRIDE;
+        }
     }
 
     if (first)

--- a/src/xkbcomp/include.c
+++ b/src/xkbcomp/include.c
@@ -34,9 +34,10 @@
  * xkb_symbols "basic" { ... }) , as opposed to the default map of the file.
  *
  * @param nextop_rtrn Set to the next operation in the complete statement,
- * which is '\0' if it's the last file or '+' or '|' if there are more.
- * Separating the files with '+' sets the merge mode to MERGE_MODE_OVERRIDE,
- * while '|' sets the merge mode to MERGE_MODE_AUGMENT.
+ * which is '\0' if it's the last file or '+' or '|' or '^' if there are more.
+ * Separating the files with '+' sets the merge mode to `MERGE_MODE_OVERRIDE`,
+ * while '|' sets the merge mode to `MERGE_MODE_AUGMENT` and '^' sets the merge
+ * mode to `MERGE_REPLACE`.
  *
  * @param extra_data Set to the string after ':', if any. Currently the
  * extra data is only used for setting an explicit group index for a symbols
@@ -71,7 +72,7 @@ ParseIncludeMap(char **str_inout, char **file_rtrn, char **map_rtrn,
      * Find the position in the string where the next file is included,
      * if there is more than one left in the statement.
      */
-    next = strpbrk(str, "|+");
+    next = strpbrk(str, MERGE_MODE_PREFIXES);
     if (next) {
         /* Got more files, this function will be called again. */
         *nextop_rtrn = *next;

--- a/src/xkbcomp/include.h
+++ b/src/xkbcomp/include.h
@@ -11,9 +11,13 @@
 
 #define MERGE_OVERRIDE_PREFIX '+'
 #define MERGE_AUGMENT_PREFIX  '|'
+#define MERGE_REPLACE_PREFIX  '^'
 #define MERGE_DEFAULT_PREFIX  MERGE_OVERRIDE_PREFIX
 #define is_merge_mode_prefix(ch) \
-    ((ch) == MERGE_OVERRIDE_PREFIX || (ch) == MERGE_AUGMENT_PREFIX)
+    ((ch) == MERGE_OVERRIDE_PREFIX || (ch) == MERGE_AUGMENT_PREFIX || \
+     (ch) == MERGE_REPLACE_PREFIX)
+static const char MERGE_MODE_PREFIXES[] =
+    { MERGE_OVERRIDE_PREFIX, MERGE_AUGMENT_PREFIX, MERGE_REPLACE_PREFIX, 0 };
 
 bool
 ParseIncludeMap(char **str_inout, char **file_rtrn, char **map_rtrn,

--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -117,6 +117,10 @@ skip_more_whitespace_and_comments:
         return TOK_INCLUDE;
 
     /* Identifier. */
+    /* Ensure that we can parse KcCGST values with merge modes */
+    assert(is_ident(MERGE_OVERRIDE_PREFIX));
+    assert(is_ident(MERGE_AUGMENT_PREFIX));
+    assert(is_ident(MERGE_REPLACE_PREFIX));
     if (is_ident(scanner_peek(s))) {
         val->string.start = s->s + s->pos;
         val->string.len = 0;
@@ -1148,6 +1152,7 @@ append_expanded_kccgst_value(struct matcher *m, struct scanner *s,
             /* New item */
             case MERGE_OVERRIDE_PREFIX:
             case MERGE_AUGMENT_PREFIX:
+            case MERGE_REPLACE_PREFIX:
                 darray_appends_nullterminate(expanded, &str[i++], 1);
                 last_item_idx = darray_size(expanded) - 1;
                 has_separator = true;

--- a/test/data/rules/merge-mode-replace
+++ b/test/data/rules/merge-mode-replace
@@ -1,0 +1,24 @@
+! model         = keycodes
+  *             = evdev
+
+
+! model         = types
+  *             = complete
+
+! model         = compat
+  *             = complete
+
+! layout        = symbols
+  *             = pc+%l
+
+! layout[1]     = symbols
+  *             = pc+%l[1]
+
+! layout[2]     = symbols
+  *             = +%l[2]:2
+
+! option        = symbols
+replace:single  = ^level3(ralt_alt)
+replace:first   = ^level3(ralt_alt)|empty
+replace:later   = +level3(ralt_switch)^level3(ralt_alt)|empty
+grp:menu_toggle	= +group(menu_toggle)

--- a/test/rules-file.c
+++ b/test/rules-file.c
@@ -232,6 +232,19 @@ main(int argc, char *argv[])
     };
     assert(test_rules(ctx, &test7));
 
+    struct test_data test_merge_mode_replace = {
+        .rules = "merge-mode-replace",
+
+        .model = "my_model", .layout = "us,de", .variant = "",
+        .options = "replace:first",
+
+        .keycodes = "evdev", .types = "complete",
+        .compat = "complete",
+        .symbols = "pc+us+de:2^level3(ralt_alt)|empty",
+        .explicit_layouts = 2,
+    };
+    assert(test_rules(ctx, &test_merge_mode_replace));
+
     /* Wild card does not match empty entries for layouts and variants */
 #define ENTRY(_model, _layout, _variant, _options, _symbols, _layouts, _fail) \
     { .rules = "wildcard", .model = (_model),                                 \

--- a/test/rulescomp.c
+++ b/test/rulescomp.c
@@ -7,6 +7,7 @@
 
 #include "evdev-scancodes.h"
 #include "test.h"
+#include "utils.h"
 
 static int
 test_rmlvo_va(struct xkb_context *context, const char *rules,
@@ -166,6 +167,20 @@ main(int argc, char *argv[])
     /* Ensure a keymap with an empty xkb_keycodes compiles fine. */
     assert(test_rmlvo_env(ctx, "base", "empty", "empty", "", "",
                           KEY_A,          BOTH, XKB_KEY_NoSymbol,         FINISH));
+
+    /* Check replace merge mode: it should replace the whole <RALT> key */
+    const char* replace_options[] = {
+        "replace:single,grp:menu_toggle",
+        "replace:first,grp:menu_toggle",
+        "replace:later,grp:menu_toggle",
+    };
+    for (unsigned int k = 0; k < ARRAY_SIZE(replace_options); k++) {
+        const char* const options = replace_options[k];
+        assert(test_rmlvo(ctx, "merge-mode-replace", "", "us,de", "", options,
+                          KEY_RIGHTALT,        BOTH, XKB_KEY_Alt_R,           NEXT,
+                          KEY_COMPOSE,         BOTH, XKB_KEY_ISO_Next_Group,  NEXT,
+                          KEY_RIGHTALT,        BOTH, XKB_KEY_Alt_R,           FINISH));
+    }
 
     /* Has an illegal escape sequence, but shouldn't fail. */
     assert(test_rmlvo_env(ctx, "evdev", "", "cz", "bksl", "",


### PR DESCRIPTION
Previously only the merge modes “override” and “augment” were available in include statements, using the prefix `+` and `|` respectively. While one can use the `replace` include statement in keymap files, *rules* files have no way to express the *replace* mode.

This commit enables the merge mode “replace” using the prefix `^`. This prefix was chosen because it due to its similarity with the `XOR` bit operator, which convey mutual exclusion.

[Related discussion](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/issues/525) in `xkeyboard-config` project.

EDIT: changed from `!` to `^` prefix

## Discussion

Other ASCII symbols candidates:
- `!` conveys some kind of higher precedence, akin to CSS `!important`. But it conflicts with the section header `!`, which is a token in the current parser. It would require special handling, not worth it. It also convey the meaning of negation, which is confusing.
- `&`, which has the advantage of not corresponding to a token in the rules parser. `^` seems however to stand out more and it is less likely to trigger erroneous comparison with `|` and `&` bit operators.

Discarded ASCII symbols:
- `=`: another interesting candidate to convey the replace/unchanged info, but confusing as it is also used for assignment.
- `#`: probably not a good idea for its usual role as “number sign”.
- `*`: already used as wild card; not a good idea to overload it.
- `~`: do not convey much.
- `<`, `>`: interesting for the direction they point, but would be better paired with another character, else they are difficult to interpret.
- `@`: might have a use in #500.

While I like `!` better, we could go for `&` or another ASCII character if we foresee a use for the (`!`, `?`) pair in the include statements or the qualifier (the suffix starting with `:`, currently used for group index). Note that `!`, `?` and `+` are new wild cards for rules, proposed in #685.

@bluetech @whot @mahkoh @fooishbar 