### PR TITLE
tools: Update bash completion

### DIFF
--- a/tools/xkbcli-bash-completion.sh
+++ b/tools/xkbcli-bash-completion.sh
@@ -72,6 +72,10 @@ ___xkbcli_subcommand()
                     _filedir
                     return;;
             esac
+            if [[ ${COMP_WORDS[COMP_CWORD]} != -* ]]; then
+                _filedir
+                return
+            fi
             ;;
         compile-compose)
             case ${COMP_WORDS[COMP_CWORD-1]} in
@@ -79,6 +83,10 @@ ___xkbcli_subcommand()
                     _filedir
                     return;;
             esac
+            if [[ ${COMP_WORDS[COMP_CWORD]} != -* ]]; then
+                _filedir
+                return
+            fi
             ;;
         list)
             if [[ ${COMP_WORDS[COMP_CWORD]} != -* ]]; then


### PR DESCRIPTION
Handle positional argument as a path for the `compile-*` tools.

Fixes #705