### PR TITLE
symbols: Fix leak in HandleSymbolsDef

### DIFF
--- a/src/xkbcomp/symbols.c
+++ b/src/xkbcomp/symbols.c
@@ -1320,22 +1320,15 @@ HandleSymbolsDef(SymbolsInfo *info, SymbolsDef *stmt)
     keyi.merge = stmt->merge;
     keyi.name = stmt->keyName;
 
-    if (!HandleSymbolsBody(info, stmt->symbols, &keyi)) {
-        info->errorCount++;
-        return false;
+    if (HandleSymbolsBody(info, stmt->symbols, &keyi) &&
+        SetExplicitGroup(info, &keyi) &&
+        AddKeySymbols(info, &keyi, true)) {
+        return true;
     }
 
-    if (!SetExplicitGroup(info, &keyi)) {
-        info->errorCount++;
-        return false;
-    }
-
-    if (!AddKeySymbols(info, &keyi, true)) {
-        info->errorCount++;
-        return false;
-    }
-
-    return true;
+    ClearKeyInfo(&keyi);
+    info->errorCount++;
+    return false;
 }
 
 static bool


### PR DESCRIPTION
Found while working on #680.

Note that we currently display error message suggesting that we recover from errors (e.g. “… ignored”), but we actually do not recover. This MR does not change that.