### PR TITLE
Support multiple actions in interpret

### DIFF
--- a/changes/api/695.feature.md
+++ b/changes/api/695.feature.md
@@ -1,0 +1,2 @@
+Added support for sequences of actions in `interpret` statements of the
+`xkb_compat` component, mirroring the syntax used in `xkb_symbols`.

--- a/doc/keymap-format-text-v1.md
+++ b/doc/keymap-format-text-v1.md
@@ -1580,7 +1580,7 @@ The <code>[xkb_symbols]</code> section (see below)
 allows the keymap author to perform, among other things, the following
 things for each key:
 
-- Bind an [action], like `SetMods` or `LockGroup`, to the key.
+- Bind a sequence of [actions], like `SetMods` or `LockGroup`, to the key.
   Actions, like symbols, are specified for each level of each group
   in the key separately.
 
@@ -1674,6 +1674,11 @@ Note: the other possible value is `any` and is the default value.
 
 Bind this action to the matching levels. See [key actions][actions]
 for the list of available key actions.
+
+Since 1.9.0, it is also possible to assign a sequence of actions, mirroring
+the feature used in the [key statement](@ref key-multiple-symbols-per-level).
+
+    action = {SetMods(modifiers=NumLock),SetGroup(group=2)};
 
 #### “virtualModifier” statement {#interpret-virtualModifier}
 
@@ -1896,8 +1901,9 @@ keysym when some modifiers are not [consumed](@ref consumed-modifiers).
 
 @remark Trailing `NoSymbol` are dropped.
 
-As an extension to the XKB legacy format, libxkbcommon supports multiple key
-symbols and actions per level (the latter since version 1.8.0):
+@anchor key-multiple-symbols-per-level As an extension to the XKB legacy format,
+libxkbcommon supports multiple key symbols and actions per level (the latter
+since version 1.8.0):
 
     key <AD01> { [ {a, b}, Q ] };
 

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -35,6 +35,13 @@ clear_level(struct xkb_level *leveli)
         free(leveli->a.actions);
 }
 
+static void
+clear_interpret(struct xkb_sym_interpret *interp)
+{
+    if (interp->num_actions > 1)
+        free(interp->a.actions);
+}
+
 void
 xkb_keymap_unref(struct xkb_keymap *keymap)
 {
@@ -65,6 +72,9 @@ xkb_keymap_unref(struct xkb_keymap *keymap)
             free(keymap->types[i].level_names);
         }
         free(keymap->types);
+    }
+    for (unsigned int k = 0; k < keymap->num_sym_interprets; k++) {
+        clear_interpret(&keymap->sym_interprets[k]);
     }
     free(keymap->sym_interprets);
     free(keymap->key_aliases);

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -215,9 +215,15 @@ struct xkb_sym_interpret {
     enum xkb_match_operation match;
     xkb_mod_mask_t mods;
     xkb_mod_index_t virtual_mod;
-    union xkb_action action;
     bool level_one_only;
     bool repeat;
+    unsigned int num_actions;
+    union {
+        /* num_actions <= 1 */
+        union xkb_action action;
+        /* num_actions >  1 */
+        union xkb_action *actions;
+    } a;
 };
 
 struct xkb_led {

--- a/src/x11/keymap.c
+++ b/src/x11/keymap.c
@@ -848,8 +848,10 @@ get_sym_interprets(struct xkb_keymap *keymap, xcb_connection_t *conn,
             sym_interpret->virtual_mod = NUM_REAL_MODS + wire->virtualMod;
 
         sym_interpret->repeat = (wire->flags & 0x01);
-        translate_action(&sym_interpret->action,
+        translate_action(&sym_interpret->a.action,
                          (xcb_xkb_action_t *) &wire->action);
+        sym_interpret->num_actions =
+            (sym_interpret->a.action.type != ACTION_TYPE_NONE);
 
         xcb_xkb_sym_interpret_next(&iter);
     }

--- a/src/xkbcomp/parser.y
+++ b/src/xkbcomp/parser.y
@@ -780,13 +780,15 @@ Term            :       MINUS Term
                 |       INVERT Term
                         { $$ = ExprCreateUnary(STMT_EXPR_INVERT, $2); }
                 |       Lhs
-                        { $$ = $1;  }
+                        { $$ = $1; }
                 |       FieldSpec OPAREN ExprList CPAREN %prec OPAREN
                         { $$ = ExprCreateAction($1, $3.head); }
+                |       Actions
+                        { $$ = $1; }
                 |       Terminal
-                        { $$ = $1;  }
+                        { $$ = $1; }
                 |       OPAREN Expr CPAREN
-                        { $$ = $2;  }
+                        { $$ = $2; }
                 ;
 
 MultiActionList :       MultiActionList COMMA Action

--- a/test/buffercomp.c
+++ b/test/buffercomp.c
@@ -742,6 +742,12 @@ test_multi_keysyms_actions(struct xkb_context *ctx, bool update_output_files)
                 "    <39> = 39;\n"
                 "  };\n"
                 "  xkb_types { include \"basic+extra\" };\n"
+                "  xkb_compat {\n"
+                "    interpret 1 { action = {}; };\n"
+                "    interpret 2 { action = {NoAction()}; };\n"
+                "    interpret 3 { action = {SetMods()}; };\n"
+                "    interpret 4 { action = {SetMods(), SetGroup(group=1)}; };\n"
+                "  };\n"
                 "  xkb_symbols {\n"
                 /* Empty keysyms */
                 "    key <10> { [any, any ] };\n"

--- a/test/data/keymaps/empty-compound-statements.xkb
+++ b/test/data/keymaps/empty-compound-statements.xkb
@@ -46,12 +46,9 @@ xkb_compatibility {
 
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
-	interpret q+AnyOfOrNone(all) {
-		action= NoAction();
-	};
+	interpret q+AnyOfOrNone(all) {};
 	interpret w+AnyOfOrNone(all) {
 		repeat= True;
-		action= NoAction();
 	};
 	indicator "yyy" {
 		modifiers= Shift;

--- a/test/data/keymaps/stringcomp.data
+++ b/test/data/keymaps/stringcomp.data
@@ -605,9 +605,7 @@ xkb_compatibility "complete_caps(caps_lock)_4_misc(assign_shift_left_action)_4_l
 		virtualModifier= NumLock;
 		action= LockMods(modifiers=NumLock);
 	};
-	interpret ISO_Lock+AnyOf(all) {
-		action= NoAction();
-	};
+	interpret ISO_Lock+AnyOf(all) {};
 	interpret ISO_Level3_Shift+AnyOf(all) {
 		virtualModifier= LevelThree;
 		useModMapMods=level1;

--- a/test/data/keymaps/symbols-multi-keysyms-empty.xkb
+++ b/test/data/keymaps/symbols-multi-keysyms-empty.xkb
@@ -146,6 +146,14 @@ xkb_compatibility {
 
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret 1+AnyOfOrNone(all) {};
+	interpret 2+AnyOfOrNone(all) {};
+	interpret 3+AnyOfOrNone(all) {
+		action= SetMods(modifiers=none);
+	};
+	interpret 4+AnyOfOrNone(all) {
+		action= {SetMods(modifiers=none), SetGroup(group=1)};
+	};
 };
 
 xkb_symbols {


### PR DESCRIPTION
Before this commit we supported multiple actions per level, but not in *interpret* statements. Let’s fix this asymmetry, so we can equivalently assign all actions sets either implicitly or explicitly.

Fixes #695