### PR TITLE
modifiers: Add xkb_keymap_mod_get_mask()

### DIFF
--- a/changes/api/+xkb_keymap_mod_get_mask.feature.md
+++ b/changes/api/+xkb_keymap_mod_get_mask.feature.md
@@ -1,0 +1,1 @@
+Added `xkb_keymap_mod_get_mask()` to query the mapping of a modifier.

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -93,10 +93,16 @@ See also the [keymap text format][text format] documentation for the syntax.
 
 #### How to get the virtual to real modifiers mappings?
 
-The [virtual modifiers] mappings to [real modifiers] is an implementation
-detail that is not exposed directly. However, some applications may require
-it in order to interface with legacy code. These may adapt the following
-snippet:
+The [virtual modifiers] mappings to [real modifiers] is an implementation detail.
+However, some applications may require it in order to interface with legacy code.
+
+##### libxkbcommon ≥ 1.10
+
+Use the dedicated function `xkb_keymap::xkb_keymap_mod_get_mask()`.
+
+##### libxkbcommon ≤ 1.9
+
+Use the following snippet:
 
 ```c
 // Find the real modifier mapping of the virtual modifier `LevelThree`

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -1154,6 +1154,23 @@ XKB_EXPORT xkb_mod_index_t
 xkb_keymap_mod_get_index(struct xkb_keymap *keymap, const char *name);
 
 /**
+ * Get the mapping of a modifier by name.
+ *
+ * In X11 terminology it corresponds to the mapping to the *[real modifiers]*.
+ *
+ * @returns The mapping of a modifier.  Note that it may be 0 if the name does
+ * not exist or if the modifier is not mapped.
+ *
+ * @since 1.10.0
+ * @memberof xkb_keymap
+ *
+ * [real modifiers]: @ref real-modifier-def
+ */
+XKB_EXPORT xkb_mod_mask_t
+xkb_keymap_mod_get_mask(struct xkb_keymap *keymap, const char *name);
+
+
+/**
  * Get the number of layouts in the keymap.
  *
  * @sa xkb_layout_index_t xkb_rule_names xkb_keymap_num_layouts_for_key()

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -18,6 +18,7 @@
 
 #include "keymap.h"
 #include "text.h"
+#include "xkbcommon/xkbcommon.h"
 
 struct xkb_keymap *
 xkb_keymap_ref(struct xkb_keymap *keymap)
@@ -281,13 +282,22 @@ xkb_keymap_mod_get_name(struct xkb_keymap *keymap, xkb_mod_index_t idx)
 xkb_mod_index_t
 xkb_keymap_mod_get_index(struct xkb_keymap *keymap, const char *name)
 {
-    xkb_atom_t atom;
+    const xkb_atom_t atom = xkb_atom_lookup(keymap->ctx, name);
+    return (atom == XKB_ATOM_NONE)
+        ? XKB_MOD_INVALID
+        : XkbModNameToIndex(&keymap->mods, atom, MOD_BOTH);
+}
 
-    atom = xkb_atom_lookup(keymap->ctx, name);
-    if (atom == XKB_ATOM_NONE)
-        return XKB_MOD_INVALID;
-
-    return XkbModNameToIndex(&keymap->mods, atom, MOD_BOTH);
+/**
+ * Return the canonical mapping of a named modifier.
+ */
+xkb_mod_mask_t
+xkb_keymap_mod_get_mask(struct xkb_keymap *keymap, const char* name)
+{
+    const xkb_mod_index_t idx = xkb_keymap_mod_get_index(keymap, name);
+    return (idx >= keymap->mods.num_mods)
+        ? 0
+        : keymap->mods.mods[idx].mapping;
 }
 
 /**

--- a/test/modifiers.c
+++ b/test/modifiers.c
@@ -34,7 +34,8 @@ test_real_mod(struct xkb_keymap *keymap, const char* name,
     return xkb_keymap_mod_get_index(keymap, name) == idx &&
            (keymap->mods.mods[idx].type == MOD_REAL) &&
            mapping == keymap->mods.mods[idx].mapping &&
-           mapping == (UINT32_C(1) << idx);
+           mapping == (UINT32_C(1) << idx) &&
+           xkb_keymap_mod_get_mask(keymap, name) == mapping;
 }
 
 static bool
@@ -43,7 +44,8 @@ test_virtual_mod(struct xkb_keymap *keymap, const char* name,
 {
     return xkb_keymap_mod_get_index(keymap, name) == idx &&
            (keymap->mods.mods[idx].type == MOD_VIRT) &&
-           mapping == keymap->mods.mods[idx].mapping;
+           mapping == keymap->mods.mods[idx].mapping &&
+           xkb_keymap_mod_get_mask(keymap, name) == mapping;
 }
 
 /* Check that the provided modifier names work */
@@ -521,6 +523,7 @@ test_virtual_modifiers_mapping_hack(struct xkb_context *context)
         assert_printf(mapping == mods[k].mapping,
                       "%s: expected %#"PRIx32", got: %#"PRIx32"\n",
                       mods[k].name, mods[k].mapping, mapping);
+        assert(mapping == xkb_keymap_mod_get_mask(keymap, mods[k].name));
     }
 
     xkb_state_unref(state);

--- a/xkbcommon.map
+++ b/xkbcommon.map
@@ -124,3 +124,8 @@ V_1.9.0 {
 global:
     xkb_components_names_from_rules;
 } V_1.6.0;
+
+V_1.10.0 {
+global:
+    xkb_keymap_mod_get_mask;
+} V_1.9.0;


### PR DESCRIPTION
Added a dedicated API to query modifier masks rather than relying on a hack using `xkb_state_update_mask`. Furthermore, this hack may not work in the future if we remove virtual mods resolution in `xkb_state_update_mask` to avoid corner-cases issues.

Rationale: see [this comment](https://github.com/xkbcommon/libxkbcommon/pull/745#issuecomment-2854029663)

TODO:
- [x] Rebase on #745