### PR TITLE
Deprecate legacy modifiers names

### DIFF
--- a/changes/README.md
+++ b/changes/README.md
@@ -12,9 +12,10 @@ There are 3 sections types:
 - Tools: `changes/tools`
 - Build System: `changes/build`
 
-There are 3 news fragments types:
+There are 4 news fragments types:
 
 - Breaking changes: `.breaking`
+- Deprecations: `.deprecation`
 - New: `.feature`
 - Fixes: `.bugfix`
 

--- a/changes/api/538.deprecation.md
+++ b/changes/api/538.deprecation.md
@@ -1,0 +1,4 @@
+The following modifiers names in `xkbcommon/xkbcommon-names.h` are now deprecated:
+- `XKB_MOD_NAME_ALT`: use `XKB_VMOD_NAME_ALT` instead.
+- `XKB_MOD_NAME_LOGO`: use `XKB_VMOD_NAME_SUPER` instead.
+- `XKB_MOD_NAME_NUM`: use `XKB_VMOD_NAME_NUM` instead.

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -74,3 +74,5 @@ ALIASES                += figure="@htmlonly[block]<figure>@endhtmlonly"
 ALIASES                += endfigure="@htmlonly[block]</figure>@endhtmlonly"
 ALIASES                += figcaption="@htmlonly[block]<figcaption>@endhtmlonly"
 ALIASES                += endfigcaption="@htmlonly[block]</figcaption>@endhtmlonly"
+
+EXCLUDE_SYMBOLS        = XKB_INTERNAL_*

--- a/include/xkbcommon/xkbcommon-names.h
+++ b/include/xkbcommon/xkbcommon-names.h
@@ -8,12 +8,24 @@
 #ifndef _XKBCOMMON_NAMES_H
 #define _XKBCOMMON_NAMES_H
 
+#define XKB_INTERNAL_STRINGIFY(x) #x
+#if defined(__GNUC__) || defined(__clang__)
+    #define XKB_INTERNAL_PRAGMA(x) _Pragma(#x)
+    #define XKB_INTERNAL_DEPRECATION_WARNING(x) \
+        XKB_INTERNAL_PRAGMA(GCC warning #x)
+    #define XKB_INTERNAL_DEPRECATED_MOD_NAME(msg, str) \
+        (XKB_INTERNAL_DEPRECATION_WARNING(msg) str)
+#else
+    #define XKB_INTERNAL_DEPRECATED_MOD_NAME(msg, str) str
+#endif
+
 /**
  * @file
  * @brief Predefined names for common modifiers and LEDs.
  */
 
 /* *Real* modifiers names are hardcoded in libxkbcommon */
+
 #define XKB_MOD_NAME_SHIFT      "Shift"
 #define XKB_MOD_NAME_CAPS       "Lock"
 #define XKB_MOD_NAME_CTRL       "Control"
@@ -24,9 +36,43 @@
 #define XKB_MOD_NAME_MOD5       "Mod5"
 
 /* Usual virtual modifiers mappings to real modifiers */
-#define XKB_MOD_NAME_ALT        "Mod1" /* Alt */
-#define XKB_MOD_NAME_LOGO       "Mod4" /* Super */
-#define XKB_MOD_NAME_NUM        "Mod2" /* NumLock */
+
+/**
+ * Usual *real* modifier for the *virtual* modifier `Alt`.
+ *
+ * @deprecated
+ * Use `XKB_VMOD_NAME_ALT` instead.
+ */
+#define XKB_MOD_NAME_ALT                                        \
+    XKB_INTERNAL_DEPRECATED_MOD_NAME(                           \
+        XKB_INTERNAL_STRINGIFY(XKB_MOD_NAME_ALT) is deprecated: \
+        use XKB_INTERNAL_STRINGIFY(XKB_VMOD_NAME_ALT) instead,  \
+        "Mod1"                                                  \
+    )
+/**
+ * Usual *real* modifier for the *virtual* modifier `Super`.
+ *
+ * @deprecated
+ * Use `XKB_VMOD_NAME_SUPER` instead.
+ */
+#define XKB_MOD_NAME_LOGO                                       \
+    XKB_INTERNAL_DEPRECATED_MOD_NAME(                           \
+        XKB_INTERNAL_STRINGIFY(XKB_MOD_NAME_LOGO) is deprecated:\
+        use XKB_INTERNAL_STRINGIFY(XKB_VMOD_NAME_SUPER) instead,\
+        "Mod4"                                                  \
+    )
+/**
+ * Usual *real* modifier for the *virtual* modifier `NumLock`.
+ *
+ * @deprecated
+ * Use `XKB_VMOD_NAME_NUM` instead.
+ */
+#define XKB_MOD_NAME_NUM                                        \
+    XKB_INTERNAL_DEPRECATED_MOD_NAME(                           \
+        XKB_INTERNAL_STRINGIFY(XKB_MOD_NAME_NUM) is deprecated: \
+        use XKB_INTERNAL_STRINGIFY(XKB_VMOD_NAME_NUM) instead,  \
+        "Mod2"                                                  \
+    )
 
 /* Common *virtual* modifiers, encoded in xkeyboard-config in the compat and
  * symbols files. They have been stable since the beginning of the project and

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -36,6 +36,11 @@ name = "Breaking changes"
 showcontent = true
 
 [[tool.towncrier.type]]
+directory = "deprecation"
+name = "Deprecations"
+showcontent = true
+
+[[tool.towncrier.type]]
 directory = "feature"
 name = "New"
 showcontent = true


### PR DESCRIPTION
The following modifiers names in `xkbcommon/xkbcommon-names.h` are now deprecated:
- `XKB_MOD_NAME_ALT`: use `XKB_VMOD_NAME_ALT` instead.
- `XKB_MOD_NAME_LOGO`: use `XKB_VMOD_NAME_SUPER` instead.
- `XKB_MOD_NAME_NUM`: use `XKB_VMOD_NAME_NUM` instead.

⚠️ Using them will now trigger a compiler warning.

Fixes #538