### PR TITLE
Support empty symbols and actions lists

### DIFF
--- a/changes/api/+empty-keysym-action-lists.feature.md
+++ b/changes/api/+empty-keysym-action-lists.feature.md
@@ -1,0 +1,2 @@
+Added support for actions and keysyms level list of length 0 and 1: respectively
+`{}` and `{a}`. Example: `key <A> { [{}, {a}, {a, A}] };`.

--- a/doc/keymap-format-text-v1.md
+++ b/doc/keymap-format-text-v1.md
@@ -1656,14 +1656,38 @@ There are some *limitations* with this extension:
   - `SetMods` + `LockMods`: *error*
   - `SetMods` + `LockGroup`: ok
 - Multiple actions are only supported from version 1.8.0.
-- Since 1.8.0, `NoSymbol` and `NoAction` are dropped in order to normalize levels:
 
-  ```c
-  // Before normalization
-  key <> { [{NoSymbol}, {a, NoSymbol}, {NoSymbol,b}, {a, NoSymbol, b}] };
-  // After normalization
-  key <> { [NoSymbol, a, b, {a, b}] };
-  ```
+<div>
+
+@since 1.8.0: When using multiple keysyms or actions per level, `NoSymbol` and
+`NoAction()` are dropped in order to normalize the levels:
+```c
+// Before normalization
+key <> { [{NoSymbol}, {a, NoSymbol}, {NoSymbol,b}, {a, NoSymbol, b}] };
+// After normalization
+key <> { [NoSymbol, a, b, {a, b}] };
+```
+
+</div>
+<div>
+
+@since 1.9.0: Trailing `NoSymbol` and `NoAction()` are dropped in groups:
+```c
+// Before normalization
+key <> { [a, NoSymbol] };
+// After normalization
+key <> { [a] };
+```
+This affects the automatic key type detection.
+
+</div>
+<div>
+
+@since 1.9.0: Added support for keysyms and actions lists of length 0 and 1,
+respectively `{}` and `{a}`. `{}` is equivalent to the corresponding `NoSymbol`
+or `NoAction()`.
+
+</div>
 
 @warning Keymaps containing multiple key symbols per level are not supported
 by the various X11-related tools (`setxkbmap`, `xkbcomp`, etc.).

--- a/src/xkbcomp/ast-build.c
+++ b/src/xkbcomp/ast-build.c
@@ -175,7 +175,7 @@ ExprCreateActionList(ExprDef *actions)
 }
 
 ExprDef *
-ExprCreateKeysymList(xkb_keysym_t sym)
+ExprCreateKeySymList(xkb_keysym_t sym)
 {
     ExprDef *expr = ExprCreate(STMT_EXPR_KEYSYM_LIST);
     if (!expr)
@@ -190,7 +190,7 @@ ExprCreateKeysymList(xkb_keysym_t sym)
 }
 
 ExprDef *
-ExprAppendKeysymList(ExprDef *expr, xkb_keysym_t sym)
+ExprAppendKeySymList(ExprDef *expr, xkb_keysym_t sym)
 {
     if (sym == XKB_KEY_NoSymbol) {
         /* Discard NoSymbol */

--- a/src/xkbcomp/ast-build.h
+++ b/src/xkbcomp/ast-build.h
@@ -49,10 +49,10 @@ ExprDef *
 ExprCreateActionList(ExprDef *actions);
 
 ExprDef *
-ExprCreateKeysymList(xkb_keysym_t sym);
+ExprCreateKeySymList(xkb_keysym_t sym);
 
 ExprDef *
-ExprAppendKeysymList(ExprDef *list, xkb_keysym_t sym);
+ExprAppendKeySymList(ExprDef *list, xkb_keysym_t sym);
 
 KeycodeDef *
 KeycodeCreate(xkb_atom_t name, int64_t value);

--- a/src/xkbcomp/symbols.c
+++ b/src/xkbcomp/symbols.c
@@ -14,11 +14,11 @@
 
 #include "config.h"
 
-#include "keymap.h"
 #include "xkbcommon/xkbcommon.h"
 #include "xkbcommon/xkbcommon-keysyms.h"
 
 #include "darray.h"
+#include "keymap.h"
 #include "xkbcomp-priv.h"
 #include "text.h"
 #include "expr.h"
@@ -912,13 +912,15 @@ AddActionsToKey(SymbolsInfo *info, KeyInfo *keyi, ExprDef *arrayNdx,
         assert(leveli->num_actions == 0);
 
         unsigned int num_actions = 0;
-        for (ParseCommon *p = &actionList->actions->common; p; p = p->next)
+        for (ExprDef *act = actionList->actions;
+             act; act = (ExprDef *) act->common.next)
             num_actions++;
 
         /* Parse actions and add only defined actions */
         darray(union xkb_action) actions = darray_new();
         unsigned int act_index = 0;
-        for (ExprDef *act = actionList->actions; act; act = (ExprDef *) act->common.next, act_index++) {
+        for (ExprDef *act = actionList->actions;
+             act; act = (ExprDef *) act->common.next, act_index++) {
             union xkb_action toAct = { 0 };
             if (!HandleActionDef(info->ctx, info->actions, &info->mods, act, &toAct))
                 log_err(info->ctx, XKB_ERROR_INVALID_VALUE,

--- a/test/buffercomp.c
+++ b/test/buffercomp.c
@@ -632,31 +632,40 @@ test_multi_keysyms_actions(struct xkb_context *ctx, bool update_output_files)
             "    <07> = 7;\n"                                               \
             "    <08> = 8;\n"                                               \
             "    <09> = 9;\n"                                               \
+            "    <10> = 10;\n"                                              \
+            "    <11> = 11;\n"                                              \
+            "    <12> = 12;\n"                                              \
+            "    <13> = 13;\n"                                              \
+            "    <14> = 14;\n"                                              \
+            "    <15> = 15;\n"                                              \
             "  };\n"                                                        \
             "  xkb_types { include \"basic+extra\" };\n"                    \
             "  xkb_compat { include \"basic\" };\n"                         \
             "  xkb_symbols {\n"                                             \
             "    key <01> { [ "a "] };\n"                                   \
             "    key <02> { [ "a", "b" ] };\n"                              \
-            "    key <03> { [ { "a", "b" } ] };\n"                          \
-            "    key <04> { [ { "a", "b", "c" } ] };\n"                     \
-            "    key <05> { [ "a", { "b", "c" } ] };\n"                     \
-            "    key <06> { [ { "a", "b" }, "c" ] };\n"                     \
-            "    key <07> { [ { "a", "b" }, { "c", "d" } ] };\n"            \
-            "    key <08> { [ { "a", "b" }, "c", { "d", "a" } ] };\n"       \
-            "    key <09> { [ { "a", "b" }, { "c", "d" }, "a" ] };\n"       \
+            "    key <03> { [ {} ] };\n"                                    \
+            "    key <04> { [ {}, "b" ] };\n"                               \
+            "    key <05> { [ "a", {} ] };\n"                               \
+            "    key <06> { [ {}, {} ] };\n"                                \
+            "    key <07> { [ { "a" } ] };\n"                               \
+            "    key <08> { [ { "a" }, { "b" } ] };\n"                      \
+            "    key <09> { [ { "a", "b" } ] };\n"                          \
+            "    key <10> { [ { "a", "b", "c" } ] };\n"                     \
+            "    key <11> { [ "a", { "b", "c" } ] };\n"                     \
+            "    key <12> { [ { "a", "b" }, "c" ] };\n"                     \
+            "    key <13> { [ { "a", "b" }, { "c", "d" } ] };\n"            \
+            "    key <14> { [ { "a", "b" }, "c", { "d", "a" } ] };\n"       \
+            "    key <15> { [ { "a", "b" }, { "c", "d" }, "a" ] };\n"       \
             "  };\n"                                                        \
             "};",                                                           \
         .expected = GOLDEN_TESTS_OUTPUTS "symbols-multi-" name ".xkb"       \
     },                                                                      \
     /* Test: invalid keymaps */                                             \
-    { .keymap = func("{}")                            , .expected = NULL }, \
     { .keymap = func("{ {} }")                        , .expected = NULL }, \
-    { .keymap = func("{ "a" }")                       , .expected = NULL }, \
     { .keymap = func("{ "a", {} }")                   , .expected = NULL }, \
     { .keymap = func("{ {}, "b" }")                   , .expected = NULL }, \
     { .keymap = func("{ {}, {} }")                    , .expected = NULL }, \
-    { .keymap = func("{ "a" }, { "b" }")              , .expected = NULL }, \
     { .keymap = func("{ "a", { "b" } }")              , .expected = NULL }, \
     { .keymap = func("{ { "a" }, "b" }")              , .expected = NULL }, \
     { .keymap = func("{ { "a", "b" }, "c" }")         , .expected = NULL }, \
@@ -710,28 +719,28 @@ test_multi_keysyms_actions(struct xkb_context *ctx, bool update_output_files)
                 "  xkb_symbols {\n"
                 /* Empty keysyms */
                 "    key <10> { [any, any ] };\n"
-             // "    key <11> { [{} , {}  ] };\n"
+                "    key <11> { [{} , {}  ] };\n"
                 "    key <12> { [any, any ], [SetMods(modifiers=Shift)] };\n"
-             // "    key <13> { [{} , {}  ], [SetMods(modifiers=Shift)] };\n"
+                "    key <13> { [{} , {}  ], [SetMods(modifiers=Shift)] };\n"
                 "    key <14> { [any, any ], type = \"TWO_LEVEL\" };\n"
-             // "    key <15> { [{} , {}  ], type = \"TWO_LEVEL\" };\n"
+                "    key <15> { [{} , {}  ], type = \"TWO_LEVEL\" };\n"
                 "    key <16> { [a, A, any] };\n"
-             // "    key <17> { [a, A, {} ] };\n"
+                "    key <17> { [a, A, {} ] };\n"
                 "    key <18> { [a, A, any], type = \"FOUR_LEVEL_SEMIALPHABETIC\" };\n"
-             // "    key <19> { [a, A, {} ], type = \"FOUR_LEVEL_SEMIALPHABETIC\" };\n"
+                "    key <19> { [a, A, {} ], type = \"FOUR_LEVEL_SEMIALPHABETIC\" };\n"
                 "    key <20> { [a, A, ae, any] };\n"
-             // "    key <21> { [a, A, ae, {} ] };\n"
+                "    key <21> { [a, A, ae, {} ] };\n"
                 "    key <22> { [a, A, ae, AE, any] };\n"
-             // "    key <23> { [a, A, ae, AE, {} ] };\n"
+                "    key <23> { [a, A, ae, AE, {} ] };\n"
                 /* Empty actions */
                 "    key <30> { [NoAction(), NoAction() ] };\n"
-             // "    key <31> { actions=[{}, {}         ] };\n"
+                "    key <31> { actions=[{}, {}         ] };\n"
                 "    key <32> { [NoAction(), NoAction() ], [a] };\n"
-             // "    key <33> { actions=[{}, {}         ], [a] };\n"
+                "    key <33> { actions=[{}, {}         ], [a] };\n"
                 "    key <34> { [NoAction(), NoAction() ], type = \"TWO_LEVEL\" };\n"
-             // "    key <35> { actions=[{}, {}         ], type = \"TWO_LEVEL\" };\n"
+                "    key <35> { actions=[{}, {}         ], type = \"TWO_LEVEL\" };\n"
                 "    key <38> { [NoAction(), NoAction() ], type = \"FOUR_LEVEL_SEMIALPHABETIC\" };\n"
-             // "    key <39> { actions=[{}, {}         ], type = \"FOUR_LEVEL_SEMIALPHABETIC\" };\n"
+                "    key <39> { actions=[{}, {}         ], type = \"FOUR_LEVEL_SEMIALPHABETIC\" };\n"
                 "  };\n"
                 "};",
             .expected = GOLDEN_TESTS_OUTPUTS "symbols-multi-keysyms-empty.xkb"

--- a/test/data/keymaps/symbols-multi-actions.xkb
+++ b/test/data/keymaps/symbols-multi-actions.xkb
@@ -11,6 +11,12 @@ xkb_keycodes {
 	<07>                 = 7;
 	<08>                 = 8;
 	<09>                 = 9;
+	<10>                 = 10;
+	<11>                 = 11;
+	<12>                 = 12;
+	<13>                 = 13;
+	<14>                 = 14;
+	<15>                 = 15;
 	indicator 1 = "Caps Lock";
 	indicator 2 = "Num Lock";
 	indicator 3 = "Shift Lock";
@@ -177,37 +183,57 @@ xkb_symbols {
 		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
 		actions[Group1]= [     SetMods(modifiers=Control),             SetGroup(group=+1) ]
 	};
-	key <03>                 {
+	key <04>                 {
+		repeat= No,
+		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
+		actions[Group1]= [                     NoAction(),             SetGroup(group=+1) ]
+	};
+	key <05>                 {
+		repeat= No,
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [     SetMods(modifiers=Control) ]
+	};
+	key <07>                 {
+		repeat= No,
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [     SetMods(modifiers=Control) ]
+	};
+	key <08>                 {
+		repeat= No,
+		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
+		actions[Group1]= [     SetMods(modifiers=Control),             SetGroup(group=+1) ]
+	};
+	key <09>                 {
 		repeat= No,
 		symbols[Group1]= [                       NoSymbol ],
 		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) } ]
 	};
-	key <04>                 {
+	key <10>                 {
 		repeat= No,
 		symbols[Group1]= [                       NoSymbol ],
 		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1), Private(type=0x0f,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) } ]
 	};
-	key <05>                 {
+	key <11>                 {
 		repeat= No,
 		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
 		actions[Group1]= [     SetMods(modifiers=Control), {             SetGroup(group=+1), Private(type=0x0f,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) } ]
 	};
-	key <06>                 {
+	key <12>                 {
 		repeat= No,
 		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
 		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, Private(type=0x0f,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) ]
 	};
-	key <07>                 {
+	key <13>                 {
 		repeat= No,
 		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
 		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, { Private(type=0x0f,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00), Private(type=0x0f,data[0]=0x62,data[1]=0x61,data[2]=0x72,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) } ]
 	};
-	key <08>                 {
+	key <14>                 {
 		repeat= No,
 		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
 		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, Private(type=0x0f,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00), { Private(type=0x0f,data[0]=0x62,data[1]=0x61,data[2]=0x72,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00),     SetMods(modifiers=Control) },                     NoAction() ]
 	};
-	key <09>                 {
+	key <15>                 {
 		repeat= No,
 		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
 		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, { Private(type=0x0f,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00), Private(type=0x0f,data[0]=0x62,data[1]=0x61,data[2]=0x72,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) },     SetMods(modifiers=Control),                     NoAction() ]

--- a/test/data/keymaps/symbols-multi-keysyms-empty.xkb
+++ b/test/data/keymaps/symbols-multi-keysyms-empty.xkb
@@ -154,18 +154,39 @@ xkb_symbols {
 		symbols[Group1]= [                       NoSymbol ],
 		actions[Group1]= [       SetMods(modifiers=Shift) ]
 	};
+	key <13>                 {
+		repeat= No,
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [       SetMods(modifiers=Shift) ]
+	};
 	key <14>                 {
 		type= "TWO_LEVEL",
 		symbols[Group1]= [        NoSymbol,        NoSymbol ]
 	};
+	key <15>                 {
+		type= "TWO_LEVEL",
+		symbols[Group1]= [        NoSymbol,        NoSymbol ]
+	};
 	key <16>                 {	[               a,               A ] };
+	key <17>                 {	[               a,               A ] };
 	key <18>                 {
 		type= "FOUR_LEVEL_SEMIALPHABETIC",
 		symbols[Group1]= [               a,               A,        NoSymbol,        NoSymbol ]
 	};
+	key <19>                 {
+		type= "FOUR_LEVEL_SEMIALPHABETIC",
+		symbols[Group1]= [               a,               A,        NoSymbol,        NoSymbol ]
+	};
 	key <20>                 {	[               a,               A,              ae,        NoSymbol ] };
+	key <21>                 {	[               a,               A,              ae,        NoSymbol ] };
 	key <22>                 {	[               a,               A,              ae,              AE ] };
+	key <23>                 {	[               a,               A,              ae,              AE ] };
 	key <32>                 {
+		repeat= No,
+		symbols[Group1]= [                              a ],
+		actions[Group1]= [                     NoAction() ]
+	};
+	key <33>                 {
 		repeat= No,
 		symbols[Group1]= [                              a ],
 		actions[Group1]= [                     NoAction() ]
@@ -176,7 +197,19 @@ xkb_symbols {
 		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
 		actions[Group1]= [                     NoAction(),                     NoAction() ]
 	};
+	key <35>                 {
+		type= "TWO_LEVEL",
+		repeat= No,
+		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
+		actions[Group1]= [                     NoAction(),                     NoAction() ]
+	};
 	key <38>                 {
+		type= "FOUR_LEVEL_SEMIALPHABETIC",
+		repeat= No,
+		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
+		actions[Group1]= [                     NoAction(),                     NoAction(),                     NoAction(),                     NoAction() ]
+	};
+	key <39>                 {
 		type= "FOUR_LEVEL_SEMIALPHABETIC",
 		repeat= No,
 		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],

--- a/test/data/keymaps/symbols-multi-keysyms.xkb
+++ b/test/data/keymaps/symbols-multi-keysyms.xkb
@@ -11,6 +11,12 @@ xkb_keycodes {
 	<07>                 = 7;
 	<08>                 = 8;
 	<09>                 = 9;
+	<10>                 = 10;
+	<11>                 = 11;
+	<12>                 = 12;
+	<13>                 = 13;
+	<14>                 = 14;
+	<15>                 = 15;
 	indicator 1 = "Caps Lock";
 	indicator 2 = "Num Lock";
 	indicator 3 = "Shift Lock";
@@ -169,13 +175,17 @@ xkb_compatibility "basic" {
 xkb_symbols {
 	key <01>                 {	[               a ] };
 	key <02>                 {	[               a,               b ] };
-	key <03>                 {	[        { a, b } ] };
-	key <04>                 {	[     { a, b, c } ] };
-	key <05>                 {	[               a,        { b, c } ] };
-	key <06>                 {	[        { a, b },               c ] };
-	key <07>                 {	[        { a, b },        { c, d } ] };
-	key <08>                 {	[        { a, b },               c,        { d, a },        NoSymbol ] };
-	key <09>                 {	[        { a, b },        { c, d },               a,        NoSymbol ] };
+	key <04>                 {	[        NoSymbol,               b ] };
+	key <05>                 {	[               a ] };
+	key <07>                 {	[               a ] };
+	key <08>                 {	[               a,               b ] };
+	key <09>                 {	[        { a, b } ] };
+	key <10>                 {	[     { a, b, c } ] };
+	key <11>                 {	[               a,        { b, c } ] };
+	key <12>                 {	[        { a, b },               c ] };
+	key <13>                 {	[        { a, b },        { c, d } ] };
+	key <14>                 {	[        { a, b },               c,        { d, a },        NoSymbol ] };
+	key <15>                 {	[        { a, b },        { c, d },               a,        NoSymbol ] };
 };
 
 };


### PR DESCRIPTION
Enable empty lists in more places:
- (Empty `interpret`)
- (Empty key `type`)
- (Empty `indicator`)
- Empty list of keysyms and actions: `{}`

Motivations:
- Follow the principle of least astonishment;
- Ensure consistency;
- Enhance the use of custom defaults;
- Facilitate the tests.

Fixes #565

NOTE: Using `{}` for both actions and keysyms introduces an ambiguity, which is resolved when reaching the first non `{}` in the list. I managed to modify the parser the handle it, but I wonder if we can do better.

TODO:
- [x] Rebase on #701
- [x] Rebase on #704
- [x] Moaar tests
- [x] Changelog
