### PR TITLE
doc: Introduce a FAQ page with how to get the vmod → rmod mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ layouts.
 - [User-configuration](doc/user-configuration.md): instructions to add
   a *custom layout* or option.
 - [Quick Guide](doc/quick-guide.md): introduction on how to use this library.
+- [Frequently Asked Question (FAQ)](doc/faq.md).
 
 ## Building
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -1,0 +1,114 @@
+# Frequently Asked Question (FAQ) {#faq}
+
+## XKB
+
+### What is XKB?
+
+See: [Introduction to XKB](./introduction-to-xkb.md).
+
+### What does … mean?
+
+See: [terminology](./keymap-format-text-v1.md#terminology).
+
+## Keyboard layout
+
+### Where are the keyboard layouts defined?
+
+The xkbcommon project does not provide keyboard layouts.
+See the [xkeyboard-config] project for further information.
+
+### Why do my keyboard shortcuts not work properly?
+
+- 🚧 TODO: Setups with multiple layout and/or non-Latin keyboard layouts may have some
+  issues.
+- 🚧 TODO: [#420]
+
+[#420]: https://github.com/xkbcommon/libxkbcommon/issues/420
+
+### Why does my key combination to switch between layouts not work?
+
+See [this issue][#420].
+
+### Why does my keyboard layout not work as expected?
+
+There could be many reasons!
+
+<dl>
+<dt>There is an issue with your keyboard layout database</dt>
+<dd>
+libxkbcommon may not be able to load your configuration due to an issue
+(file not found, syntax error, unsupported keysym, etc.). Please use our
+[debugging tools] to get further information.
+
+Note that the xkbcommon project does not provide keyboard layouts.
+See the [xkeyboard-config] project for further information.
+</dd>
+<dt>Diacritics/accents do not work</dt>
+<dd>
+This is most probably an issue with your *Compose* configuration.
+If you customized it, do not forget to restart your session before trying it.
+
+Please use our [debugging tools] with the option `--enable-compose` to get
+further information.
+</dd>
+<dt>The application you use does not handle the keyboard properly</dt>
+<dd>
+Please use our [debugging tools] to ensure that it is specific to the
+application.
+</dd>
+<dt>Your keyboard layout uses features not supported by libxkbcommon</dt>
+<dd>See: [compatibility](./compatibility.md)</dd>
+<dt>None of the previous</dt>
+<dd>
+If none of the previous is conclusive, then this may an issue with libxkbcommon.
+Please use our [debugging tools] to provide the maximum information (setup,
+log, expected/got results) and file a [bug report]!
+</dd>
+</dl>
+
+[debugging tools]: ./debugging.md
+[xkeyboard-config]: https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config
+[bug report]: https://github.com/xkbcommon/libxkbcommon/issues/new
+
+### How do I customize my layout?
+
+This project does not provide any keyboard layout database:
+- If you want to modify only your *local* keyboard configuration,
+  see: [User-configuration](./user-configuration.md).
+- If you want to modify the standard keyboard layout database, please
+  first try it *locally* (see previous) and then file an issue or a merge request
+  at the [xkeyboard-config] project.
+
+See also the [keymap text format][text format] documentation for the syntax.
+
+[text format]: ./keymap-format-text-v1.md
+
+### How do I swap some keys?
+
+🚧 TODO
+
+## API
+
+### Modifiers
+
+#### How to get the virtual to real modifiers mappings?
+
+The [virtual modifiers] mappings to [real modifiers] is an implementation
+detail that is not exposed directly. However, some applications may require
+it in order to interface with legacy code. These may adapt the following
+snippet:
+
+```c
+// Find the real modifier mapping of the virtual modifier `LevelThree`
+#include <xkbcommon/xkbcommon-names.h>
+const xkb_mod_index_t levelThree_idx = xkb_keymap_mod_get_index(keymap, XKB_VMOD_NAME_LEVEL3);
+const xkb_mod_mask_t levelThree = UINT32_C(1) << levelThree_idx;
+struct xkb_state* state = xkb_state_new(keymap);
+assert(state); // Please handle error properly
+xkb_state_update_mask(state, levelThree, 0, 0, 0, 0, 0);
+const xkb_mod_mask_t levelThree_mapping = xkb_state_serialize_mods(state, XKB_STATE_MODS_EFFECTIVE);
+xkb_state_unref(state);
+```
+
+[virtual modifiers]: @ref virtual-modifier-def
+[real modifiers]: @ref real-modifier-def

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -1513,8 +1513,8 @@ xkb_state_update_key(struct xkb_state *state, xkb_keycode_t key,
  * All parameters must always be passed, or the resulting state may be
  * incoherent.
  *
- * The serialization is lossy and will not survive round trips; it must only
- * be used to feed client state objects, and must not be used to update the
+ * @warning The serialization is lossy and will not survive round trips; it must
+ * only be used to feed client state objects, and must not be used to update the
  * server state.
  *
  * @returns A mask of state components that have changed as a result of

--- a/meson.build
+++ b/meson.build
@@ -1125,6 +1125,7 @@ You can disable the documentation with -Denable-docs=false.''')
         'doc/diagrams/xkb-keymap-components.dot',
         'doc/diagrams/xkb-types-explanation.dot',
         'doc/doxygen-extra.css',
+        'doc/faq.md',
         'doc/introduction-to-xkb.md',
         'doc/quick-guide.md',
         'doc/compatibility.md',


### PR DESCRIPTION
Apart from the traditional questions:
- Document how to get the vmod → rmod mapping

  Some applications may need it to interface with legacy code.

Closes #732