### PR TITLE
Avoid using strto* standard parsers

### DIFF
--- a/bench/custom-parsers.c
+++ b/bench/custom-parsers.c
@@ -1,0 +1,259 @@
+/*
+ * Copyright © 2025 Pierre Le Marre <dev@wismill.eu>
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "config.h"
+
+#include <fcntl.h>
+#include <time.h>
+#include <getopt.h>
+#include <stdint.h>
+
+#include "utils.h"
+#include "utils-numbers.h"
+
+#include "bench.h"
+
+const double DEFAULT_STDEV = 0.05;
+
+static void
+usage(char **argv)
+{
+    printf("Usage: %s [OPTIONS]\n"
+           "\n"
+           "Benchmark compilation of the given RMLVO\n"
+           "\n"
+           "Options:\n"
+           " --help\n"
+           "    Print this help and exit\n"
+           " --stdev\n"
+           "    Minimal relative standard deviation (percentage) to reach.\n"
+           "    (default: %f)\n"
+           "\n",
+           argv[0], DEFAULT_STDEV * 100);
+}
+
+static void
+print_stats(double stdev, unsigned int max_iterations,
+            struct bench_time *elapsed, struct bench *bench,
+            struct estimate *est)
+{
+    struct bench_time total_elapsed;
+    bench_elapsed(bench, &total_elapsed);
+    fprintf(stderr,
+            "mean: %lld µs; stdev: %Lf%% (target: %f%%); "
+            "last run: parsed %u times in %ld.%06lds; "
+            "total time: %ld.%06lds\n", est->elapsed / 1000,
+            (long double) est->stdev * 100.0 / (long double) est->elapsed,
+            stdev * 100,
+            max_iterations, elapsed->seconds, elapsed->nanoseconds / 1000,
+            total_elapsed.seconds, total_elapsed.nanoseconds / 1000);
+}
+
+/* NOTE: Old parser, for comparison */
+static bool
+parse_keysym_hex(const char *s, uint32_t *out)
+{
+    uint32_t result = 0;
+    unsigned int i;
+    for (i = 0; i < 8 && s[i] != '\0'; i++) {
+        result <<= 4;
+        if ('0' <= s[i] && s[i] <= '9')
+            result += s[i] - '0';
+        else if ('a' <= s[i] && s[i] <= 'f')
+            result += 10 + s[i] - 'a';
+        else if ('A' <= s[i] && s[i] <= 'F')
+            result += 10 + s[i] - 'A';
+        else
+            return false;
+    }
+    *out = result;
+    return s[i] == '\0' && i > 0;
+}
+
+int
+main(int argc, char **argv)
+{
+    struct bench bench;
+    struct bench_time elapsed;
+    struct estimate est;
+    int ret = 0;
+    double stdev = DEFAULT_STDEV;
+
+    enum options {
+        OPT_STDEV,
+    };
+
+    static struct option opts[] = {
+        {"help",             no_argument,            0, 'h'},
+        {"stdev",            required_argument,      0, OPT_STDEV},
+        {0, 0, 0, 0},
+    };
+
+    while (1) {
+        int c;
+        int option_index = 0;
+        c = getopt_long(argc, argv, "h", opts, &option_index);
+        if (c == -1)
+            break;
+
+        switch (c) {
+        case 'h':
+            usage(argv);
+            exit(EXIT_SUCCESS);
+        case OPT_STDEV:
+            stdev = atof(optarg) / 100;
+            if (stdev <= 0)
+                stdev = DEFAULT_STDEV;
+            break;
+        default:
+            usage(argv);
+            exit(EXIT_INVALID_USAGE);
+        }
+    }
+
+    FILE *file = fopen(__FILE__, "r");
+    assert(file);
+    size_t size = 0;
+    char *content = NULL;
+    map_file(file, &content, &size);
+    assert(content);
+
+    /*
+     * Some numbers for the parsers, do not delete.
+     *
+     * 0x0000000000000000   0x0000000000000002   0x0000000000000003
+     * 0x0000000000000001   0x00000000000000FE   0x00000000000001FE
+     * 0x000000000000000A   0x0000000000000200   0x0000000000000400
+     * 0x00000000000000FF   0x0000000000020000   0x0000000000040000
+     * 0x0000000000000100   0x0000000002000000   0x0000000004000000
+     * 0x0000000000001000   0x0000000200000000   0x0000000400000000
+     * 0x0000000000010000   0x0000020000000000   0x0000040000000000
+     * 0x0000000001000000   0x0002000000000000   0x0004000000000000
+     * 0x0000000100000000   0x0200000000000000   0x0400000000000000
+     * 0x0000010000000000   0x2000000000000000   0x4000000000000001
+     * 0x0001000000000000   0x4000000000000000   0x3FFFFFFFFFFFFFFF
+     * 0x0100000000000000   0x6FFFFFFFFFFFFFFF   0xA000000000000000
+     * 0x1000000000000000   0x9000000000000000   0xCFFFFFFFFFFFFFFF
+     * 0x7FFFFFFFFFFFFFFF   0xEFFFFFFFFFFFFFFF   0xD000000000000000
+     * 0x8000000000000000   0xF000000000000000   0xE000000000000000
+     * 0xFFFFFFFFFFFFFFFF   0x1A2B3C4D5E6F7089   0x0807060504030201
+     * 0x123456789ABCDEF0   0x89706F5E4D3C2B1A   0xF1E2D3C4B5A69788
+     * 0xFEDCBA9876543210   0x5A5A5A5A5A5A5A5A   0x6B6B6B6B6B6B6B6B
+     * 0xABABABABABABABAB   0xA5A5A5A5A5A5A5A5   0xB6B6B6B6B6B6B6B6
+     * 0xCDCDCDCDCDCDCDCD   0xC3D2E1F00F1E2D3C   0x1122334455667788
+     * 0x0123456789ABCDEF   0x3C2D1E0F0FE1D2C3   0x8877665544332211
+     * 0x9876543210FEDCBA   0x0000000080000000   0x0000000040000000
+     * 0x00000000FFFFFFFF   0x8000000000000000   0x4000000000000000
+     * 0xFFFFFFFF00000000   0x6666666666666666   0x7777777777777777
+     * 0x5555555555555555   0x9999999999999999   0x8888888888888888
+     * 0x0AAAAAAAAAAAAAAA   0x0000000200000002   0x0000000300000003
+     * 0x0000000100000001   0x4444444444444444   0x5F5F5F5F5F5F5F5F
+     * 0x1111111111111111   0xBBBBBBBBBBBBBBBB   0xC0C0C0C0C0C0C0C0
+     * 0x2222222222222222   0xCCCCCCCCCCCCCCCC   0xE1E1E1E1E1E1E1E1
+     * 0x3333333333333333   0xDDDDDDDDDDDDDDDD   0xF2F2F2F2F2F2F2F2
+     * 0x1A3F5C7E9D2B4A68   0x8E6D4C2B1A0F9E7D   0x3F9A8B7C6D5E4F2A
+     * 0x7B6C5D4E3F2A1B09   0x2D4E6F8A9C0B1D3E   0x5A4B3C2D1E0F9A8B
+     * 0x9E8D7C6B5A4F3E2D   0x1C3E5F7A9D0B2E4F   0x6D5E4F3A2B1C0D9E
+     * 0xA0B1C2D3E4F56789   0x3B4D5F6E7A8C9D0E   0x7E8F9A0B1C2D3E4F
+     * 0x2C3D4E5F6A7B8C9D   0x9A8B7C6D5E4F3A2B   0x1E2D3C4B5A6F7E8D
+     * 0x4D5E6F7A8B9C0D1E   0x3A2B1C0D9E8F7A6B   0x8C9D0E1F2A3B4C5D
+     * 0x5F6E7D8C9B0A1F2E   0x0A1B2C3D4E5F6A7B   0x9C0D1E2F3A4B5C6D
+     * 0x6A7B8C9D0E1F2A3B   0x2E3F4A5B6C7D8E9F   0x1D2C3B4A5F6E7D8C
+     * 0x7D8E9F0A1B2C3D4E   0x4B5C6D7E8F9A0B1C   0x0F1E2D3C4B5A6F7E
+     * 0x8B9C0D1E2F3A4B5C   0x5A6B7C8D9E0F1A2B   0x3C4D5E6F7A8B9C0D
+     * 0x9D0E1F2A3B4C5D6E   0x6B7C8D9E0F1A2B3C   0x2A3B4C5D6E7F8A9B
+     * 0x0E1F2A3B4C5D6E7F   0x7C8D9E0F1A2B3C4D   0x4A5B6C7D8E9F0A1B
+     * 0x1F2A3B4C5D6E7F8A   0x8D9E0F1A2B3C4D5E   0x5B6C7D8E9F0A1B2C
+     * 0x2B3C4D5E6F7A8B9C   0x9E0F1A2B3C4D5E6F   0x6C7D8E9F0A1B2C3D
+     * 0x0A1B2C3D4E5F6A7B   0x7E8F9A0B1C2D3E4F   0x3D4E5F6A7B8C9D0E
+     * 0x1B2C3D4E5F6A7B8C   0x8F9A0B1C2D3E4F5A   0x4E5F6A7B8C9D0E1F
+     * 0x3A4B5C6D7E8F9A0B   0x9F0A1B2C3D4E5F6A   0x5C6D7E8F9A0B1C2D
+     * 0x0B1C2D3E4F5A6B7C   0x7F8A9B0C1D2E3F4A   0x2D3E4F5A6B7C8D9E
+     * 0x1C2D3E4F5A6B7C8D   0x9A0B1C2D3E4F5A6B   0x4F5A6B7C8D9E0F1A
+     * 0x6D7E8F9A0B1C2D3E   0x0C1D2E3F4A5B6C7D   0x3B4C5D6E7F8A9B0C
+     * 0x8E9F0A1B2C3D4E5F   0x5D6E7F8A9B0C1D2E   0x1A2B3C4D5E6F7A8B
+     * 0x0D1E2F3A4B5C6D7E   0x7A8B9C0D1E2F3A4B   0x2E3F4A5B6C7D8E9F
+     * 0x9B0C1D2E3F4A5B6C   0x6E7F8A9B0C1D2E3F   0x0F1A2B3C4D5E6F7A
+     */
+
+    volatile uint32_t __attribute__((unused)) dummy32 = 0;
+    volatile uint64_t __attribute__((unused)) dummy64 = 0;
+    unsigned int max_iterations;
+
+    printf("*** parse_hex_to_uint32_t ***\n");
+    bench_start2(&bench);
+        BENCH(stdev, max_iterations, elapsed, est,
+            for (size_t n = 0; n < size; n++) {
+                uint32_t val = 0;
+                parse_hex_to_uint32_t(content + n, 8, &val);
+                dummy32 += val;
+            }
+        );
+    bench_stop2(&bench);
+    print_stats(stdev, max_iterations, &elapsed, &bench, &est);
+
+    printf("*** parse_keysym_hex ***\n");
+    bench_start2(&bench);
+        BENCH(stdev, max_iterations, elapsed, est,
+            for (size_t n = 0; n < size; n++) {
+                uint32_t val = 0;
+                parse_keysym_hex(content + n, &val);
+                dummy32 += val;
+            }
+        );
+    bench_stop2(&bench);
+    print_stats(stdev, max_iterations, &elapsed, &bench, &est);
+
+    printf("*** parse_dec_to_uint64_t ***\n");
+    bench_start2(&bench);
+        BENCH(stdev, max_iterations, elapsed, est,
+            for (size_t n = 0; n < size; n++) {
+                uint64_t val = 0;
+                parse_dec_to_uint64_t(content + n, size - n, &val);
+                dummy64 += val;
+            }
+        );
+    bench_stop2(&bench);
+    print_stats(stdev, max_iterations, &elapsed, &bench, &est);
+
+    printf("*** strtol, base 10 ***\n");
+    bench_start2(&bench);
+        BENCH(stdev, max_iterations, elapsed, est,
+            for (size_t n = 0; n < size; n++) {
+                dummy64 += strtol(content + n, NULL, 10);
+            }
+        );
+    bench_stop2(&bench);
+    print_stats(stdev, max_iterations, &elapsed, &bench, &est);
+
+
+    printf("*** parse_hex_to_uint64_t ***\n");
+    bench_start2(&bench);
+        BENCH(stdev, max_iterations, elapsed, est,
+            for (size_t n = 0; n < size; n++) {
+                uint64_t val = 0;
+                parse_hex_to_uint64_t(content + n, size - n, &val);
+                dummy64 += val;
+            }
+        );
+    bench_stop2(&bench);
+    print_stats(stdev, max_iterations, &elapsed, &bench, &est);
+
+
+    printf("*** strtol, base 16 ***\n");
+    bench_start2(&bench);
+        BENCH(stdev, max_iterations, elapsed, est,
+            for (size_t n = 0; n < size; n++) {
+                dummy64 += strtol(content + n, NULL, 16);
+            }
+        );
+    bench_stop2(&bench);
+    print_stats(stdev, max_iterations, &elapsed, &bench, &est);
+
+    unmap_file(content, size);
+    fclose(file);
+
+    return ret;
+}

--- a/meson.build
+++ b/meson.build
@@ -256,6 +256,7 @@ libxkbcommon_sources = [
     'src/utils.c',
     'src/utils.h',
     'src/util-mem.h',
+    'src/utils-numbers.h',
     'src/utils-paths.c',
     'src/utils-paths.h',
 ]
@@ -856,6 +857,9 @@ test(
     'utils',
     executable(
         'test-utils',
+        'src/utils.h',
+        'src/utils-numbers.h',
+        'src/utils-paths.h',
         'test/utils.c',
         'test/utils-text.c',
         'test/utils-text.h',
@@ -1000,6 +1004,18 @@ if cc.has_header_symbol('getopt.h', 'getopt_long', prefix: '#define _GNU_SOURCE'
             'bench/compile-keymap.c',
             dependencies: test_dep,
             c_args: ['-DKEYMAP_DUMP'],
+        ),
+        env: bench_env,
+    )
+    benchmark(
+        'custom-parsers',
+        executable(
+            'bench-custom-parsers',
+            'bench/custom-parsers.c',
+            'src/utils.c',
+            'src/utils.h',
+            'src/utils-numbers.h',
+            dependencies: test_dep,
         ),
         env: bench_env,
     )

--- a/src/utils-numbers.h
+++ b/src/utils-numbers.h
@@ -43,6 +43,13 @@ parse_dec_to_##type(const char *s, size_t len, type (*out))  \
 }
 
 /**
+ * Parse a `uint32_t` in decimal format.
+ *
+ * @returns -1 on error (overflow) or the count of characters parsed.
+ */
+MAKE_PARSE_DEC_TO(uint32_t, UINT32_MAX)
+
+/**
  * Parse a `uint64_t` in decimal format.
  *
  * @returns -1 on error (overflow) or the count of characters parsed.

--- a/src/utils-numbers.h
+++ b/src/utils-numbers.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2025 Pierre Le Marre <dev@wismill.eu>
+ * SPDX-License-Identifier: MIT
+ */
+#pragma once
+
+#include "config.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "utils.h"
+
+/*
+ * Define various parsers to avoid the use of strto* -- it’s slower and accepts
+ * a bunch of stuff we don’t want to allow, like signs, spaces, even locale stuff.
+ *
+ * But the real feature is that it does not require a NULL-terminated string, so
+ * it works safely *also* on any buffer, assuming the correct corresponding size
+ * is provided. For NULL-terminated strings, just pass `SIZE_MAX` as the length:
+ * the parsers will *always* stop on a NULL character.
+ */
+
+#define MAKE_PARSE_DEC_TO(type, max)                         \
+static inline int                                            \
+parse_dec_to_##type(const char *s, size_t len, type (*out))  \
+{                                                            \
+    type result = 0;                                         \
+    size_t i;                                                \
+    for (i = 0;                                              \
+         i < len && (unsigned char)(s[i] - '0') < 10U &&     \
+         result <= (max) / 10 &&                             \
+         result * 10 <= (max) - (unsigned char) (s[i] - '0');\
+         i++) {                                              \
+        result = result * 10 + (s[i] - '0');                 \
+    }                                                        \
+    *out = result;                                           \
+    /* Check if there is more to parse */                    \
+    /* We can safely convert the length to int on success */ \
+    return (i >= len || (unsigned char)(s[i] - '0') >= 10U)  \
+           ? (int) i                                         \
+           : -1;                                             \
+}
+
+/**
+ * Parse a `uint64_t` in decimal format.
+ *
+ * @returns -1 on error (overflow) or the count of characters parsed.
+ */
+MAKE_PARSE_DEC_TO(uint64_t, UINT64_MAX)
+
+#undef MAKE_PARSE_DEC_TO
+
+static const unsigned char digits__[] = {
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0,  1,  2,  3,  4,  5,  6,  7,  8,
+    9,  -1, -1, -1, -1, -1, -1, -1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, -1, -1, -1, -1,
+    -1, -1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+    27, 28, 29, 30, 31, 32, 33, 34, 35, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1
+};
+
+#define MAKE_PARSE_HEX_TO(type, max)                           \
+static inline int                                              \
+parse_hex_to_##type(const char *s, size_t len, type (*out))    \
+{                                                              \
+    type result = 0;                                           \
+    size_t i = 0;                                              \
+    for (; i < len && digits__[(unsigned char) s[i]] < 16u &&  \
+         result <= (max) >> 4;                                 \
+         i++) {                                                \
+        result = result * 16 + digits__[(unsigned char) s[i]]; \
+    }                                                          \
+    *out = result;                                             \
+    /* Check if there is more to parse */                      \
+    /* We can safely convert the length to int on success */   \
+    return (i >= len || !is_xdigit(s[i])) ? (int) i : -1;      \
+}
+
+/**
+ * Parse a `uint32_t` in hexdecimal format.
+ *
+ * @returns -1 on error (overflow) or the count of characters parsed.
+ */
+MAKE_PARSE_HEX_TO(uint32_t, UINT32_MAX)
+
+/**
+ * Parse a `uint64_t` in hexdecimal format.
+ *
+ * @returns -1 on error (overflow) or the count of characters parsed.
+ */
+MAKE_PARSE_HEX_TO(uint64_t, UINT64_MAX)
+
+#undef MAKE_PARSE_HEX_TO

--- a/test/data/keymaps/integers.xkb
+++ b/test/data/keymaps/integers.xkb
@@ -21,7 +21,7 @@ xkb_symbols {
 	key <>                   {
 		repeat= No,
 		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [                     NoAction() ],
+		actions[Group1]= [              MovePtr(x=0,y=+0) ],
 		symbols[Group2]= [                       NoSymbol ],
 		actions[Group2]= [           MovePtr(x=2,y=32766) ]
 	};

--- a/test/data/rules/invalid-group-index
+++ b/test/data/rules/invalid-group-index
@@ -1,0 +1,19 @@
+! model         = keycodes
+  *             = default_keycodes
+
+! layout        = symbols
+  *             = default_symbols
+
+// Invalid group index
+! layout[+1]    = symbols
+  *             = default_symbols
+
+// Invalid group index
+! layout[+2]    = symbols
+  *             = +default_symbols:2
+
+! model         = types
+  *             = default_types
+
+! model         = compat
+  *             = default_compat

--- a/test/data/rules/invalid-group-qualifier
+++ b/test/data/rules/invalid-group-qualifier
@@ -1,0 +1,18 @@
+! model         = keycodes
+  *             = default_keycodes
+
+! layout        = symbols
+  *             = default_symbols
+
+! layout[1]     = symbols
+  *             = default_symbols
+
+! layout[2]     = symbols
+// Invalid group qualifier
+  *             = +default_symbols:+2
+
+! model         = types
+  *             = default_types
+
+! model         = compat
+  *             = default_compat

--- a/test/rules-file.c
+++ b/test/rules-file.c
@@ -9,6 +9,7 @@
 #include "utils.h"
 #include "test.h"
 #include "xkbcomp/rules.h"
+#include <stdlib.h>
 
 struct test_data {
     /* Rules file */
@@ -95,7 +96,7 @@ main(int argc, char *argv[])
 
     test_init();
 
-    ctx = test_get_context(0);
+    ctx = test_get_context(CONTEXT_NO_FLAG);
     assert(ctx);
 
     struct test_data test_utf_8_with_bom = {
@@ -149,6 +150,34 @@ main(int argc, char *argv[])
         .explicit_layouts = 1,
     };
     assert(!test_rules(ctx, &test_utf_32be));
+
+    /* Only parse strict decimal groups */
+    struct test_data test_invalid_group_index = {
+        .rules = "invalid-group-index",
+
+        .model = "my_model", .layout = "1,2", .variant = NULL,
+        .options = NULL,
+
+        .keycodes = "default_keycodes", .types = "default_types",
+        .compat = "default_compat",
+        .symbols = "default_symbols+default_symbols:2",
+        .explicit_layouts = 2,
+    };
+    assert(!test_rules(ctx, &test_invalid_group_index));
+
+    /* Only parse strict decimal groups */
+    struct test_data test_invalid_group_qualifier = {
+        .rules = "invalid-group-qualifier",
+
+        .model = "my_model", .layout = "1,2", .variant = NULL,
+        .options = NULL,
+
+        .keycodes = "default_keycodes", .types = "default_types",
+        .compat = "default_compat",
+        .symbols = "default_symbols+default_symbols:+2",
+        .explicit_layouts = 1,
+    };
+    assert(test_rules(ctx, &test_invalid_group_qualifier));
 
     struct test_data test1 = {
         .rules = "simple",
@@ -526,5 +555,5 @@ main(int argc, char *argv[])
     assert(test_rules(ctx, &all_qualified_with_special_indexes2));
 
     xkb_context_unref(ctx);
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/test/utils.c
+++ b/test/utils.c
@@ -326,6 +326,9 @@ test_number_parsers(void)
     };
     for (size_t k = 0; k < ARRAY_SIZE(values); k++) {
         /* Basic: decimal */
+        count = snprintf(buffer, sizeof(buffer), "%"PRIu32, (uint32_t) values[k]);
+        assert(count > 0);
+        test_parse_to(uint32_t, dec, buffer, count, (uint32_t) values[k]);
         count = snprintf(buffer, sizeof(buffer), "%"PRIu64, values[k]);
         assert(count > 0);
         test_parse_to(uint64_t, dec, buffer, count, values[k]);
@@ -346,6 +349,10 @@ test_number_parsers(void)
         /* Prefix with some zeroes */
         for (int z = 0; z < 10 ; z++) {
             /* Decimal */
+            count = snprintf(buffer, sizeof(buffer), "%0*"PRIu32,
+                             z, (uint32_t) values[k]);
+            assert(count > 0);
+            test_parse_to(uint32_t, dec, buffer, count, (uint32_t) values[k]);
             count = snprintf(buffer, sizeof(buffer), "%0*"PRIu64,
                              z, values[k]);
             assert(count > 0);
@@ -363,6 +370,10 @@ test_number_parsers(void)
             for (int c = 0; c < 0x100 ; c++) {
                 if (c < '0' || c > '9') {
                     /* Decimal */
+                    count = snprintf(buffer, sizeof(buffer), "%0*u%"PRIu32"%c",
+                                     z, 0, (uint32_t) values[k], (char) c);
+                    assert(count > 0);
+                    test_parse_to(uint32_t, dec, buffer, count - 1, (uint32_t) values[k]);
                     count = snprintf(buffer, sizeof(buffer), "%0*u%"PRIu64"%c",
                                      z, 0, values[k], (char) c);
                     assert(count > 0);
@@ -409,11 +420,17 @@ test_number_parsers(void)
         /* Hex: some garbage after */
         buffer[count] = (char) (((unsigned) rand()) % '0');
         test_parse_to(uint64_t, hex, buffer, count, x64);
-        /* Decimal */
+        /* Decimal (32 bits) */
+        count = snprintf(buffer, sizeof(buffer), "%"PRIu32, x32);
+        assert(count > 0);
+        test_parse_to(uint32_t, dec, buffer, count, x32);
+        /* Decimal: some garbage after */
+        buffer[count] = (char) (((unsigned) rand()) % '0');
+        test_parse_to(uint32_t, dec, buffer, count, x32);
+        /* Decimal (64 bits) */
         count = snprintf(buffer, sizeof(buffer), "%"PRIu64, x64);
         assert(count > 0);
         test_parse_to(uint64_t, dec, buffer, count, x64);
-        /* Decimal: some garbage after */
         buffer[count] = (char) (((unsigned) rand()) % '0');
         test_parse_to(uint64_t, dec, buffer, count, x64);
     }

--- a/test/utils.c
+++ b/test/utils.c
@@ -7,11 +7,14 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "test.h"
 #include "utils.h"
+#include "utils-numbers.h"
 #include "utils-paths.h"
 #include "test/utils-text.h"
 
@@ -96,12 +99,334 @@ test_path_functions(void)
 #endif
 }
 
+static uint32_t
+rand_uint32(void)
+{
+    static int initialized = 0;
+    if (!initialized) {
+        srand((unsigned int)time(NULL));
+        initialized = 1;
+    }
+
+    /* First decide how many bits we’ll actually use (1-32) */
+    int bits = 1 + (rand() % 32);
+
+    /* Generate a number with that many bits */
+    uint32_t result = 0;
+    while (bits > 0) {
+        int bits_this_round = bits > 16 ? 16 : bits;
+        result = (result << bits_this_round)
+               | (rand() & ((1U << bits_this_round) - 1));
+        bits -= bits_this_round;
+    }
+
+    return result;
+}
+
+static uint64_t
+rand_uint64(void)
+{
+    static int initialized = 0;
+    if (!initialized) {
+        srand((unsigned int)time(NULL));
+        initialized = 1;
+    }
+
+    /* First decide how many bits we’ll actually use (1-64) */
+    int bits = 1 + (rand() % 64);
+
+    /* Generate a number with that many bits */
+    uint64_t result = 0;
+    while (bits > 0) {
+        int bits_this_round = bits > 16 ? 16 : bits;
+        result = (result << bits_this_round)
+               | (rand() & ((1U << bits_this_round) - 1));
+        bits -= bits_this_round;
+    }
+
+    return result;
+}
+
+/* NOLINTBEGIN(google-readability-function-size) */
+static void
+test_number_parsers(void)
+{
+    /* Check the claim that it always works on normal strings using SIZE_MAX and
+     * that it always stops on the first NULL byte */
+    {
+        const struct {
+            const char* input;
+            struct { int count; uint64_t val; } dec;
+            struct { int count; uint64_t val; } hex;
+        } tests[] = {
+            {
+                .input = "",
+                .dec = { 0, UINT64_C(0) },
+                .hex = { 0, UINT64_C(0) }
+            },
+            {
+                .input = "\0""123",
+                .dec = { 0, UINT64_C(0) },
+                .hex = { 0, UINT64_C(0) }
+            },
+            {
+                .input = "x",
+                .dec = { 0, UINT64_C(0) },
+                .hex = { 0, UINT64_C(0) }
+            },
+            {
+                .input = "1",
+                .dec = { 1, UINT64_C(1) },
+                .hex = { 1, UINT64_C(1) }
+            },
+            {
+                .input = "123",
+                .dec = { 3, UINT64_C(123)  },
+                .hex = { 3, UINT64_C(0x123)}
+            },
+            {
+                .input = "123x",
+                .dec = { 3, UINT64_C(123)  },
+                .hex = { 3, UINT64_C(0x123)}
+            },
+            {
+                .input = "123""\0""456",
+                .dec = { 3, UINT64_C(123)  },
+                .hex = { 3, UINT64_C(0x123)}
+            },
+            {
+                .input = "18446744073709551615",
+                .dec = { 20, UINT64_MAX                  },
+                .hex = { -1, UINT64_C(0x1844674407370955)}
+            },
+            {
+                .input = "184467440737095516150",
+                .dec = { -1, UINT64_MAX                  },
+                .hex = { -1, UINT64_C(0x1844674407370955)}
+            },
+            {
+                .input = "ffffffffffffffff",
+                .dec = { 0 , 0         },
+                .hex = { 16, UINT64_MAX}
+            },
+            {
+                .input = "fffffffffffffffff",
+                .dec = { 0 , 0         },
+                .hex = { -1, UINT64_MAX}
+            },
+
+        };
+        for (size_t k = 0; k < ARRAY_SIZE(tests); k++) {
+            uint64_t dec = 0;
+            int count;
+            count = parse_dec_to_uint64_t(tests[k].input, SIZE_MAX, &dec);
+            assert_printf(count == tests[k].dec.count,
+                          "SIZE_MAX #%zu, expected: %d, got: %d\n",
+                          k, tests[k].dec.count, count);
+            assert_printf(dec == tests[k].dec.val,
+                          "SIZE_MAX #%zu, expected: %"PRIu64", got: %"PRIu64"\n",
+                          k, tests[k].dec.val, dec);
+            uint64_t hex = 0;
+            count = parse_hex_to_uint64_t(tests[k].input, SIZE_MAX, &hex);
+            assert_printf(count == tests[k].hex.count,
+                          "SIZE_MAX #%zu, expected: %d, got: %d\n",
+                          k, tests[k].hex.count, count);
+            assert_printf(hex == tests[k].hex.val,
+                          "SIZE_MAX #%zu, expected: %#"PRIx64", got: %#"PRIx64"\n",
+                          k, tests[k].hex.val, hex);
+        }
+    }
+
+#define str_safe_len(input) \
+    (sizeof(input) == 0 ?   \
+        0                   \
+        : sizeof(input) - ((input)[sizeof(input) - 1] == '\0' ? -1 : 0))
+#define PRIuint64_t PRIx64
+#define PRIuint32_t PRIx32
+#define test_parse_to(type, format, input, count, expected) do {             \
+    type n = 0;                                                              \
+    int r = parse_##format##_to_##type(input, str_safe_len(input), &n);      \
+    assert_printf(r == (count),                                              \
+                  "expected count: %d, got: %d (value: %#"PRI##type", string: %s)\n", \
+                  count, r, n, input);                                       \
+    assert_printf(n == (expected),                                           \
+                  "expected value: %#"PRI##type", got: %#"PRI##type"\n", expected, n);         \
+} while (0)
+
+    char empty[] = {};
+    char not_null_terminated_0[] = { '0' };
+    char not_null_terminated_1[] = { '1' };
+    char not_null_terminated_dec_max[] = {
+        '1', '8', '4', '4', '6', '7', '4', '4', '0', '7', '3', '7', '0', '9',
+        '5', '5', '1', '6', '1', '5'
+    };
+    char buffer[30] = {0};
+    int count;
+
+    test_parse_to(uint64_t, dec, empty, 0, UINT64_C(0));
+    test_parse_to(uint64_t, dec, not_null_terminated_0, 1, UINT64_C(0));
+    test_parse_to(uint64_t, dec, not_null_terminated_1, 1, UINT64_C(1));
+    test_parse_to(uint64_t, dec, not_null_terminated_dec_max,
+                  (int) sizeof(not_null_terminated_dec_max), UINT64_MAX);
+    test_parse_to(uint64_t, dec, empty, 0, UINT64_C(0));
+    test_parse_to(uint64_t, dec, "", 0, UINT64_C(0));
+    test_parse_to(uint64_t, dec, "/", 0, UINT64_C(0));
+    test_parse_to(uint64_t, dec, ";", 0, UINT64_C(0));
+    test_parse_to(uint64_t, dec, "x", 0, UINT64_C(0));
+    test_parse_to(uint64_t, dec, "/0", 0, UINT64_C(0));
+    test_parse_to(uint64_t, dec, ";0", 0, UINT64_C(0));
+    test_parse_to(uint64_t, dec, "x0", 0, UINT64_C(0));
+    test_parse_to(uint64_t, dec, "18446744073709551616", -1, UINT64_MAX / 10);
+    test_parse_to(uint64_t, dec, "184467440737095516150", -1, UINT64_MAX);
+    test_parse_to(uint64_t, dec, "99999999999999999999", -1,
+                  UINT64_C(9999999999999999999));
+
+    char not_null_terminated_hex_max[] = {
+        'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f',
+        'f', 'f', 'f', 'f', 'f', 'f', 'f', 'f',
+    };
+
+    test_parse_to(uint64_t, hex, empty, 0, UINT64_C(0x0));
+    test_parse_to(uint64_t, hex, not_null_terminated_0, 1, UINT64_C(0x0));
+    test_parse_to(uint64_t, hex, not_null_terminated_1, 1, UINT64_C(0x1));
+    test_parse_to(uint64_t, hex, not_null_terminated_hex_max,
+                  (int) sizeof(not_null_terminated_hex_max), UINT64_MAX);
+    test_parse_to(uint64_t, hex, "", 0, UINT64_C(0x0));
+    test_parse_to(uint64_t, hex, "/", 0, UINT64_C(0x0));
+    test_parse_to(uint64_t, hex, ";", 0, UINT64_C(0x0));
+    test_parse_to(uint64_t, hex, "x", 0, UINT64_C(0x0));
+    test_parse_to(uint64_t, hex, "xf", 0, UINT64_C(0x0));
+    test_parse_to(uint64_t, hex, "00000000000000000", 17, UINT64_C(0x0));
+    test_parse_to(uint64_t, hex, "00000000000000001", 17, UINT64_C(0x1));
+    test_parse_to(uint64_t, hex, "ffffffffffffffff0", -1, UINT64_MAX);
+    test_parse_to(uint64_t, hex, "10000000000000000", -1,
+                  UINT64_C(0x1000000000000000));
+
+    const uint64_t values[] = {
+        UINT64_C(0),
+        UINT64_C(1),
+        UINT64_C(10),
+        UINT64_C(0xA),
+        UINT64_C(0xF),
+        UINT64_C(123),
+        UINT32_MAX / 10,
+        UINT32_MAX / 10 + 9,
+        UINT32_MAX >> 4,
+        UINT32_MAX >> 4 | 0xf,
+        UINT32_MAX - 1,
+        UINT32_MAX,
+        UINT32_MAX + UINT64_C(1),
+        UINT64_C(9999999999999999999),
+        UINT64_MAX / 10,
+        UINT64_MAX / 10 + 9,
+        UINT64_MAX >> 4,
+        UINT64_MAX >> 4 | 0xf,
+        UINT64_MAX - 1,
+        UINT64_MAX,
+    };
+    for (size_t k = 0; k < ARRAY_SIZE(values); k++) {
+        /* Basic: decimal */
+        count = snprintf(buffer, sizeof(buffer), "%"PRIu64, values[k]);
+        assert(count > 0);
+        test_parse_to(uint64_t, dec, buffer, count, values[k]);
+        /* Basic: hex lower case */
+        count = snprintf(buffer, sizeof(buffer), "%"PRIx32, (uint32_t) values[k]);
+        assert(count > 0);
+        test_parse_to(uint32_t, hex, buffer, count, (uint32_t) values[k]);
+        count = snprintf(buffer, sizeof(buffer), "%"PRIx64, values[k]);
+        assert(count > 0);
+        test_parse_to(uint64_t, hex, buffer, count, values[k]);
+        /* Basic: hex upper case */
+        count = snprintf(buffer, sizeof(buffer), "%"PRIX32, (uint32_t) values[k]);
+        assert(count > 0);
+        test_parse_to(uint32_t, hex, buffer, count, (uint32_t) values[k]);
+        count = snprintf(buffer, sizeof(buffer), "%"PRIX64, values[k]);
+        assert(count > 0);
+        test_parse_to(uint64_t, hex, buffer, count, values[k]);
+        /* Prefix with some zeroes */
+        for (int z = 0; z < 10 ; z++) {
+            /* Decimal */
+            count = snprintf(buffer, sizeof(buffer), "%0*"PRIu64,
+                             z, values[k]);
+            assert(count > 0);
+            test_parse_to(uint64_t, dec, buffer, count, values[k]);
+            /* Hexadecimal */
+            count = snprintf(buffer, sizeof(buffer), "%0*u%"PRIx32,
+                             z, 0, (uint32_t) values[k]);
+            assert(count > 0);
+            test_parse_to(uint32_t, hex, buffer, count, (uint32_t) values[k]);
+            count = snprintf(buffer, sizeof(buffer), "%0*u%"PRIx64,
+                             z, 0, values[k]);
+            assert(count > 0);
+            test_parse_to(uint64_t, hex, buffer, count, values[k]);
+            /* Append some garbage */
+            for (int c = 0; c < 0x100 ; c++) {
+                if (c < '0' || c > '9') {
+                    /* Decimal */
+                    count = snprintf(buffer, sizeof(buffer), "%0*u%"PRIu64"%c",
+                                     z, 0, values[k], (char) c);
+                    assert(count > 0);
+                    test_parse_to(uint64_t, dec, buffer, count - 1, values[k]);
+                }
+                if (!is_xdigit((char) c)) {
+                    /* Hexadecimal */
+                    count = snprintf(buffer, sizeof(buffer), "%0*u%"PRIx32"%c",
+                                     z, 0, (uint32_t) values[k], (char) c);
+                    assert(count > 0);
+                    test_parse_to(uint32_t, hex, buffer, count - 1, (uint32_t) values[k]);
+                    count = snprintf(buffer, sizeof(buffer), "%0*u%"PRIx64"%c",
+                                     z, 0, values[k], (char) c);
+                    assert(count > 0);
+                    test_parse_to(uint64_t, hex, buffer, count - 1, values[k]);
+                }
+            }
+        }
+    }
+
+    /* Random */
+    srand(time(NULL));
+    for (unsigned k = 0; k < 10000; k++) {
+        const uint32_t x32 = rand_uint32();
+        const uint64_t x64 = rand_uint64();
+        /* Hex: Lower case */
+        count = snprintf(buffer, sizeof(buffer), "%"PRIx32, x32);
+        assert(count > 0);
+        test_parse_to(uint32_t, hex, buffer, count, x32);
+        count = snprintf(buffer, sizeof(buffer), "%"PRIx64, x64);
+        assert(count > 0);
+        test_parse_to(uint64_t, hex, buffer, count, x64);
+        /* Hex: Upper case (32 bits) */
+        count = snprintf(buffer, sizeof(buffer), "%"PRIX32, x32);
+        assert(count > 0);
+        test_parse_to(uint32_t, hex, buffer, count, x32);
+        /* Hex: some garbage after */
+        buffer[count] = (char) (((unsigned) rand()) % '0');
+        test_parse_to(uint32_t, hex, buffer, count, x32);
+        /* Hex: Upper case (64 bits) */
+        count = snprintf(buffer, sizeof(buffer), "%"PRIX64, x64);
+        assert(count > 0);
+        test_parse_to(uint64_t, hex, buffer, count, x64);
+        /* Hex: some garbage after */
+        buffer[count] = (char) (((unsigned) rand()) % '0');
+        test_parse_to(uint64_t, hex, buffer, count, x64);
+        /* Decimal */
+        count = snprintf(buffer, sizeof(buffer), "%"PRIu64, x64);
+        assert(count > 0);
+        test_parse_to(uint64_t, dec, buffer, count, x64);
+        /* Decimal: some garbage after */
+        buffer[count] = (char) (((unsigned) rand()) % '0');
+        test_parse_to(uint64_t, dec, buffer, count, x64);
+    }
+}
+/* NOLINTEND(google-readability-function-size) */
+
 int
 main(void)
 {
     test_init();
     test_string_functions();
     test_path_functions();
+    test_number_parsers();
 
-    return 0;
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This mainly fixes the case where we would parse a buffer that is not NULL-terminated with the last token being a number. Previously the dummy example:

```c
const char keymap_str[] = {'1'};
```

would trigger a memory violation instead of raising a syntax error and exiting safely.

There are some issues with the rules too.

Note that this is unlikely to be an in issue IRL.

Fixes #690