### PR TITLE
registry: Exclude the trailing NUL byte from embedded DTD

### DIFF
--- a/src/registry.c
+++ b/src/registry.c
@@ -1196,7 +1196,7 @@ validate(struct rxkb_context *ctx, xmlDoc *doc)
     xmlCtxtSetOptions(xmlCtxt, _XML_OPTIONS | XML_PARSE_DTDLOAD);
 
     xmlParserInputPtr pinput =
-        xmlNewInputFromMemory(NULL, dtdstr, sizeof(dtdstr),
+        xmlNewInputFromMemory(NULL, dtdstr, sizeof(dtdstr) - 1,
                               XML_INPUT_BUF_STATIC);
     if (!pinput)
         goto dtd_error;
@@ -1206,7 +1206,7 @@ validate(struct rxkb_context *ctx, xmlDoc *doc)
     /* Note: do not use xmlParserInputBufferCreateStatic, it generates random
      * DTD validity errors for unknown reasons */
     xmlParserInputBufferPtr buf =
-        xmlParserInputBufferCreateMem(dtdstr, sizeof(dtdstr),
+        xmlParserInputBufferCreateMem(dtdstr, sizeof(dtdstr) - 1,
                                       XML_CHAR_ENCODING_NONE);
     if (!buf)
         goto dtd_error;


### PR DESCRIPTION
Since libxml2-2.14.0, the trailing NUL byte is considered an invalid encoding error.

Link: https://gitlab.gnome.org/GNOME/libxml2/-/issues/886