### PR TITLE
rules: Added extended wild cards <none>, <some> and <any>

### DIFF
--- a/changes/api/+extended-rules-wild-cards.feature.md
+++ b/changes/api/+extended-rules-wild-cards.feature.md
@@ -1,0 +1,6 @@
+Added the following *wild cards* to the **rules** file syntax, in addition to
+the current `*` legacy wild card:
+- `<none>`: Match *empty* value.
+- `<some>`: Match *non-empty* value.
+- `<any>`: Match *any* (optionally empty) value. Its behavior does not depend on
+  the context, contrary to the legacy wild card `*`.

--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -52,7 +52,18 @@ On the other hand, some features and extensions were added.
 - multiple keysyms per level
   + such levels are ignored by x11/xkbcomp.
 - key names (e.g. `<AE11>`) can be longer than 4 characters.
-- `! include` statement for rules files.
+
+## Rules support {#rules-support}
+
+### Additions
+
+- `! include` statement.
+- Additional wild cards:
+  - `<none>` matches *empty* value;
+  - `<some>` matches *non-empty* value in *every* context.
+  - `<any>` matches *optionally empty* value in *every* context, contrary to the
+    legacy `*` wild card which does not match empty values for layout and
+    variant;
 
 ## Compose support {#compose-support}
 

--- a/doc/rules-format.md
+++ b/doc/rules-format.md
@@ -53,10 +53,11 @@ of the following fields (called [RMLVO] for short):
 [option]: @ref config-options-def
 [options]: @ref config-options-def
 
-Format of the file
-------------------
+# Format of the file
+
+## Rules and rule sets {#rule-def}
+
 @anchor rule-set-def
-@anchor rule-def
 The file consists of **rule sets**, each consisting of **rules** (one
 per line), which match the [MLVO] values on the left hand side, and,
 if the values match to the values the user passed in, results in the
@@ -85,7 +86,8 @@ resulting [KcCGST]. See @ref rmlvo-resolution for further details.
   fr        caps:digits_row = +capslock(digits_row)
 ```
 
-@anchor rules-group-def
+## Groups {#rules-group-def}
+
 Since some values are related and repeated often, it is possible
 to *group* them together and refer to them by a **group name** in the
 rules.
@@ -105,13 +107,51 @@ rules.
  $azerty    caps:digits_row = +capslock(digits_row)
 ```
 
-@anchor rules-wildcard-def
+## Wild cards {#rules-wildcard-def}
+
 Along with matching values by simple string equality and for
 membership in a [group] defined previously, rules may also contain
-**wildcard** values “\*” with the following behavior:
+**wild card** values with the following behavior:
+
+<dl>
+<dt>* @anchor rules-wildcard-legacy-def</dt>
+<dd>
+
+Legacy wild card:
 - For `model` and `options`: *always* match.
 - For `layout` and `variant`: match any *non-empty* value.
-These usually appear near the end of a rule set to set *default* values.
+
+This wild card usually appears near the end of a rule set to set *default* values.
+
+@note Prefer using the wild cards @ref rules-wildcard-some-def "\<some\>" or
+@ref rules-wildcard-any-def "\<any\>" for their simpler semantics, as it does not
+depend on the context.
+</dd>
+<dt>\<none\> @anchor rules-wildcard-none-def</dt>
+<dd>
+
+Match *empty* values
+
+@since 1.9.0
+</dd>
+<dt>\<some\> @anchor rules-wildcard-some-def</dt>
+<dd>
+
+Match *non-empty* value
+
+@since 1.9.0
+</dd>
+<dt>\<any\> @anchor rules-wildcard-any-def</dt>
+<dd>
+
+Match *any* (optionally empty) value. Its behavior does not depend on the
+context, contrary to the legacy wild card @ref rules-wildcard-legacy-def "*".
+
+This wild card usually appears near the end of a rule set to set *default* values.
+
+@since 1.9.0
+</dd>
+</dl>
 
 ```c
 ! layout = keycodes
@@ -123,8 +163,8 @@ These usually appear near the end of a rule set to set *default* values.
   *      = +aliases(qwerty)
 ```
 
-Grammar
--------
+# Grammar
+
 It is advised to look at a file like `rules/evdev` along with
 this grammar.
 
@@ -149,7 +189,7 @@ SpecialIndex ::= "single" | "first" | "later" | "any"
 Kccgst       ::= "keycodes" | "symbols" | "types" | "compat" | "geometry"
 
 Rule         ::= { MlvoValue } "=" { KccgstValue } "\n"
-MlvoValue    ::= "*" | GroupName | <ident>
+MlvoValue    ::= "*" | "<none>" | "<some>" | "<any>" | GroupName | <ident>
 KccgstValue  ::= <ident> [ { Qualifier } ]
 Qualifier    ::= ":" ({ NumericIndex } | "all")
 ```
@@ -327,8 +367,9 @@ or %%H seems to do the job though.
     </tr>
   </table>
 
-RMLVO resolution process {#rmlvo-resolution}
-------------------------
+# RMLVO resolution process {#rmlvo-resolution}
+
+## Process
 
 First of all, the rules *file* is extracted from the provided
 [<em>R</em>MLVO][RMLVO] configuration (usually `evdev`). Then its path
@@ -375,6 +416,8 @@ inside lists.
 
 [value update]: @ref rules-kccgst-value-update
 [merge mode]: @ref merge-mode-def
+
+## Examples
 
 ### Example: key codes
 

--- a/test/data/rules/extended-wild-cards
+++ b/test/data/rules/extended-wild-cards
@@ -1,0 +1,23 @@
+! model = keycodes
+  *     = evdev
+
+! model = compat
+  *     = complete
+
+! model = types
+  *     = complete
+
+! model = symbols
+  *     = pc
+
+! layout[any] variant[any] = symbols
+  l1          <none>       = +l10:%i             // compatibity mapping: l1, no variant
+  l1          v1           = +l20:%i             // compatibity mapping: l1, specific variant
+  l1          <some>       = +l30%(v[%i]):%i     // compatibity mapping: l1, some variant
+  l2          *            = +l40%(v[%i]):%i     // compatibity mapping: l2, some variant (legacy)
+  l3          <any>        = +l50%(v[%i]):%i     // compatibity mapping: l3, any variant (catch-all)
+  *           v2           = +%l[%i](v20):%i     // compatibity mapping: specific variant
+  *           <any>        = +%l[%i]%(v[%i]):%i  // catch-all
+
+! option = symbols
+  opt1   = +opt1

--- a/test/rules-file.c
+++ b/test/rules-file.c
@@ -357,6 +357,45 @@ main(int argc, char *argv[])
         assert(test_rules(ctx, &special_indexes_first_data[k]));
     }
 
+    /* Test extended wild cards: <none>, <some> and <any> */
+#define ENTRY(_rules, _layout, _variant, _symbols, _layouts, _fail)   \
+    { .rules = (_rules), .model = NULL,                               \
+      .layout = (_layout), .variant = (_variant), .options = NULL,    \
+      .keycodes = "evdev", .types = "complete", .compat = "complete", \
+      .symbols = (_symbols) , .explicit_layouts = (_layouts),         \
+      .should_fail = (_fail) }
+
+    struct test_data extended_wild_cards_data[] = {
+        ENTRY("extended-wild-cards", "l1", NULL, "pc+l10:1", 1, false),
+        ENTRY("extended-wild-cards", "l1", "v1", "pc+l20:1", 1, false),
+        ENTRY("extended-wild-cards", "l1", "v2", "pc+l30(v2):1", 1, false),
+        /* legacy wild card * does not catch empty variant */
+        ENTRY("extended-wild-cards", "l2", NULL, "pc+l2:1", 1, false),
+        ENTRY("extended-wild-cards", "l2", "v1", "pc+l40(v1):1", 1, false),
+        ENTRY("extended-wild-cards", "l2", "v2", "pc+l40(v2):1", 1, false),
+        ENTRY("extended-wild-cards", "l3", NULL, "pc+l50:1", 1, false),
+        ENTRY("extended-wild-cards", "l3", "v1", "pc+l50(v1):1", 1, false),
+        ENTRY("extended-wild-cards", "l3", "v2", "pc+l50(v2):1", 1, false),
+        /* ? wild card does catch empty variant */
+        ENTRY("extended-wild-cards", "l4", NULL, "pc+l4:1", 1, false),
+        ENTRY("extended-wild-cards", "l4", "v1", "pc+l4(v1):1", 1, false),
+        ENTRY("extended-wild-cards", "l4", "v2", "pc+l4(v20):1", 1, false),
+        ENTRY("extended-wild-cards", "l1,l1,l1,l2", ",v1,v2,",
+              "pc+l10:1+l20:2+l30(v2):3+l2:4", 4, false),
+        ENTRY("extended-wild-cards", "l2,l2,l3,l3", "v1,v2,,v1",
+              "pc+l40(v1):1+l40(v2):2+l50:3+l50(v1):4", 4, false),
+        /* NOTE: `l4(v2)` (4th LV index) is matched *before* the other LV indexes,
+         *       because with the extended indexes we follow the order of the rules in the
+         *       file, not the RMLVO order. This is similar to options handling. */
+        ENTRY("extended-wild-cards", "l3,l4,l4,l4", "v2,,v1,v2",
+              "pc+l50(v2):1+l4(v20):4+l4:2+l4(v1):3", 4, false),
+    };
+
+    for (size_t k = 0; k < ARRAY_SIZE(extended_wild_cards_data); k++) {
+        assert(test_rules(ctx, &extended_wild_cards_data[k]));
+    }
+#undef ENTRY
+
     /* Test :all qualifier without special indexes, with option */
     struct test_data all_qualified_alone1 = {
         .rules = "all_qualifier",


### PR DESCRIPTION
Added the following wild cards to the rules file syntax, in addition to the current `*` legacy wild card:

EDIT: *current* proposal:

- `<none>`: Match *empty* value.
- `<some>`: Match *non-empty* value.
- `<any>`: Match *any* (optionally empty) value. Its behavior does not depend on the context, contrary to the legacy wild card `*`.

The verbose wild cards are preferred to single characters:
- More intuitive: self-explanatory.
- Does not steal syntax from other token.
- Extensible syntax, should we need it.

This will enable writing much simpler rules, see [!764] for an example of tricky rules in the `xkeyboard-config` project, that would benefit from the new wild cards. The extended rules support is tracked in [this issue](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/issues/524).

[!764]: https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/merge_requests/764

---

EDIT: *previous* proposal:
- `!`: Match *empty* value.
- `+`: Match *non-empty* value.
- `?`: Match *any* (optionally empty) value. Its behavior does not depend on the context, contrary to the legacy wild card `*`.

The characters were chosen for their similarity with the corresponding syntax of regular expressions (negative assertion & quantifiers), in line with `*`.

Note that the current parser disallows using `!` in the first MLVO component of a rule, because it would match a new rule set, an include statement or a group definition. This is unfortunate, but:
- rules are usually written respecting the MLVO components order;
- model and layout are normally non-empty if proper defaults are set;
- variant is normally used paired with layout, in the LV order;
- option is usually not tested for empty values;
- one can always use model as a first component and use the wild card `*` or `?` to always match, enabling `!` in the further MLVO components. So this limitation has a very low probability to cause issues in real use cases.

@bluetech @whot @mahkoh @fooishbar 