### PR TITLE
build: Warn if missing xkbcomp for X11 tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -891,8 +891,14 @@ test(
 )
 if get_option('enable-x11')
     has_xvfb = find_program('Xvfb', required: false)
+    has_xkbcomp = find_program('xkbcomp', required: false)
+    # We only warn because the build machine may not be the same
+    # as the host/test machine.
     if not has_xvfb.found()
         warning('Xvfb program not found, but is required to run X11 tests.')
+    endif
+    if not has_xkbcomp.found()
+        warning('xkbcomp program not found, but is required to run X11 tests.')
     endif
     test(
         'x11',

--- a/test/x11.c
+++ b/test/x11.c
@@ -5,6 +5,8 @@
 
 #include "config.h"
 
+#include <stdlib.h>
+
 #include "test.h"
 #include "xvfb-wrapper.h"
 #include "xkbcommon/xkbcommon-x11.h"
@@ -18,7 +20,7 @@ X11_TEST(test_basic)
     struct xkb_keymap *keymap;
     struct xkb_state *state;
     char *dump;
-    int exit_code = 0;
+    int exit_code = EXIT_SUCCESS;
 
     /*
     * The next two steps depend on a running X server with XKB support.

--- a/test/x11comp.c
+++ b/test/x11comp.c
@@ -5,13 +5,14 @@
 
 #include "config.h"
 
-#include <stdio.h>
-#include <spawn.h>
-#include <unistd.h>
 #include <assert.h>
 #include <signal.h>
+#include <spawn.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <unistd.h>
 
 #include "test.h"
 #include "xvfb-wrapper.h"
@@ -54,6 +55,15 @@ X11_TEST(test_basic)
     ret = posix_spawnp(&xkbcomp_pid, "xkbcomp", NULL, NULL, xkbcomp_argv, envp);
     free(xkb_path);
     if (ret != 0) {
+        fprintf(stderr,
+                "[ERROR] Cannot run xkbcomp. posix_spawnp error %d: %s\n",
+                ret, strerror(ret));
+        if (ret == ENOENT) {
+            fprintf(stderr,
+                    "[ERROR] xkbcomp may be missing. "
+                    "Please install the corresponding package, "
+                    "e.g. \"xkbcomp\" or \"x11-xkb-utils\".\n");
+        }
         ret = TEST_SETUP_FAILURE;
         goto err_xcb;
     }
@@ -86,7 +96,7 @@ X11_TEST(test_basic)
         goto err_dump;
     }
 
-    ret = 0;
+    ret = EXIT_SUCCESS;
 err_dump:
     free(original);
     free(dump);


### PR DESCRIPTION
Fixes #709

- meson: Warn if missing xkbcomp for X11 tests;
- test: Better logging to spot missing Xorg executables.

@Apteryks