### PR TITLE
Do not discard extra bits in vmod masks

### DIFF
--- a/src/xkbcomp/keymap.c
+++ b/src/xkbcomp/keymap.c
@@ -30,10 +30,18 @@ has_unbound_vmods(struct xkb_keymap *keymap, xkb_mod_mask_t mask)
     return false;
 }
 
-static void
+static inline void
 ComputeEffectiveMask(struct xkb_keymap *keymap, struct xkb_mods *mods)
 {
-    mods->mask = mod_mask_get_effective(keymap, mods->mods);
+    /*
+     * Since we accept numeric values for the vmod mask in the keymap, we may
+     * have extra bits set that encode no real/virtual modifier. Keep them
+     * unchanged for consistency.
+     */
+    const xkb_mod_mask_t unknown_mods = ~(xkb_mod_mask_t)
+        ((UINT64_C(1) << keymap->mods.num_mods) - UINT64_C(1));
+    mods->mask = mod_mask_get_effective(keymap, mods->mods)
+               | (mods->mods & unknown_mods);
 }
 
 static void

--- a/test/buffercomp.c
+++ b/test/buffercomp.c
@@ -717,6 +717,17 @@ test_masks(struct xkb_context *ctx, bool update_output_files) {
                 "  };\n"
                 "};",
             .expected = GOLDEN_TESTS_OUTPUTS "masks.xkb"
+        },
+        {
+            .keymap =
+                "xkb_keymap {\n"
+                "    xkb_keycodes { <a> = 38; };\n"
+                "    xkb_symbols {\n"
+                "        virtual_modifiers X = 0xf0000000;\n"
+                "        key <a> { [ SetMods(mods = 0x00001100) ] };\n"
+                "    };\n"
+                "};",
+            .expected = GOLDEN_TESTS_OUTPUTS "masks-extra-bits.xkb"
         }
     };
     for (unsigned int k = 0; k < ARRAY_SIZE(keymaps); k++) {

--- a/test/data/keymaps/masks-extra-bits.xkb
+++ b/test/data/keymaps/masks-extra-bits.xkb
@@ -1,0 +1,34 @@
+xkb_keymap {
+xkb_keycodes {
+	minimum = 8;
+	maximum = 255;
+	<a>                  = 38;
+};
+
+xkb_types {
+	virtual_modifiers X=0xf0000000;
+
+	type "default" {
+		modifiers= none;
+	};
+};
+
+xkb_compatibility {
+	virtual_modifiers X=0xf0000000;
+
+	interpret.useModMapMods= AnyLevel;
+	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
+};
+
+xkb_symbols {
+	key <a>                  {
+		repeat= No,
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [      SetMods(modifiers=0x1100) ]
+	};
+};
+
+};


### PR DESCRIPTION
Since we accept numeric values for the vmod mask in the keymap, we may have extra bits set that encode *no* real/virtual modifier. Keep them unchanged for consistency.

E.g. the following keymap:

```c
xkb_keymap {
    xkb_keycodes { <a> = 38; };
    xkb_symbols {
        virtual_modifiers X = 0xf0000000;
        key <a> { [ SetMods(mods = 0x00001100) ] };
    };
};
```

would compile to:

```c
xkb_keymap {
    xkb_keycodes { <a> = 38; };
    xkb_symbols {
        virtual_modifiers X = 0xf0000000;
        // Internal state
        key <a> { [ SetMods(mods = 0xf0001000) ] };
        // Serializatiion
        key <a> { [ SetMods(mods = 0x00001100) ] };
    };
};
```

See also [this discussion](https://github.com/xkbcommon/libxkbcommon/pull/745#issuecomment-2851848503).

TODO:
- [ ] changelog? it’s very niche
- [x] rebase on #745