### PR TITLE
logging: Handle NULL map name

### DIFF
--- a/src/compose/parser.c
+++ b/src/compose/parser.c
@@ -464,7 +464,7 @@ parse_string_literal(struct xkb_context *ctx, const char *string)
 {
     struct scanner s;
     union lvalue val;
-    scanner_init(&s, ctx, string, strlen(string), "(unamed)", NULL);
+    scanner_init(&s, ctx, string, strlen(string), "(unnamed)", NULL);
     switch (lex(&s, &val)) {
         case TOK_STRING:
             return strdup(val.string.str);

--- a/src/xkbcomp/ast-build.h
+++ b/src/xkbcomp/ast-build.h
@@ -99,5 +99,3 @@ XkbFileCreate(enum xkb_file_type type, char *name, ParseCommon *defs,
 
 void
 FreeStmt(ParseCommon *stmt);
-
-static const char default_component_name[] = "(unnamed map)";

--- a/src/xkbcomp/compat.c
+++ b/src/xkbcomp/compat.c
@@ -831,7 +831,8 @@ HandleCompatMapFile(CompatInfo *info, XkbFile *file, enum merge_mode merge)
 
         if (info->errorCount > 10) {
             log_err(info->ctx, XKB_LOG_MESSAGE_NO_ID,
-                    "Abandoning compatibility map \"%s\"\n", file->name);
+                    "Abandoning compatibility map \"%s\"\n",
+                    safe_map_name(file));
             break;
         }
     }

--- a/src/xkbcomp/keycodes.c
+++ b/src/xkbcomp/keycodes.c
@@ -571,7 +571,7 @@ HandleKeycodesFile(KeyNamesInfo *info, XkbFile *file, enum merge_mode merge)
         if (info->errorCount > 10) {
             log_err(info->ctx, XKB_LOG_MESSAGE_NO_ID,
                     "Abandoning keycodes file \"%s\"\n",
-                    file->name);
+                    safe_map_name(file));
             break;
         }
     }

--- a/src/xkbcomp/keymap.c
+++ b/src/xkbcomp/keymap.c
@@ -413,7 +413,7 @@ CompileKeymap(XkbFile *file, struct xkb_keymap *keymap, enum merge_mode merge)
         } else {
             log_dbg(ctx, XKB_LOG_MESSAGE_NO_ID,
                     "Compiling %s \"%s\"\n",
-                    xkb_file_type_to_string(type), files[type]->name);
+                    xkb_file_type_to_string(type), safe_map_name(files[type]));
         }
 
         /* Missing components are initialized with defaults */

--- a/src/xkbcomp/parser.y
+++ b/src/xkbcomp/parser.y
@@ -1022,8 +1022,7 @@ parse(struct xkb_context *ctx, struct scanner *scanner, const char *map)
                 XKB_WARNING_MISSING_DEFAULT_SECTION,
                 "No map in include statement, but \"%s\" contains several; "
                 "Using first defined map, \"%s\"\n",
-                scanner->file_name,
-                (first->name) ? first->name : default_component_name);
+                scanner->file_name, safe_map_name(first));
 
     return first;
 }

--- a/src/xkbcomp/symbols.c
+++ b/src/xkbcomp/symbols.c
@@ -1450,7 +1450,7 @@ HandleSymbolsFile(SymbolsInfo *info, XkbFile *file, enum merge_mode merge)
         if (info->errorCount > 10) {
             log_err(info->ctx, XKB_ERROR_INVALID_XKB_SYNTAX,
                     "Abandoning symbols file \"%s\"\n",
-                    file->name);
+                    safe_map_name(file));
             break;
         }
     }

--- a/src/xkbcomp/types.c
+++ b/src/xkbcomp/types.c
@@ -672,7 +672,8 @@ HandleKeyTypesFile(KeyTypesInfo *info, XkbFile *file, enum merge_mode merge)
 
         if (info->errorCount > 10) {
             log_err(info->ctx, XKB_ERROR_INVALID_XKB_SYNTAX,
-                    "Abandoning keytypes file \"%s\"\n", file->name);
+                    "Abandoning keytypes file \"%s\"\n",
+                    safe_map_name(file));
             break;
         }
     }

--- a/src/xkbcomp/xkbcomp-priv.h
+++ b/src/xkbcomp/xkbcomp-priv.h
@@ -91,3 +91,9 @@ ReportBadField(struct xkb_context *ctx, const char *type, const char *field,
             type, field, name, name);
     return false;
 }
+
+static inline const char*
+safe_map_name(XkbFile *file)
+{
+    return file->name ? file->name : "(unnamed map)";
+}


### PR DESCRIPTION
Display “(unnamed map)” instead of “(null)”.