### PR TITLE
test: Fix `main()` function prototype

### DIFF
--- a/test/keysym-unicode.c
+++ b/test/keysym-unicode.c
@@ -8,7 +8,8 @@
 
 #ifdef _WIN32
 
-main()
+int
+main(void)
 {
     test_init();
     return SKIP_TEST;


### PR DESCRIPTION
Fix compilation error when building for Windows with clang-cl:

    ../subprojects/libxkbcommon-xkbcommon-1.9.0/test/keysym-unicode.c:11:1: error: return type defaults to 'int' [-Wimplicit-int]
    ../subprojects/libxkbcommon-xkbcommon-1.9.0/test/keysym-unicode.c:11:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]