### PR TITLE
doc: Fix usual vmods mapping typo

### DIFF
--- a/doc/keymap-format-text-v1.md
+++ b/doc/keymap-format-text-v1.md
@@ -162,8 +162,8 @@ Some additional resources are:
   | `Meta`       | Virtual | `Mod1` or `Mod4` | The legacy [Meta] key    |
   | `NumLock`    | Virtual | `Mod2`        | The usual [NumLock]         |
   | `Super`      | Virtual | `Mod4`        | The usual [Super]/GUI       |
-  | `LevelThree` | Virtual | `Mod3`        | [ISO][ISO9995] level 3, aka [AltGr] |
-  | `LevelFive`  | Virtual | `Mod5`        | [ISO][ISO9995] level 5      |
+  | `LevelThree` | Virtual | `Mod5`        | [ISO][ISO9995] level 3, aka [AltGr] |
+  | `LevelFive`  | Virtual | `Mod3`        | [ISO][ISO9995] level 5      |
 
   [usual modifiers]: @ref usual-modifiers
   [Shift]: https://en.wikipedia.org/wiki/Control_key


### PR DESCRIPTION
`LevelThree` and `LevelFive` are mapped respectively to `Mod5` and `Mod3`. This is counter-intuitive but set so for ages and probably hard-coded[^1] in some places.

Thanks to @johnp for indirectly [reporting](https://bugzilla.mozilla.org/show_bug.cgi?id=1827615#c29) via #732. You are not alone to find this situtation confusing 😅

[^1]: Note that this is a bad practice: `LevelThree` → `Mod5` is a *usual* mapping, but no protocol fixes that.