### PR TITLE
Define the mapping of real modifiers explicitly

### DIFF
--- a/src/keymap-priv.c
+++ b/src/keymap-priv.c
@@ -29,11 +29,13 @@ update_builtin_keymap_fields(struct xkb_keymap *keymap)
         [XKB_MOD_INDEX_MOD5]  = XKB_MOD_NAME_MOD5
     };
 
-    for (unsigned i = 0; i < ARRAY_SIZE(builtin_mods); i++) {
+    for (xkb_mod_index_t i = 0; i < ARRAY_SIZE(builtin_mods); i++) {
         keymap->mods.mods[i].name = xkb_atom_intern(keymap->ctx,
                                                     builtin_mods[i],
                                                     strlen(builtin_mods[i]));
         keymap->mods.mods[i].type = MOD_REAL;
+        /* Real modifiers have a canonical mapping */
+        keymap->mods.mods[i].mapping = UINT32_C(1) << i;
     }
     keymap->mods.num_mods = ARRAY_SIZE(builtin_mods);
 }

--- a/test/modifiers.c
+++ b/test/modifiers.c
@@ -38,6 +38,7 @@ test_real_mod(struct xkb_keymap *keymap, const char* name,
 {
     return xkb_keymap_mod_get_index(keymap, name) == idx &&
            (keymap->mods.mods[idx].type == MOD_REAL) &&
+           mapping == keymap->mods.mods[idx].mapping &&
            mapping == (UINT32_C(1) << idx);
 }
 


### PR DESCRIPTION
When querying for a modifier mapping, we should treat all modifiers equally. So simply store real modifier mapping as we do for the virtual ones.

Also fixed useless boolean conversions.