### PR TITLE
xkbcomp: Drop trailing NoSymbol and NoAction()

### DIFF
--- a/changes/api/+drop-trailing-empty-actions-and-keysyms.breaking.md
+++ b/changes/api/+drop-trailing-empty-actions-and-keysyms.breaking.md
@@ -1,0 +1,23 @@
+Trailing `NoSymbol` and `NoAction()` are now dropped. This may affect
+keys that rely on an *implicit* key type.
+
+Example:
+- Input:
+  ```c
+  key <> { [a, A, NoSymbol] };
+  ```
+- Compilation with xkbcommon \< 1.9.0:
+  ```c
+  key <> {
+    type= "FOUR_LEVEL_SEMIALPHABETIC",
+    [a, A, NoSymbol, NoSymbol]
+  };
+  ```
+
+- Compilation with xkbcommon ≥ 1.9.0:
+  ```c
+  key <> {
+    type= "ALPHABETIC",
+    [a, A]
+  };
+  ```

--- a/doc/keymap-format-text-v1.md
+++ b/doc/keymap-format-text-v1.md
@@ -1603,6 +1603,8 @@ level 1 and `XKB_KEY_Q` for level 2. These levels are configured by the
 @remark Remember that @ref keysym-transformations may affect the resulting
 keysym when some modifiers are not [consumed](@ref consumed-modifiers).
 
+@remark Trailing `NoSymbol` are dropped.
+
 As an extension to the XKB legacy format, libxkbcommon supports multiple key
 symbols and actions per level (the latter since version 1.8.0):
 
@@ -1765,6 +1767,8 @@ key <LALT> {
 @endfigure
 
 For further details see [key actions][actions].
+
+@remark Trailing `NoAction()` are dropped.
 
 #### Multiple groups {#key-groups}
 

--- a/test/buffercomp.c
+++ b/test/buffercomp.c
@@ -676,7 +676,66 @@ test_multi_keysyms_actions(struct xkb_context *ctx, bool update_output_files)
                           "SetMods(modifiers=Control)",
                           "SetGroup(group=+1)",
                           "Private(data=\"foo\")",
-                          "Private(data=\"bar\")")
+                          "Private(data=\"bar\")"),
+        {
+            .keymap =
+                "xkb_keymap {\n"
+                "  xkb_keycodes {\n"
+                "    <10> = 10;\n"
+                "    <11> = 11;\n"
+                "    <12> = 12;\n"
+                "    <13> = 13;\n"
+                "    <14> = 14;\n"
+                "    <15> = 15;\n"
+                "    <16> = 16;\n"
+                "    <17> = 17;\n"
+                "    <18> = 18;\n"
+                "    <19> = 19;\n"
+                "    <20> = 20;\n"
+                "    <21> = 21;\n"
+                "    <22> = 22;\n"
+                "    <23> = 23;\n"
+                "    <30> = 30;\n"
+                "    <31> = 31;\n"
+                "    <32> = 32;\n"
+                "    <33> = 33;\n"
+                "    <34> = 34;\n"
+                "    <35> = 35;\n"
+                "    <36> = 36;\n"
+                "    <37> = 37;\n"
+                "    <38> = 38;\n"
+                "    <39> = 39;\n"
+                "  };\n"
+                "  xkb_types { include \"basic+extra\" };\n"
+                "  xkb_symbols {\n"
+                /* Empty keysyms */
+                "    key <10> { [any, any ] };\n"
+             // "    key <11> { [{} , {}  ] };\n"
+                "    key <12> { [any, any ], [SetMods(modifiers=Shift)] };\n"
+             // "    key <13> { [{} , {}  ], [SetMods(modifiers=Shift)] };\n"
+                "    key <14> { [any, any ], type = \"TWO_LEVEL\" };\n"
+             // "    key <15> { [{} , {}  ], type = \"TWO_LEVEL\" };\n"
+                "    key <16> { [a, A, any] };\n"
+             // "    key <17> { [a, A, {} ] };\n"
+                "    key <18> { [a, A, any], type = \"FOUR_LEVEL_SEMIALPHABETIC\" };\n"
+             // "    key <19> { [a, A, {} ], type = \"FOUR_LEVEL_SEMIALPHABETIC\" };\n"
+                "    key <20> { [a, A, ae, any] };\n"
+             // "    key <21> { [a, A, ae, {} ] };\n"
+                "    key <22> { [a, A, ae, AE, any] };\n"
+             // "    key <23> { [a, A, ae, AE, {} ] };\n"
+                /* Empty actions */
+                "    key <30> { [NoAction(), NoAction() ] };\n"
+             // "    key <31> { actions=[{}, {}         ] };\n"
+                "    key <32> { [NoAction(), NoAction() ], [a] };\n"
+             // "    key <33> { actions=[{}, {}         ], [a] };\n"
+                "    key <34> { [NoAction(), NoAction() ], type = \"TWO_LEVEL\" };\n"
+             // "    key <35> { actions=[{}, {}         ], type = \"TWO_LEVEL\" };\n"
+                "    key <38> { [NoAction(), NoAction() ], type = \"FOUR_LEVEL_SEMIALPHABETIC\" };\n"
+             // "    key <39> { actions=[{}, {}         ], type = \"FOUR_LEVEL_SEMIALPHABETIC\" };\n"
+                "  };\n"
+                "};",
+            .expected = GOLDEN_TESTS_OUTPUTS "symbols-multi-keysyms-empty.xkb"
+        }
     };
     for (size_t k = 0; k < ARRAY_SIZE(keymaps); k++) {
         fprintf(stderr, "------\n*** %s: #%zu ***\n", __func__, k);

--- a/test/data/keymaps/merge-modes/augment.xkb
+++ b/test/data/keymaps/merge-modes/augment.xkb
@@ -271,37 +271,37 @@ xkb_symbols "" {
 		symbols[Group1]= [                              a, {                              A,                              Y } ],
 		actions[Group1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
-	key <T016>               {	[     Greek_alpha,               A,        NoSymbol,        NoSymbol ] };
+	key <T016>               {	[     Greek_alpha,               A ] };
 	key <T017>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T018>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha,                              A ],
+		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T020>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T021>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha,                              A ],
+		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
-	key <T022>               {	[     Greek_alpha,               A,        NoSymbol,        NoSymbol ] };
+	key <T022>               {	[     Greek_alpha,               A ] };
 	key <T023>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T024>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha,                              A ],
+		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T025>               {	[               a,               A,     Greek_alpha,        NoSymbol ] };
 	key <T026>               {
@@ -325,23 +325,23 @@ xkb_symbols "" {
 		symbols[Group1]= [                              a,                              A,                              a,                       NoSymbol ],
 		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2),              SetGroup(group=2),                     NoAction() ]
 	};
-	key <T031>               {	[        NoSymbol,        NoSymbol ] };
+	key <T031>               {	[        NoSymbol ] };
 	key <T032>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [                     NoAction() ]
 	};
-	key <T033>               {	[        NoSymbol,        NoSymbol ] };
-	key <T034>               {	[     Greek_alpha,        NoSymbol ] };
+	key <T033>               {	[        NoSymbol ] };
+	key <T034>               {	[     Greek_alpha ] };
 	key <T035>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T036>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T037>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T038>               {
@@ -414,27 +414,27 @@ xkb_symbols "" {
 		symbols[Group1]= [                              a,                              X ],
 		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
-	key <T061>               {	[     Greek_alpha,        NoSymbol ] };
+	key <T061>               {	[     Greek_alpha ] };
 	key <T062>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T063>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
-	key <T064>               {	[     Greek_alpha,        NoSymbol ] };
+	key <T064>               {	[     Greek_alpha ] };
 	key <T065>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T066>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T067>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T068>               {
@@ -623,13 +623,13 @@ xkb_symbols "" {
 		symbols[Group1]= [ {                              a,                              y }, {                              X,                              B } ],
 		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
 	};
-	key <T124>               {	[        NoSymbol,        NoSymbol ] };
+	key <T124>               {	[        NoSymbol ] };
 	key <T125>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [                     NoAction() ]
 	};
-	key <T126>               {	[        NoSymbol,        NoSymbol ] };
+	key <T126>               {	[        NoSymbol ] };
 	key <T127>               {	[ { Greek_alpha, Greek_xi }, { Greek_XI, Greek_BETA } ] };
 	key <T128>               {
 		repeat= No,

--- a/test/data/keymaps/merge-modes/default.xkb
+++ b/test/data/keymaps/merge-modes/default.xkb
@@ -271,37 +271,37 @@ xkb_symbols "" {
 		symbols[Group1]= [                              a, {                              A,                              Y } ],
 		actions[Group1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
-	key <T016>               {	[     Greek_alpha,               A,        NoSymbol,        NoSymbol ] };
+	key <T016>               {	[     Greek_alpha,               A ] };
 	key <T017>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T018>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha,                              A ],
+		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T020>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T021>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha,                              A ],
+		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
-	key <T022>               {	[     Greek_alpha,               A,        NoSymbol,        NoSymbol ] };
+	key <T022>               {	[     Greek_alpha,               A ] };
 	key <T023>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T024>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha,                              A ],
+		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T025>               {	[     Greek_alpha,     Greek_ALPHA,     Greek_alpha,        NoSymbol ] };
 	key <T026>               {
@@ -325,23 +325,23 @@ xkb_symbols "" {
 		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA,                              a,                       NoSymbol ],
 		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=2),                     NoAction() ]
 	};
-	key <T031>               {	[        NoSymbol,        NoSymbol ] };
+	key <T031>               {	[        NoSymbol ] };
 	key <T032>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [                     NoAction() ]
 	};
-	key <T033>               {	[        NoSymbol,        NoSymbol ] };
-	key <T034>               {	[     Greek_alpha,        NoSymbol ] };
+	key <T033>               {	[        NoSymbol ] };
+	key <T034>               {	[     Greek_alpha ] };
 	key <T035>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T036>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T037>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T038>               {
@@ -414,27 +414,27 @@ xkb_symbols "" {
 		symbols[Group1]= [                              a,                              X ],
 		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
-	key <T061>               {	[     Greek_alpha,        NoSymbol ] };
+	key <T061>               {	[     Greek_alpha ] };
 	key <T062>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T063>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
-	key <T064>               {	[     Greek_alpha,        NoSymbol ] };
+	key <T064>               {	[     Greek_alpha ] };
 	key <T065>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T066>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T067>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T068>               {
@@ -623,13 +623,13 @@ xkb_symbols "" {
 		symbols[Group1]= [                    Greek_alpha,                     Greek_BETA ],
 		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
-	key <T124>               {	[        NoSymbol,        NoSymbol ] };
+	key <T124>               {	[        NoSymbol ] };
 	key <T125>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [                     NoAction() ]
 	};
-	key <T126>               {	[        NoSymbol,        NoSymbol ] };
+	key <T126>               {	[        NoSymbol ] };
 	key <T127>               {	[ { Greek_alpha, Greek_xi }, { Greek_XI, Greek_BETA } ] };
 	key <T128>               {
 		repeat= No,

--- a/test/data/keymaps/merge-modes/override.xkb
+++ b/test/data/keymaps/merge-modes/override.xkb
@@ -271,37 +271,37 @@ xkb_symbols "" {
 		symbols[Group1]= [                              a, {                              A,                              Y } ],
 		actions[Group1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
-	key <T016>               {	[     Greek_alpha,               A,        NoSymbol,        NoSymbol ] };
+	key <T016>               {	[     Greek_alpha,               A ] };
 	key <T017>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T018>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha,                              A ],
+		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T020>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T021>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha,                              A ],
+		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
-	key <T022>               {	[     Greek_alpha,               A,        NoSymbol,        NoSymbol ] };
+	key <T022>               {	[     Greek_alpha,               A ] };
 	key <T023>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T024>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha,                              A ],
+		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T025>               {	[     Greek_alpha,     Greek_ALPHA,     Greek_alpha,        NoSymbol ] };
 	key <T026>               {
@@ -325,23 +325,23 @@ xkb_symbols "" {
 		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA,                              a,                       NoSymbol ],
 		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=2),                     NoAction() ]
 	};
-	key <T031>               {	[        NoSymbol,        NoSymbol ] };
+	key <T031>               {	[        NoSymbol ] };
 	key <T032>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [                     NoAction() ]
 	};
-	key <T033>               {	[        NoSymbol,        NoSymbol ] };
-	key <T034>               {	[     Greek_alpha,        NoSymbol ] };
+	key <T033>               {	[        NoSymbol ] };
+	key <T034>               {	[     Greek_alpha ] };
 	key <T035>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T036>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T037>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T038>               {
@@ -414,27 +414,27 @@ xkb_symbols "" {
 		symbols[Group1]= [                              a,                              X ],
 		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
-	key <T061>               {	[     Greek_alpha,        NoSymbol ] };
+	key <T061>               {	[     Greek_alpha ] };
 	key <T062>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T063>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
-	key <T064>               {	[     Greek_alpha,        NoSymbol ] };
+	key <T064>               {	[     Greek_alpha ] };
 	key <T065>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T066>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T067>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T068>               {
@@ -623,13 +623,13 @@ xkb_symbols "" {
 		symbols[Group1]= [                    Greek_alpha,                     Greek_BETA ],
 		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
-	key <T124>               {	[        NoSymbol,        NoSymbol ] };
+	key <T124>               {	[        NoSymbol ] };
 	key <T125>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [                     NoAction() ]
 	};
-	key <T126>               {	[        NoSymbol,        NoSymbol ] };
+	key <T126>               {	[        NoSymbol ] };
 	key <T127>               {	[ { Greek_alpha, Greek_xi }, { Greek_XI, Greek_BETA } ] };
 	key <T128>               {
 		repeat= No,

--- a/test/data/keymaps/merge-modes/replace.xkb
+++ b/test/data/keymaps/merge-modes/replace.xkb
@@ -260,37 +260,37 @@ xkb_symbols "" {
 		symbols[Group1]= [                              a, {                              A,                              Y } ],
 		actions[Group1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
-	key <T016>               {	[     Greek_alpha,        NoSymbol,        NoSymbol,        NoSymbol ] };
+	key <T016>               {	[     Greek_alpha ] };
 	key <T017>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction(),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T018>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction(),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T020>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction(),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T021>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction(),                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
-	key <T022>               {	[     Greek_alpha,        NoSymbol ] };
+	key <T022>               {	[     Greek_alpha ] };
 	key <T023>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T024>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T025>               {	[     Greek_alpha,     Greek_ALPHA,     Greek_alpha,        NoSymbol ] };
 	key <T026>               {
@@ -314,23 +314,23 @@ xkb_symbols "" {
 		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
 		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
-	key <T031>               {	[        NoSymbol,        NoSymbol ] };
+	key <T031>               {	[        NoSymbol ] };
 	key <T032>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [                     NoAction() ]
 	};
-	key <T033>               {	[        NoSymbol,        NoSymbol ] };
-	key <T034>               {	[     Greek_alpha,        NoSymbol ] };
+	key <T033>               {	[        NoSymbol ] };
+	key <T034>               {	[     Greek_alpha ] };
 	key <T035>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T036>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T037>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T038>               {
@@ -354,23 +354,23 @@ xkb_symbols "" {
 		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
 		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
-	key <T046>               {	[        NoSymbol,        NoSymbol ] };
+	key <T046>               {	[        NoSymbol ] };
 	key <T047>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [                     NoAction() ]
 	};
-	key <T048>               {	[        NoSymbol,        NoSymbol ] };
-	key <T049>               {	[     Greek_alpha,        NoSymbol ] };
+	key <T048>               {	[        NoSymbol ] };
+	key <T049>               {	[     Greek_alpha ] };
 	key <T050>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T051>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T052>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T053>               {
@@ -399,27 +399,27 @@ xkb_symbols "" {
 		symbols[Group1]= [                       NoSymbol,                              X ],
 		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
 	};
-	key <T061>               {	[     Greek_alpha,        NoSymbol ] };
+	key <T061>               {	[     Greek_alpha ] };
 	key <T062>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T063>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
-	key <T064>               {	[     Greek_alpha,        NoSymbol ] };
+	key <T064>               {	[     Greek_alpha ] };
 	key <T065>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T066>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T067>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T068>               {
@@ -465,27 +465,27 @@ xkb_symbols "" {
 		symbols[Group1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
 		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
-	key <T079>               {	[     Greek_alpha,        NoSymbol ] };
+	key <T079>               {	[     Greek_alpha ] };
 	key <T080>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T081>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
-	key <T085>               {	[     Greek_alpha,        NoSymbol ] };
+	key <T085>               {	[     Greek_alpha ] };
 	key <T086>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T087>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[Group1]= [                    Greek_alpha ],
+		actions[Group1]= [              SetGroup(group=3) ]
 	};
 	key <T088>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T089>               {
@@ -608,13 +608,13 @@ xkb_symbols "" {
 		symbols[Group1]= [                    Greek_alpha,                     Greek_BETA ],
 		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
-	key <T124>               {	[        NoSymbol,        NoSymbol ] };
+	key <T124>               {	[        NoSymbol ] };
 	key <T125>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [                     NoAction() ]
 	};
-	key <T126>               {	[        NoSymbol,        NoSymbol ] };
+	key <T126>               {	[        NoSymbol ] };
 	key <T127>               {	[ { Greek_alpha, Greek_xi }, { Greek_XI, Greek_BETA } ] };
 	key <T128>               {
 		repeat= No,
@@ -626,13 +626,13 @@ xkb_symbols "" {
 		symbols[Group1]= [ {                    Greek_alpha,                       Greek_xi }, {                       Greek_XI,                     Greek_BETA } ],
 		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
-	key <T130>               {	[        NoSymbol,        NoSymbol ] };
+	key <T130>               {	[        NoSymbol ] };
 	key <T131>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [                     NoAction() ]
 	};
-	key <T132>               {	[        NoSymbol,        NoSymbol ] };
+	key <T132>               {	[        NoSymbol ] };
 	key <T133>               {	[ { Greek_alpha, Greek_xi }, { Greek_XI, Greek_BETA } ] };
 	key <T134>               {
 		repeat= No,
@@ -644,13 +644,13 @@ xkb_symbols "" {
 		symbols[Group1]= [ {                    Greek_alpha,                       Greek_xi }, {                       Greek_XI,                     Greek_BETA } ],
 		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
-	key <T136>               {	[        NoSymbol,        NoSymbol ] };
+	key <T136>               {	[        NoSymbol ] };
 	key <T137>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [                     NoAction() ]
 	};
-	key <T138>               {	[        NoSymbol,        NoSymbol ] };
+	key <T138>               {	[        NoSymbol ] };
 	key <T139>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T140>               {
 		repeat= No,
@@ -662,13 +662,13 @@ xkb_symbols "" {
 		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
 		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
-	key <T142>               {	[        NoSymbol,        NoSymbol ] };
+	key <T142>               {	[        NoSymbol ] };
 	key <T143>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),                     NoAction() ]
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [                     NoAction() ]
 	};
-	key <T144>               {	[        NoSymbol,        NoSymbol ] };
+	key <T144>               {	[        NoSymbol ] };
 	key <T145>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T146>               {
 		repeat= No,

--- a/test/data/keymaps/symbols-multi-keysyms-empty.xkb
+++ b/test/data/keymaps/symbols-multi-keysyms-empty.xkb
@@ -1,0 +1,193 @@
+xkb_keymap {
+xkb_keycodes {
+	minimum = 8;
+	maximum = 255;
+	<10>                 = 10;
+	<11>                 = 11;
+	<12>                 = 12;
+	<13>                 = 13;
+	<14>                 = 14;
+	<15>                 = 15;
+	<16>                 = 16;
+	<17>                 = 17;
+	<18>                 = 18;
+	<19>                 = 19;
+	<20>                 = 20;
+	<21>                 = 21;
+	<22>                 = 22;
+	<23>                 = 23;
+	<30>                 = 30;
+	<31>                 = 31;
+	<32>                 = 32;
+	<33>                 = 33;
+	<34>                 = 34;
+	<35>                 = 35;
+	<36>                 = 36;
+	<37>                 = 37;
+	<38>                 = 38;
+	<39>                 = 39;
+};
+
+xkb_types "basic_extra" {
+	virtual_modifiers NumLock,Alt,LevelThree;
+
+	type "ONE_LEVEL" {
+		modifiers= none;
+		level_name[1]= "Any";
+	};
+	type "TWO_LEVEL" {
+		modifiers= Shift;
+		map[Shift]= 2;
+		level_name[1]= "Base";
+		level_name[2]= "Shift";
+	};
+	type "ALPHABETIC" {
+		modifiers= Shift+Lock;
+		map[Shift]= 2;
+		map[Lock]= 2;
+		level_name[1]= "Base";
+		level_name[2]= "Caps";
+	};
+	type "FOUR_LEVEL" {
+		modifiers= Shift+LevelThree;
+		map[Shift]= 2;
+		map[LevelThree]= 3;
+		map[Shift+LevelThree]= 4;
+		level_name[1]= "Base";
+		level_name[2]= "Shift";
+		level_name[3]= "Alt Base";
+		level_name[4]= "Shift Alt";
+	};
+	type "FOUR_LEVEL_ALPHABETIC" {
+		modifiers= Shift+Lock+LevelThree;
+		map[Shift]= 2;
+		map[Lock]= 2;
+		map[LevelThree]= 3;
+		map[Shift+LevelThree]= 4;
+		map[Lock+LevelThree]= 4;
+		map[Shift+Lock+LevelThree]= 3;
+		level_name[1]= "Base";
+		level_name[2]= "Shift";
+		level_name[3]= "Alt Base";
+		level_name[4]= "Shift Alt";
+	};
+	type "FOUR_LEVEL_SEMIALPHABETIC" {
+		modifiers= Shift+Lock+LevelThree;
+		map[Shift]= 2;
+		map[Lock]= 2;
+		map[LevelThree]= 3;
+		map[Shift+LevelThree]= 4;
+		map[Lock+LevelThree]= 3;
+		preserve[Lock+LevelThree]= Lock;
+		map[Shift+Lock+LevelThree]= 4;
+		preserve[Shift+Lock+LevelThree]= Lock;
+		level_name[1]= "Base";
+		level_name[2]= "Shift";
+		level_name[3]= "Alt Base";
+		level_name[4]= "Shift Alt";
+	};
+	type "FOUR_LEVEL_MIXED_KEYPAD" {
+		modifiers= Shift+NumLock+LevelThree;
+		map[NumLock]= 2;
+		map[Shift]= 2;
+		map[LevelThree]= 3;
+		map[NumLock+LevelThree]= 3;
+		map[Shift+LevelThree]= 4;
+		map[Shift+NumLock+LevelThree]= 4;
+		level_name[1]= "Base";
+		level_name[2]= "Number";
+		level_name[3]= "Alt Base";
+		level_name[4]= "Shift Alt";
+	};
+	type "FOUR_LEVEL_X" {
+		modifiers= Shift+Control+Alt+LevelThree;
+		map[LevelThree]= 2;
+		map[Shift+LevelThree]= 3;
+		map[Control+Alt]= 4;
+		level_name[1]= "Base";
+		level_name[2]= "Alt Base";
+		level_name[3]= "Shift Alt";
+		level_name[4]= "Ctrl+Alt";
+	};
+	type "SEPARATE_CAPS_AND_SHIFT_ALPHABETIC" {
+		modifiers= Shift+Lock+LevelThree;
+		map[Shift]= 2;
+		map[Lock]= 4;
+		preserve[Lock]= Lock;
+		map[LevelThree]= 3;
+		map[Shift+LevelThree]= 4;
+		map[Lock+LevelThree]= 3;
+		preserve[Lock+LevelThree]= Lock;
+		map[Shift+Lock+LevelThree]= 3;
+		level_name[1]= "Base";
+		level_name[2]= "Shift";
+		level_name[3]= "AltGr Base";
+		level_name[4]= "Shift AltGr";
+	};
+	type "FOUR_LEVEL_PLUS_LOCK" {
+		modifiers= Shift+Lock+LevelThree;
+		map[Shift]= 2;
+		map[LevelThree]= 3;
+		map[Shift+LevelThree]= 4;
+		map[Lock]= 5;
+		map[Shift+Lock]= 2;
+		map[Lock+LevelThree]= 3;
+		map[Shift+Lock+LevelThree]= 4;
+		level_name[1]= "Base";
+		level_name[2]= "Shift";
+		level_name[3]= "Alt Base";
+		level_name[4]= "Shift Alt";
+		level_name[5]= "Lock";
+	};
+};
+
+xkb_compatibility {
+	virtual_modifiers NumLock,Alt,LevelThree;
+
+	interpret.useModMapMods= AnyLevel;
+	interpret.repeat= False;
+};
+
+xkb_symbols {
+	key <10>                 {	[        NoSymbol ] };
+	key <12>                 {
+		repeat= No,
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [       SetMods(modifiers=Shift) ]
+	};
+	key <14>                 {
+		type= "TWO_LEVEL",
+		symbols[Group1]= [        NoSymbol,        NoSymbol ]
+	};
+	key <16>                 {	[               a,               A ] };
+	key <18>                 {
+		type= "FOUR_LEVEL_SEMIALPHABETIC",
+		symbols[Group1]= [               a,               A,        NoSymbol,        NoSymbol ]
+	};
+	key <20>                 {	[               a,               A,              ae,        NoSymbol ] };
+	key <22>                 {	[               a,               A,              ae,              AE ] };
+	key <30>                 {
+		repeat= No,
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [                     NoAction() ]
+	};
+	key <32>                 {
+		repeat= No,
+		symbols[Group1]= [                              a ],
+		actions[Group1]= [                     NoAction() ]
+	};
+	key <34>                 {
+		type= "TWO_LEVEL",
+		repeat= No,
+		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
+		actions[Group1]= [                     NoAction(),                     NoAction() ]
+	};
+	key <38>                 {
+		type= "FOUR_LEVEL_SEMIALPHABETIC",
+		repeat= No,
+		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
+		actions[Group1]= [                     NoAction(),                     NoAction(),                     NoAction(),                     NoAction() ]
+	};
+};
+
+};


### PR DESCRIPTION
This brings us closer to what `xkbcomp` outputs. One should use the explicit `VoidSymbol` instead of `NoSymbol`, in order to avoid dropping empty levels.

This may affect keys that rely on an *implicit* key type.

Example:
- Input:
  ```c
  key <> { [a, A, NoSymbol] };
  ```
- Compilation with xkbcommon \< 1.9.0:
  ```c
  key <> {
    type= "FOUR_LEVEL_SEMIALPHABETIC",
    [a, A, NoSymbol, NoSymbol]
  };
  ```

- Compilation with xkbcommon ≥ 1.9.0:
  ```c
  key <> {
    type= "ALPHABETIC",
    [a, A]
  };
  ```

This is also necessary to #699 in order to make `[NoSymbol, NoSymbol]` equivalent to `[{}, {}]`, which simplifies to `[]`.