### PR TITLE
keysyms: Pad Unicode keysyms only up to 4 digits

### DIFF
--- a/scripts/update-keysyms-derived-headers.py
+++ b/scripts/update-keysyms-derived-headers.py
@@ -29,6 +29,7 @@ def load_keysyms(path: Path) -> tuple[KeysymsBounds, KeysymsCaseFoldedNames]:
     keysym_max = 0
     min_unicode_keysym = 0x01000100
     max_unicode_keysym = 0x0110FFFF
+    names: dict[int, set[str]] = defaultdict(set)
     canonical_names: dict[int, str] = {}
     casefolded_names: dict[str, list[str]] = defaultdict(list)
     max_unicode_name = "U10FFFF"
@@ -41,6 +42,7 @@ def load_keysyms(path: Path) -> tuple[KeysymsBounds, KeysymsCaseFoldedNames]:
                 keysym_min = min(keysym_min, value)
                 keysym_max = max(keysym_max, value)
                 name = m.group("name")
+                names[value].add(name)
                 casefolded_names[name.casefold()].append(name)
                 if value not in canonical_names:
                     canonical_names[value] = name
@@ -57,6 +59,7 @@ def load_keysyms(path: Path) -> tuple[KeysymsBounds, KeysymsCaseFoldedNames]:
         max_keysym_name,
         key=len,
     )
+    XKB_KEYSYM_EXPLICIT_ALIASES_MAX = max(map(len, names.values()))
 
     # Keep only ambiguous case-insensitive names and sort them
     for name in tuple(casefolded_names.keys()):
@@ -81,6 +84,7 @@ def load_keysyms(path: Path) -> tuple[KeysymsBounds, KeysymsCaseFoldedNames]:
             "XKB_KEYSYM_NAME_MAX_SIZE": len(XKB_KEYSYM_LONGEST_CANONICAL_NAME) + 1,
             "XKB_KEYSYM_LONGEST_CANONICAL_NAME": XKB_KEYSYM_LONGEST_CANONICAL_NAME,
             "XKB_KEYSYM_LONGEST_NAME": XKB_KEYSYM_LONGEST_NAME,
+            "XKB_KEYSYM_EXPLICIT_ALIASES_MAX": XKB_KEYSYM_EXPLICIT_ALIASES_MAX,
         },
         casefolded_names,
     )

--- a/src/keysym.c
+++ b/src/keysym.c
@@ -60,8 +60,7 @@ get_name(const struct name_keysym *entry)
 static inline int
 get_unicode_name(xkb_keysym_t ks, char *buffer, size_t size)
 {
-    const int width = (ks & 0xff0000UL) ? 8 : 4;
-    return snprintf(buffer, size, "U%0*lX", width, ks & 0xffffffUL);
+    return snprintf(buffer, size, "U%04"PRIX32, ks & UINT32_C(0xffffff));
 }
 
 int

--- a/src/keysym.c
+++ b/src/keysym.c
@@ -91,6 +91,30 @@ xkb_keysym_is_assigned(xkb_keysym_t ks)
            find_keysym_index(ks) != -1;
 }
 
+int
+xkb_keysym_get_explicit_names(xkb_keysym_t ks, const char **buffer, size_t size)
+{
+    if (ks > XKB_KEYSYM_MAX)
+        return -1;
+    const ssize_t index = find_keysym_index(ks);
+    if (index < 0)
+        return 0;
+    const uint16_t canonical = keysym_to_name[index].offset;
+    if (size > 0)
+        buffer[0] = get_name(&keysym_to_name[index]);
+    int count = 1;
+    for (size_t pos = 0; pos < ARRAY_SIZE(name_to_keysym); pos++) {
+        if (name_to_keysym[pos].keysym == ks &&
+            name_to_keysym[pos].offset != canonical) {
+            if ((size_t) count < size) {
+                buffer[count] = get_name(&name_to_keysym[pos]);
+            }
+            count++;
+        }
+    }
+    return count;
+}
+
 struct xkb_keysym_iterator {
     bool explicit;       /* If true, traverse only explicitly named keysyms */
     int32_t index;       /* Current index in `keysym_to_name` */

--- a/src/keysym.h
+++ b/src/keysym.h
@@ -46,12 +46,17 @@
 #define XKB_KEYSYM_LONGEST_CANONICAL_NAME ISO_Discontinuous_Underline
 /** Longest keysym name */
 #define XKB_KEYSYM_LONGEST_NAME ISO_Discontinuous_Underline
+/** Maximum of distinct explicit names for a keysym */
+#define XKB_KEYSYM_EXPLICIT_ALIASES_MAX 9
 /** Maximum bytes to encode the Unicode representation of a keysym in UTF-8:
  * 4 bytes + NULL-terminating byte */
 #define XKB_KEYSYM_UTF8_MAX_SIZE  5
 
 XKB_EXPORT_PRIVATE bool
 xkb_keysym_is_assigned(xkb_keysym_t ks);
+
+XKB_EXPORT_PRIVATE int
+xkb_keysym_get_explicit_names(xkb_keysym_t ks, const char **buffer, size_t size);
 
 struct xkb_keysym_iterator;
 

--- a/src/keysym.h.jinja
+++ b/src/keysym.h.jinja
@@ -46,12 +46,17 @@
 #define XKB_KEYSYM_LONGEST_CANONICAL_NAME {{ XKB_KEYSYM_LONGEST_CANONICAL_NAME }}
 /** Longest keysym name */
 #define XKB_KEYSYM_LONGEST_NAME {{ XKB_KEYSYM_LONGEST_NAME }}
+/** Maximum of distinct explicit names for a keysym */
+#define XKB_KEYSYM_EXPLICIT_ALIASES_MAX {{ XKB_KEYSYM_EXPLICIT_ALIASES_MAX }}
 /** Maximum bytes to encode the Unicode representation of a keysym in UTF-8:
  * 4 bytes + NULL-terminating byte */
 #define XKB_KEYSYM_UTF8_MAX_SIZE  5
 
 XKB_EXPORT_PRIVATE bool
 xkb_keysym_is_assigned(xkb_keysym_t ks);
+
+XKB_EXPORT_PRIVATE int
+xkb_keysym_get_explicit_names(xkb_keysym_t ks, const char **buffer, size_t size);
 
 struct xkb_keysym_iterator;
 

--- a/test/keysym.c
+++ b/test/keysym.c
@@ -447,6 +447,28 @@ main(void)
 
     test_modifiers_table();
 
+    /* Check xkb_keysym_get_explicit_names works */
+    const char* aliases[XKB_KEYSYM_EXPLICIT_ALIASES_MAX] = {0};
+    int aliases_count =
+        xkb_keysym_get_explicit_names(XKB_KEY_a,
+                                      aliases, ARRAY_SIZE(aliases));
+    assert(aliases_count == 1);
+    assert_streq_not_null("", "a", aliases[0]);
+
+    aliases_count =
+        xkb_keysym_get_explicit_names(XKB_KEY_ISO_Group_Shift,
+                                      aliases, ARRAY_SIZE(aliases));
+    assert(aliases_count == XKB_KEYSYM_EXPLICIT_ALIASES_MAX);
+    assert_streq_not_null("", "Mode_switch", aliases[0]);
+    assert_streq_not_null("", "Arabic_switch", aliases[1]);
+    assert_streq_not_null("", "Greek_switch", aliases[2]);
+    assert_streq_not_null("", "Hangul_switch", aliases[3]);
+    assert_streq_not_null("", "Hebrew_switch", aliases[4]);
+    assert_streq_not_null("", "ISO_Group_Shift", aliases[5]);
+    assert_streq_not_null("", "kana_switch", aliases[6]);
+    assert_streq_not_null("", "script_switch", aliases[7]);
+    assert_streq_not_null("", "SunAltGraph", aliases[8]);
+
     struct xkb_keysym_iterator *iter = xkb_keysym_iterator_new(false);
     xkb_keysym_t ks_prev = XKB_KEYSYM_MIN;
     uint32_t count = 0;


### PR DESCRIPTION
Previously there was a distinction between keysyms with code points in BMP and the others: the former used a 4-padding while the latter used a 8-padding: e.g `U0001` vs `U00010000`. This is unnecessary and makes the reading harder.

Let’s use the same padding for all: `U0001` and `U10000`.

Parsing remains unchanged and would parse both paddings.

Also added a test to check no explicit name can clash with Unicode notation.