### PR TITLE
rules: Fix merging KcCGST values in layout order

### DIFF
--- a/bench/rules.c
+++ b/bench/rules.c
@@ -5,50 +5,217 @@
 
 #include "config.h"
 
-#include <time.h>
+#include <getopt.h>
+#include <stdlib.h>
 
 #include "xkbcommon/xkbcommon.h"
 #include "../test/test.h"
 #include "xkbcomp/rules.h"
 #include "bench.h"
 
-#define BENCHMARK_ITERATIONS 20000
+const unsigned int DEFAULT_ITERATIONS = 20000;
+const double       DEFAULT_STDEV = 0.05;
+
+static void
+usage(char **argv)
+{
+    printf("Usage: %s [OPTIONS]\n"
+           "\n"
+           "Benchmark compilation of the given RMLVO\n"
+           "\n"
+           "Options:\n"
+           " --help\n"
+           "    Print this help and exit\n"
+           " --iter\n"
+           "    Exact number of iterations to run\n"
+           " --stdev\n"
+           "    Minimal relative standard deviation (percentage) to reach.\n"
+           "    (default: %f)\n"
+           "Note: --iter and --stdev are mutually exclusive.\n"
+           "\n"
+           "XKB-specific options:\n"
+           " --rules <rules>\n"
+           "    The XKB ruleset (default: '%s')\n"
+           " --model <model>\n"
+           "    The XKB model (default: '%s')\n"
+           " --layout <layout>\n"
+           "    The XKB layout (default: '%s')\n"
+           " --variant <variant>\n"
+           "    The XKB layout variant (default: '%s')\n"
+           " --options <options>\n"
+           "    The XKB options (default: '%s')\n"
+           "\n",
+           argv[0], DEFAULT_STDEV * 100, DEFAULT_XKB_RULES,
+           DEFAULT_XKB_MODEL, DEFAULT_XKB_LAYOUT,
+           DEFAULT_XKB_VARIANT ? DEFAULT_XKB_VARIANT : "<none>",
+           DEFAULT_XKB_OPTIONS ? DEFAULT_XKB_OPTIONS : "<none>");
+}
 
 int
 main(int argc, char *argv[])
 {
-    struct xkb_context *ctx;
-    int i;
-    struct xkb_rule_names rmlvo = {
-        "evdev", "pc105", "us,il", ",", "ctrl:nocaps,grp:menu_toggle",
-    };
     struct bench bench;
-    char *elapsed;
+    struct bench_time elapsed;
+    struct estimate est;
+    bool explicit_iterations = false;
+    struct xkb_rule_names rmlvo = {
+        .rules = DEFAULT_XKB_RULES,
+        .model = DEFAULT_XKB_MODEL,
+        /* layout and variant are tied together, so we either get user-supplied for
+         * both or default for both, see below */
+        .layout = NULL,
+        .variant = NULL,
+        .options = DEFAULT_XKB_OPTIONS,
+    };
+    unsigned int max_iterations = DEFAULT_ITERATIONS;
+    double stdev = DEFAULT_STDEV;
 
-    ctx = test_get_context(0);
-    assert(ctx);
+    enum options {
+        OPT_RULES,
+        OPT_MODEL,
+        OPT_LAYOUT,
+        OPT_VARIANT,
+        OPT_OPTION,
+        OPT_ITERATIONS,
+        OPT_STDEV,
+    };
 
-    xkb_context_set_log_level(ctx, XKB_LOG_LEVEL_CRITICAL);
-    xkb_context_set_log_verbosity(ctx, 0);
+    static struct option opts[] = {
+        {"help",             no_argument,            0, 'h'},
+        {"rules",            required_argument,      0, OPT_RULES},
+        {"model",            required_argument,      0, OPT_MODEL},
+        {"layout",           required_argument,      0, OPT_LAYOUT},
+        {"variant",          required_argument,      0, OPT_VARIANT},
+        {"options",          required_argument,      0, OPT_OPTION},
+        {"iter",             required_argument,      0, OPT_ITERATIONS},
+        {"stdev",            required_argument,      0, OPT_STDEV},
+        {0, 0, 0, 0},
+    };
 
-    bench_start(&bench);
-    for (i = 0; i < BENCHMARK_ITERATIONS; i++) {
-        struct xkb_component_names kccgst;
+    while (1) {
+        int c;
+        int option_index = 0;
+        c = getopt_long(argc, argv, "h", opts, &option_index);
+        if (c == -1)
+            break;
 
-        assert(xkb_components_from_rules(ctx, &rmlvo, &kccgst, NULL));
-        free(kccgst.keycodes);
-        free(kccgst.types);
-        free(kccgst.compatibility);
-        free(kccgst.symbols);
-        free(kccgst.geometry);
+        switch (c) {
+        case 'h':
+            usage(argv);
+            exit(EXIT_SUCCESS);
+        case OPT_RULES:
+            rmlvo.rules = optarg;
+            break;
+        case OPT_MODEL:
+            rmlvo.model = optarg;
+            break;
+        case OPT_LAYOUT:
+            rmlvo.layout = optarg;
+            break;
+        case OPT_VARIANT:
+            rmlvo.variant = optarg;
+            break;
+        case OPT_OPTION:
+            rmlvo.options = optarg;
+            break;
+        case OPT_ITERATIONS:
+            if (max_iterations == 0) {
+                usage(argv);
+                exit(EXIT_INVALID_USAGE);
+            }
+            {
+                const int max_iterations_raw = atoi(optarg);
+                if (max_iterations_raw <= 0)
+                    max_iterations = DEFAULT_ITERATIONS;
+                else
+                    max_iterations = (unsigned int) max_iterations_raw;
+            }
+            explicit_iterations = true;
+            break;
+        case OPT_STDEV:
+            if (explicit_iterations) {
+                usage(argv);
+                exit(EXIT_INVALID_USAGE);
+            }
+            stdev = atof(optarg) / 100;
+            if (stdev <= 0)
+                stdev = DEFAULT_STDEV;
+            max_iterations = 0;
+            break;
+        default:
+            usage(argv);
+            exit(EXIT_INVALID_USAGE);
+        }
     }
-    bench_stop(&bench);
 
-    elapsed = bench_elapsed_str(&bench);
-    fprintf(stderr, "processed %d rule files in %ss\n",
-            BENCHMARK_ITERATIONS, elapsed);
-    free(elapsed);
+    /* Now fill in the layout */
+    if (!rmlvo.layout || !*rmlvo.layout) {
+        if (rmlvo.variant && *rmlvo.variant) {
+            fprintf(stderr, "Error: a variant requires a layout\n");
+            return EXIT_INVALID_USAGE;
+        }
+        rmlvo.layout = DEFAULT_XKB_LAYOUT;
+        rmlvo.variant = DEFAULT_XKB_VARIANT;
+    }
 
-    xkb_context_unref(ctx);
-    return 0;
+    struct xkb_context *context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    if (!context)
+        exit(EXIT_FAILURE);
+
+    xkb_context_set_log_level(context, XKB_LOG_LEVEL_CRITICAL);
+    xkb_context_set_log_verbosity(context, 0);
+
+    if (explicit_iterations) {
+        stdev = 0;
+        bench_start2(&bench);
+        for (unsigned int i = 0; i < max_iterations; i++) {
+            struct xkb_component_names kccgst;
+
+            assert(xkb_components_from_rules(context, &rmlvo, &kccgst, NULL));
+            free(kccgst.keycodes);
+            free(kccgst.types);
+            free(kccgst.compatibility);
+            free(kccgst.symbols);
+            free(kccgst.geometry);
+        }
+        bench_stop2(&bench);
+
+        bench_elapsed(&bench, &elapsed);
+        est.elapsed = (bench_time_elapsed_nanoseconds(&elapsed)) / max_iterations;
+        est.stdev = 0;
+    } else {
+        bench_start2(&bench);
+        BENCH(stdev, max_iterations, elapsed, est,
+            struct xkb_component_names kccgst;
+
+            assert(xkb_components_from_rules(context, &rmlvo, &kccgst, NULL));
+            free(kccgst.keycodes);
+            free(kccgst.types);
+            free(kccgst.compatibility);
+            free(kccgst.symbols);
+            free(kccgst.geometry);
+        );
+        bench_stop2(&bench);
+    }
+
+    struct bench_time total_elapsed;
+    bench_elapsed(&bench, &total_elapsed);
+    if (explicit_iterations) {
+        fprintf(stderr,
+                "mean: %lld µs; compiled %u rules in %ld.%06lds\n",
+                est.elapsed / 1000, max_iterations,
+                total_elapsed.seconds, total_elapsed.nanoseconds / 1000);
+    } else {
+        fprintf(stderr,
+                "mean: %lld µs; stdev: %Lf%% (target: %f%%); "
+                "last run: compiled %u rules in %ld.%06lds; "
+                "total time: %ld.%06lds\n", est.elapsed / 1000,
+                (long double) est.stdev * 100.0 / (long double) est.elapsed,
+                stdev * 100,
+                max_iterations, elapsed.seconds, elapsed.nanoseconds / 1000,
+                total_elapsed.seconds, total_elapsed.nanoseconds / 1000);
+    }
+
+    xkb_context_unref(context);
+    return EXIT_SUCCESS;
 }

--- a/meson.build
+++ b/meson.build
@@ -994,16 +994,16 @@ benchmark(
     ),
 )
 benchmark(
-    'rules',
-    executable('bench-rules', 'bench/rules.c', dependencies: test_dep),
-    env: bench_env,
-)
-benchmark(
     'rulescomp',
     executable('bench-rulescomp', 'bench/rulescomp.c', dependencies: test_dep),
     env: bench_env,
 )
 if cc.has_header_symbol('getopt.h', 'getopt_long', prefix: '#define _GNU_SOURCE')
+    benchmark(
+        'rules',
+        executable('bench-rules', 'bench/rules.c', dependencies: test_dep),
+        env: bench_env,
+    )
     benchmark(
         'compile-keymap',
         executable(

--- a/test/data/rules/special_indexes
+++ b/test/data/rules/special_indexes
@@ -3,60 +3,60 @@
   *             = default_keycodes
 
 ! layout[single] variant    = symbols // valid
-  layout_a       my_variant = symbols_a+extra_variant
+  layout_a       my_variant = a+extra_variant
 
 ! layout[single] = symbols
-  layout_a       = symbols_A
+  layout_a       = A
 
 ! layout        = symbols
-  layout_b      = symbols_B
-  layout_c      = symbols_C:%i // valid, but unusual
-  layout_d      = symbols_D
-  layout_e      = symbols_E
+  layout_b      = B
+  layout_c      = C:%i // valid, but unusual
+  layout_d      = D
+  layout_e      = E
   *             = %l[%i]%(v[%i]) // valid, but unusual
 
 ! layout[first] = symbols
-  layout_a      = symbols_a:1
-  layout_b      = symbols_b:1
-  layout_c      = symbols_c:1
-  layout_d      = symbols_d:%i // valid, but unusual
-  layout_e      = symbols_e:1
+  layout_a      = a:1
+  layout_b      = b:1
+  layout_c      = c:1
+  layout_d      = d:%i // valid, but unusual
+  layout_e      = e:1
   *             = %l[%i]%(v[%i]) // valid, cannot be easily expressed otherwise
 
 ! layout[first] = symbols
   layout_e      = %+l // different output if single or multiple layouts
 
 ! layout[later] = symbols
-  layout_a      = +symbols_x:%i
-  layout_b      = +symbols_y:%i
+  layout_a      = +x:%i
+  layout_b      = +y:%i
   *             = +%l[%i]%(v[%i]):%i
 
 ! layout[any]   = symbols
-  layout_c      = +symbols_z:%i
+  layout_c      = +z:%i
 
 ! layout[any] variant[any] = symbols
   *           extra        = +foo:%i|bar:%i
 
 ! layout[1] variant = symbols // invalid mapping
-  *         *       = +symbols_AAA:%i
+  *         *       = +AAA:%i
 
 ! layout variant[1] = symbols // invalid mapping
-  *      *          = +symbols_BBB:%i
+  *      *          = +BBB:%i
 
 ! layout[1] variant[2] = symbols // invalid mapping
-  *         *          = +symbols_CCC:%i
+  *         *          = +CCC:%i
 
 ! layout[any] variant = symbols // invalid mapping
-  *           *       = +symbols_DDD:%i
+  *           *       = +DDD:%i
 
 ! layout variant[any] = symbols // invalid mapping
-  *      *            = +symbols_EEE:%i
+  *      *            = +EEE:%i
 
 ! layout[any] variant[1] = symbols // invalid mapping
-  *           *          = +symbols_FFF:%i
+  *           *          = +FFF:%i
 
 ! layout[any] variant[first] = symbols // invalid mapping
-  *           *              = +symbols_GGG:%i
+  *           *              = +GGG:%i
 
 ! model         = types
   my_model      = my_types
@@ -68,3 +68,23 @@
 
 ! option        = symbols
   my_option     = +extra_option
+
+// Used to check that special indexes merge the KcCGST values in the
+// expected order.
+! layout[any] option   = symbols
+  layout_c    option_2 = +HHH:%i
+  layout_b    option_1 = +III:%i
+  // should be skipped (no explicit merge mode) and
+  // should not interact with other rules
+  layout_b    option_2 = skip
+  layout_b    option_3 = +JJJ:%i
+  layout_c    option_1 = +KKK:%i
+
+! layout[first] option   = compat symbols
+  *             option_1 = skip1  skip
+  *             option_2 = skip2  +LLL
+
+! layout[later] option   = symbols compat
+  layout_c      option_2 = +MMM:%i skip1
+  layout_c      option_1 = +NNN:%i skip2
+  layout_b      option_1 = +OOO:%i skip3

--- a/test/rules-file.c
+++ b/test/rules-file.c
@@ -336,28 +336,32 @@ main(int argc, char *argv[])
                count, should_fail)
     struct test_data special_indexes_first_data[] = {
         /* Test index ranges: layout vs layout[first] */
-        ENTRY("layout_a", NULL, NULL, "symbols_A", 1, false),
-        ENTRY("layout_e", NULL, NULL, "symbols_E+layout_e", 1, false),
+        ENTRY("layout_a", NULL, NULL, "A", 1, false),
+        ENTRY("layout_e", NULL, NULL, "E+layout_e", 1, false),
         ENTRY("a", NULL, NULL, "a", 1, false),
         ENTRY("a", "1", NULL, "a(1)", 1, false),
         /* Test index ranges: invalid layout qualifier */
-        ENTRY("layout_c", NULL, NULL, "symbols_C:1+symbols_z:1", 1, false),
+        ENTRY("layout_c", NULL, NULL, "C:1+z:1", 1, false),
         /* Test index ranges: invalid layout[first] qualifier */
-        ENTRY("layout_d", NULL, NULL, "symbols_D", 1, false),
+        ENTRY("layout_d", NULL, NULL, "D", 1, false),
         /* Test index ranges: multiple layouts */
         ENTRY("a,b", NULL, NULL, "a+b:2", 2, false),
         ENTRY("a,b", ",c", NULL, "a+b(c):2", 2, false),
-        ENTRY("layout_e,layout_a", NULL, NULL, "symbols_e:1+symbols_x:2", 2, false),
+        ENTRY("layout_e,layout_a", NULL, NULL, "e:1+x:2", 2, false),
         ENTRY("layout_a,layout_b,layout_c,layout_d", NULL, NULL,
-              "symbols_a:1+symbols_y:2+layout_c:3+layout_d:4+symbols_z:3", 4, false),
+              "a:1+y:2+layout_c:3+layout_d:4+z:3", 4, false),
         ENTRY("layout_a,layout_b,layout_c,layout_d",
               "extra,,,extra", NULL,
-              "symbols_a:1+symbols_y:2+layout_c:3+layout_d(extra):4+symbols_z:3"
+              "a:1+y:2+layout_c:3+layout_d(extra):4+z:3"
               "+foo:1|bar:1+foo:4|bar:4", 4, false),
         /* NOTE: 5 layouts is intentional;
          * will require update when raising XKB_MAX_LAYOUTS */
         ENTRY("layout_a,layout_b,layout_c,layout_d,layout_e", NULL, NULL,
-              "symbols_a:1+symbols_y:2+layout_c:3+layout_d:4+symbols_z:3", 4, false),
+              "a:1+y:2+layout_c:3+layout_d:4+z:3", 4, false),
+        /* Check that special indexes merge the KcCGST values in the expected order */
+        ENTRY("layout_a,layout_b,layout_c", NULL, "option_3,option_2,option_1",
+              "a:1+y:2+layout_c:3+z:3+III:2+JJJ:2+HHH:3+KKK:3+LLL+OOO:2+MMM:3+NNN:3",
+              3, false),
 #undef ENTRY
         /* Test index ranges: too much layouts */
         ENTRY2("special_indexes-limit", NULL, too_much_layouts, NULL, NULL,
@@ -443,11 +447,8 @@ main(int argc, char *argv[])
               "pc+l10:1+l20:2+l30(v2):3+l2:4", 4, false),
         ENTRY("extended-wild-cards", "l2,l2,l3,l3", "v1,v2,,v1",
               "pc+l40(v1):1+l40(v2):2+l50:3+l50(v1):4", 4, false),
-        /* NOTE: `l4(v2)` (4th LV index) is matched *before* the other LV indexes,
-         *       because with the extended indexes we follow the order of the rules in the
-         *       file, not the RMLVO order. This is similar to options handling. */
         ENTRY("extended-wild-cards", "l3,l4,l4,l4", "v2,,v1,v2",
-              "pc+l50(v2):1+l4(v20):4+l4:2+l4(v1):3", 4, false),
+              "pc+l50(v2):1+l4:2+l4(v1):3+l4(v20):4", 4, false),
     };
 
     for (size_t k = 0; k < ARRAY_SIZE(extended_wild_cards_data); k++) {


### PR DESCRIPTION
When using layout index ranges (e.g. special indexes “any” or “later”), the rules still match following the order in the rules file, so layout indexes may match without following their natural order. So the resulting KcCGST value should not be merged with the output until reaching the end of the rule set.

Because the rule set may also involve options, it may match multiple times for the *same* layout index. So these multiple matches should not be merged together either until reaching the end of the rule set.

When reaching the end of the rule set, for each KcCGST component the pending values are then merged: for each layout, for each KcCGST value in the corresponding sequence, merge with the output.

---

Example:

    ! model = symbols
      *     = pc
    ! layout[any] option = symbols
      C           1      = +c1:%i
      C           2      = +c2:%i
      B           3      = skip
      B           4      = +b:%i

The result of RMLVO

    {layout: "A,B,C", options: "4,3,2,1"}

is:

    symbols = pc+b:2+c1:3+c2:3

- `skip` was dropped because it has no explicit merge mode;
- although every rule was matched in order, the resulting order of the symbols follows the order of the layouts, so `+b` appears before `+c1` and `+c2`.
- the relative order of the options for layout C follows the order within the rule set, not the order of RMLVO.

Before this commit, the result would have been:

    symbols = pc+c1:3+c2:3+b:2