### PR TITLE
keymap: Use constants for Lock and Control indexes

### DIFF
--- a/src/keymap-priv.c
+++ b/src/keymap-priv.c
@@ -19,14 +19,14 @@ update_builtin_keymap_fields(struct xkb_keymap *keymap)
 {
     /* Predefined (AKA real, core, X11) modifiers. The order is important! */
     static const char *const builtin_mods[] = {
-        [0] = XKB_MOD_NAME_SHIFT,
-        [1] = XKB_MOD_NAME_CAPS,
-        [2] = XKB_MOD_NAME_CTRL,
-        [3] = XKB_MOD_NAME_MOD1,
-        [4] = XKB_MOD_NAME_MOD2,
-        [5] = XKB_MOD_NAME_MOD3,
-        [6] = XKB_MOD_NAME_MOD4,
-        [7] = XKB_MOD_NAME_MOD5
+        [XKB_MOD_INDEX_SHIFT] = XKB_MOD_NAME_SHIFT,
+        [XKB_MOD_INDEX_CAPS]  = XKB_MOD_NAME_CAPS,
+        [XKB_MOD_INDEX_CTRL]  = XKB_MOD_NAME_CTRL,
+        [XKB_MOD_INDEX_MOD1]  = XKB_MOD_NAME_MOD1,
+        [XKB_MOD_INDEX_MOD2]  = XKB_MOD_NAME_MOD2,
+        [XKB_MOD_INDEX_MOD3]  = XKB_MOD_NAME_MOD3,
+        [XKB_MOD_INDEX_MOD4]  = XKB_MOD_NAME_MOD4,
+        [XKB_MOD_INDEX_MOD5]  = XKB_MOD_NAME_MOD5
     };
 
     for (unsigned i = 0; i < ARRAY_SIZE(builtin_mods); i++) {

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -56,6 +56,18 @@ enum mod_type {
 };
 #define MOD_REAL_MASK_ALL ((xkb_mod_mask_t) 0x000000ff)
 
+/** Predefined (AKA real, core, X11) modifiers. The order is important! */
+enum real_mod_index {
+    XKB_MOD_INDEX_SHIFT = 0,
+    XKB_MOD_INDEX_CAPS,
+    XKB_MOD_INDEX_CTRL,
+    XKB_MOD_INDEX_MOD1,
+    XKB_MOD_INDEX_MOD2,
+    XKB_MOD_INDEX_MOD3,
+    XKB_MOD_INDEX_MOD4,
+    XKB_MOD_INDEX_MOD5
+};
+
 enum xkb_action_type {
     ACTION_TYPE_NONE = 0,
     ACTION_TYPE_MOD_SET,

--- a/src/state.c
+++ b/src/state.c
@@ -922,7 +922,7 @@ xkb_state_update_mask(struct xkb_state *state,
      *
      * It might seem more reasonable to do this only for components.mods
      * in xkb_state_update_derived(), rather than for each component
-     * seperately.  That would allow to distinguish between "really"
+     * separately.  That would allow to distinguish between "really"
      * depressed mods (would be in MODS_DEPRESSED) and indirectly
      * depressed to to a mapping (would only be in MODS_EFFECTIVE).
      * However, the traditional behavior of xkb_state_update_key() is that
@@ -981,12 +981,10 @@ err:
 static bool
 should_do_caps_transformation(struct xkb_state *state, xkb_keycode_t kc)
 {
-    xkb_mod_index_t caps =
-        xkb_keymap_mod_get_index(state->keymap, XKB_MOD_NAME_CAPS);
-
     return
-        xkb_state_mod_index_is_active(state, caps, XKB_STATE_MODS_EFFECTIVE) > 0 &&
-        xkb_state_mod_index_is_consumed(state, kc, caps) == 0;
+        xkb_state_mod_index_is_active(state, XKB_MOD_INDEX_CAPS,
+                                      XKB_STATE_MODS_EFFECTIVE) > 0 &&
+        xkb_state_mod_index_is_consumed(state, kc, XKB_MOD_INDEX_CAPS) == 0;
 }
 
 /*
@@ -995,12 +993,10 @@ should_do_caps_transformation(struct xkb_state *state, xkb_keycode_t kc)
 static bool
 should_do_ctrl_transformation(struct xkb_state *state, xkb_keycode_t kc)
 {
-    xkb_mod_index_t ctrl =
-        xkb_keymap_mod_get_index(state->keymap, XKB_MOD_NAME_CTRL);
-
     return
-        xkb_state_mod_index_is_active(state, ctrl, XKB_STATE_MODS_EFFECTIVE) > 0 &&
-        xkb_state_mod_index_is_consumed(state, kc, ctrl) == 0;
+        xkb_state_mod_index_is_active(state, XKB_MOD_INDEX_CTRL,
+                                      XKB_STATE_MODS_EFFECTIVE) > 0 &&
+        xkb_state_mod_index_is_consumed(state, kc, XKB_MOD_INDEX_CTRL) == 0;
 }
 
 /*


### PR DESCRIPTION
These indexes are fixed, so there is no need to lookup their name.