### PR TITLE
Fix key type map entry with unbound vmod not ignored

### DIFF
--- a/changes/api/758.bugfix.md
+++ b/changes/api/758.bugfix.md
@@ -1,0 +1,1 @@
+Fixed key type map entries with a mix of bound and unbound modifiers not being ignored.

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -501,9 +501,11 @@ XkbKeyNumLevels(const struct xkb_key *key, xkb_layout_index_t layout)
 }
 
 /*
- * If the virtual modifiers are not bound to anything, the entry
- * is not active and should be skipped. xserver does this with
- * cached entry->active field.
+ * Map entries which specify unbound virtual modifiers are not considered.
+ * See: the XKB protocol, section “Determining the KeySym Associated with a Key
+ * Event”
+ *
+ * xserver does this with cached entry->active field.
  */
 static inline bool
 entry_is_active(const struct xkb_key_type_entry *entry)

--- a/test/data/symbols/latch
+++ b/test/data/symbols/latch
@@ -2,7 +2,7 @@ default partial alphanumeric_keys
 xkb_symbols "modifiers" {
 	name[Group1] = "Test latching behavior";
 
-	virtual_modifiers LevelThree;
+	virtual_modifiers Alt=Mod1, LevelThree;
 
 	key <AE01> { [ 1, exclam, onesuperior, exclamdown, plus ], type[Group1]="CTRL+ALT"};
 


### PR DESCRIPTION
Currently we only ignore key type map entries with non-zero mods and with a zero modifier mask. However, the XKB protocol states ([source]):

> Map entries which specify unbound virtual modifiers are not considered.

So we currently handle `map[Unbound]` key type map entries (all modifiers unbound) but not `map[Bound+Unbound]` entries (mix of bound and unbound modifiers).

Fixed by properly checking unbound modifiers on each key type map entry.

This also fixes a test that was accidentally passing.

Fixes #578

[source]: https://www.x.org/releases/X11R7.7/doc/kbproto/xkbproto.html#:~:text=Map%20entries%20which%20specify%20unbound%20virtual%20modifiers,not%20considered
