### PR TITLE
Fix compat interpretations serialization

### DIFF
--- a/changes/api/+no empty compat map.bugfix.md
+++ b/changes/api/+no empty compat map.bugfix.md
@@ -1,0 +1,2 @@
+Fixed keymap with empty compatibility interpretation map not being parsable in
+X11’s `xkbcomp`.

--- a/changes/api/750.bugfix.md
+++ b/changes/api/750.bugfix.md
@@ -1,0 +1,2 @@
+Fixed empty compatibility interpretations serialization, which can cannot be
+parsed by X11’s `xkbcomp`.

--- a/src/xkbcomp/keymap-dump.c
+++ b/src/xkbcomp/keymap-dump.c
@@ -616,7 +616,11 @@ write_compat(struct xkb_keymap *keymap, struct buf *buf)
                 return false;
             has_explicit_properties = true;
         }
-        write_buf(buf, (has_explicit_properties ? "\n\t};\n" : "};\n"));
+        write_buf(buf, (has_explicit_properties
+                        ? "\n\t};\n"
+                        /* Empty interpret is a syntax error in xkbcomp, so
+                         * use a dummy entry */
+                        : "\n\t\taction= NoAction();\n\t};\n"));
     }
 
     xkb_leds_foreach(led, keymap)

--- a/src/xkbcomp/keymap-dump.c
+++ b/src/xkbcomp/keymap-dump.c
@@ -573,8 +573,17 @@ write_compat(struct xkb_keymap *keymap, struct buf *buf)
     copy_to_buf(buf, "\tinterpret.useModMapMods= AnyLevel;\n");
     copy_to_buf(buf, "\tinterpret.repeat= False;\n");
 
-    for (unsigned i = 0; i < keymap->num_sym_interprets; i++) {
-        const struct xkb_sym_interpret *si = &keymap->sym_interprets[i];
+    /* xkbcomp requires at least one interpret entry. */
+    const unsigned int num_sym_interprets = keymap->num_sym_interprets
+                                          ? keymap->num_sym_interprets
+                                          : 1;
+    const struct xkb_sym_interpret* const sym_interprets
+        = keymap->num_sym_interprets
+        ? keymap->sym_interprets
+        : &default_interpret;
+
+    for (unsigned i = 0; i < num_sym_interprets; i++) {
+        const struct xkb_sym_interpret *si = &sym_interprets[i];
 
         write_buf(buf, "\tinterpret %s+%s(%s) {",
                   si->sym ? KeysymText(keymap->ctx, si->sym) : "Any",

--- a/src/xkbcomp/keymap.c
+++ b/src/xkbcomp/keymap.c
@@ -53,8 +53,10 @@ UpdateActionMods(struct xkb_keymap *keymap, union xkb_action *act,
     }
 }
 
-static const struct xkb_sym_interpret default_interpret = {
-    .sym = XKB_KEY_NoSymbol,
+const struct xkb_sym_interpret default_interpret = {
+    /* Keysym unused for when applying interpretation, but used as a default
+     * entry when dumping the keymap */
+    .sym = XKB_KEY_VoidSymbol,
     .repeat = true,
     .match = MATCH_ANY_OR_NONE,
     .mods = 0,

--- a/src/xkbcomp/xkbcomp-priv.h
+++ b/src/xkbcomp/xkbcomp-priv.h
@@ -41,6 +41,8 @@ CompileSymbols(XkbFile *file, struct xkb_keymap *keymap);
 bool
 CompileKeymap(XkbFile *file, struct xkb_keymap *keymap);
 
+extern const struct xkb_sym_interpret default_interpret;
+
 /***====================================================================***/
 
 static inline bool

--- a/test/data/keymaps/bidi.xkb
+++ b/test/data/keymaps/bidi.xkb
@@ -14,6 +14,9 @@ xkb_types {
 xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 };
 
 xkb_symbols {

--- a/test/data/keymaps/compat-interpret.xkb
+++ b/test/data/keymaps/compat-interpret.xkb
@@ -13,13 +13,27 @@ xkb_types {
 xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
-	interpret 1+AnyOfOrNone(all) {};
-	interpret 0x0000000b+AnyOfOrNone(all) {};
-	interpret Shift_L+AnyOfOrNone(all) {};
-	interpret a+AnyOfOrNone(all) {};
-	interpret adiaeresis+AnyOfOrNone(all) {};
-	interpret U2728+AnyOfOrNone(all) {};
-	interpret U1F3BA+AnyOfOrNone(all) {};
+	interpret 1+AnyOfOrNone(all) {
+		action= NoAction();
+	};
+	interpret 0x0000000b+AnyOfOrNone(all) {
+		action= NoAction();
+	};
+	interpret Shift_L+AnyOfOrNone(all) {
+		action= NoAction();
+	};
+	interpret a+AnyOfOrNone(all) {
+		action= NoAction();
+	};
+	interpret adiaeresis+AnyOfOrNone(all) {
+		action= NoAction();
+	};
+	interpret U2728+AnyOfOrNone(all) {
+		action= NoAction();
+	};
+	interpret U1F3BA+AnyOfOrNone(all) {
+		action= NoAction();
+	};
 };
 
 xkb_symbols {

--- a/test/data/keymaps/empty-compound-statements.xkb
+++ b/test/data/keymaps/empty-compound-statements.xkb
@@ -46,7 +46,9 @@ xkb_compatibility {
 
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
-	interpret q+AnyOfOrNone(all) {};
+	interpret q+AnyOfOrNone(all) {
+		action= NoAction();
+	};
 	interpret w+AnyOfOrNone(all) {
 		repeat= True;
 	};

--- a/test/data/keymaps/escape-sequences.xkb
+++ b/test/data/keymaps/escape-sequences.xkb
@@ -26,6 +26,9 @@ xkb_types "1__7___" {
 xkb_compatibility "Le_c≈_ur_a___ses_raisons_que_la_raison_ne_con_na√_t_point" {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 	indicator "\n‚å®Ô∏è" {
 		modifiers= Shift;
 	};

--- a/test/data/keymaps/include-banana-implicit-default.xkb
+++ b/test/data/keymaps/include-banana-implicit-default.xkb
@@ -14,6 +14,9 @@ xkb_types {
 xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 };
 
 xkb_symbols "banana" {

--- a/test/data/keymaps/include-capslock-custom.xkb
+++ b/test/data/keymaps/include-capslock-custom.xkb
@@ -14,6 +14,9 @@ xkb_types {
 xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 };
 
 xkb_symbols "capslock(custom)" {

--- a/test/data/keymaps/include-capslock-system.xkb
+++ b/test/data/keymaps/include-capslock-system.xkb
@@ -14,6 +14,9 @@ xkb_types {
 xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 };
 
 xkb_symbols "capslock" {

--- a/test/data/keymaps/include-level3-explicit-default.xkb
+++ b/test/data/keymaps/include-level3-explicit-default.xkb
@@ -33,6 +33,9 @@ xkb_compatibility {
 
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 };
 
 xkb_symbols "level3" {

--- a/test/data/keymaps/integers-overflow.xkb
+++ b/test/data/keymaps/integers-overflow.xkb
@@ -14,6 +14,9 @@ xkb_types {
 xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 };
 
 xkb_symbols {

--- a/test/data/keymaps/integers.xkb
+++ b/test/data/keymaps/integers.xkb
@@ -15,6 +15,9 @@ xkb_types {
 xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 };
 
 xkb_symbols {

--- a/test/data/keymaps/keycodes-bounds-multiple-1.xkb
+++ b/test/data/keymaps/keycodes-bounds-multiple-1.xkb
@@ -15,6 +15,9 @@ xkb_types {
 xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 };
 
 xkb_symbols {

--- a/test/data/keymaps/keycodes-bounds-single-1.xkb
+++ b/test/data/keymaps/keycodes-bounds-single-1.xkb
@@ -14,6 +14,9 @@ xkb_types {
 xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 };
 
 xkb_symbols {

--- a/test/data/keymaps/keycodes-bounds-single-2.xkb
+++ b/test/data/keymaps/keycodes-bounds-single-2.xkb
@@ -14,6 +14,9 @@ xkb_types {
 xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 };
 
 xkb_symbols {

--- a/test/data/keymaps/masks.xkb
+++ b/test/data/keymaps/masks.xkb
@@ -18,6 +18,9 @@ xkb_compatibility {
 
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 };
 
 xkb_symbols {

--- a/test/data/keymaps/merge-modes/vmods-other-component-direct.xkb
+++ b/test/data/keymaps/merge-modes/vmods-other-component-direct.xkb
@@ -17,6 +17,9 @@ xkb_compatibility "" {
 
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 };
 
 xkb_symbols {

--- a/test/data/keymaps/merge-modes/vmods-same-component-include-default-augment.xkb
+++ b/test/data/keymaps/merge-modes/vmods-same-component-include-default-augment.xkb
@@ -17,6 +17,9 @@ xkb_compatibility "" {
 
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 };
 
 xkb_symbols {

--- a/test/data/keymaps/merge-modes/vmods-same-component-include-default-override.xkb
+++ b/test/data/keymaps/merge-modes/vmods-same-component-include-default-override.xkb
@@ -17,6 +17,9 @@ xkb_compatibility "" {
 
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 };
 
 xkb_symbols {

--- a/test/data/keymaps/optional-components-basic.xkb
+++ b/test/data/keymaps/optional-components-basic.xkb
@@ -14,6 +14,9 @@ xkb_types {
 xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 };
 
 xkb_symbols {

--- a/test/data/keymaps/optional-components-no-real-led.xkb
+++ b/test/data/keymaps/optional-components-no-real-led.xkb
@@ -14,6 +14,9 @@ xkb_types {
 xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 	indicator "XXX" {
 		modifiers= Lock;
 	};

--- a/test/data/keymaps/optional-components-none.xkb
+++ b/test/data/keymaps/optional-components-none.xkb
@@ -13,6 +13,9 @@ xkb_types {
 xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 };
 
 xkb_symbols {

--- a/test/data/keymaps/stringcomp.data
+++ b/test/data/keymaps/stringcomp.data
@@ -605,7 +605,9 @@ xkb_compatibility "complete_caps(caps_lock)_4_misc(assign_shift_left_action)_4_l
 		virtualModifier= NumLock;
 		action= LockMods(modifiers=NumLock);
 	};
-	interpret ISO_Lock+AnyOf(all) {};
+	interpret ISO_Lock+AnyOf(all) {
+		action= NoAction();
+	};
 	interpret ISO_Level3_Shift+AnyOf(all) {
 		virtualModifier= LevelThree;
 		useModMapMods=level1;

--- a/test/data/keymaps/symbols-modifier_map.xkb
+++ b/test/data/keymaps/symbols-modifier_map.xkb
@@ -47,6 +47,9 @@ xkb_compatibility {
 
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 };
 
 xkb_symbols {

--- a/test/data/keymaps/symbols-multi-keysyms-empty.xkb
+++ b/test/data/keymaps/symbols-multi-keysyms-empty.xkb
@@ -146,8 +146,12 @@ xkb_compatibility {
 
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
-	interpret 1+AnyOfOrNone(all) {};
-	interpret 2+AnyOfOrNone(all) {};
+	interpret 1+AnyOfOrNone(all) {
+		action= NoAction();
+	};
+	interpret 2+AnyOfOrNone(all) {
+		action= NoAction();
+	};
 	interpret 3+AnyOfOrNone(all) {
 		action= SetMods(modifiers=none);
 	};

--- a/test/data/keymaps/unicode-keysyms.xkb
+++ b/test/data/keymaps/unicode-keysyms.xkb
@@ -299,6 +299,9 @@ xkb_compatibility {
 
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
 };
 
 xkb_symbols {

--- a/test/xkeyboard-config-test.py.in
+++ b/test/xkeyboard-config-test.py.in
@@ -30,7 +30,7 @@ from typing import (
     cast,
 )
 
-# TODO: import unconditionnaly Self from typing once we raise Python requirement to 3.11+
+# TODO: import unconditionally Self from typing once we raise Python requirement to 3.11+
 if TYPE_CHECKING:
     from typing_extensions import Self
 
@@ -274,7 +274,7 @@ class XkbCompInvocation(Invocation):
 
 
 @dataclass
-class XkbCompReformatInvocation(XkbCompInvocation):
+class XkbCompToXkbcommonInvocation(XkbCompInvocation):
     """
     Use setxkbcomp & xkbcomp, then pipe the result to xkbcli in order to enable
     comparison with direct xkbcli compilation with the same format.
@@ -343,10 +343,12 @@ class XkbcommonInvocation(Invocation):
         *args,
         **kwargs,
     ) -> Self:
-        i._run(xkb_root, output_dir, compress)
+        i._run(xkb_root, output_dir, not output_dir, compress)
         return i
 
-    def _run(self, xkb_root: Path, output_dir: Path | None, compress: int) -> None:
+    def _run(
+        self, xkb_root: Path, output_dir: Path | None, test: bool, compress: int
+    ) -> None:
         args = (
             "xkbcli-compile-keymap",  # this is run in the builddir
             "--include",
@@ -355,7 +357,7 @@ class XkbcommonInvocation(Invocation):
             # "--verbose",
             *itertools.chain.from_iterable((f"--{k}", v) for k, v in self.rmlvo),
         )
-        if not output_dir:
+        if test:
             args += ("--test",)
         self.command = shlex.join(args)
         try:
@@ -370,6 +372,44 @@ class XkbcommonInvocation(Invocation):
         else:
             if self._check_stderr(completed.stderr):
                 self.keymap = completed.stdout.encode("utf-8")
+        if output_dir:
+            self._write_keymap(output_dir, compress)
+
+
+@dataclass
+class XkbcommonToXkbcompInvocation(XkbcommonInvocation):
+    """
+    Use xkbcli, then pipe the result to xkbcomp in order to check
+    that xkbcomp can parse xkbcommon output.
+    """
+
+    def _run(
+        self, xkb_root: Path, output_dir: Path | None, test: bool, compress: int
+    ) -> None:
+        super()._run(xkb_root, output_dir, False, compress)
+
+        if self.exitstatus:
+            return
+
+        args = ("xkbcomp", "-xkb", "-opt", "g", "-", "-")
+
+        try:
+            completed = subprocess.run(
+                args,
+                check=True,
+                capture_output=True,
+                input=self.keymap,
+            )
+        except subprocess.CalledProcessError as err:
+            self.error = (
+                "failed to compile keymap:\n"
+                f"------\nstderr:\n{err.stderr}\n"
+                f"------\nstdout:\n{err.stdout}\n"
+                f"------\nstdin:\n{self.keymap.decode('utf-8')}\n"
+            )
+            self.exitstatus = err.returncode
+        else:
+            self.keymap = completed.stdout
         if output_dir:
             self._write_keymap(output_dir, compress)
 
@@ -555,11 +595,12 @@ def main() -> NoReturn:
         type=Path,
         help="XKB root directory",
     )
-    DEFAULT_TOOL = "libxkbcommon"
+    DEFAULT_TOOL = "xkbcommon"
     tools: dict[str, type[Invocation]] = {
         DEFAULT_TOOL: XkbcommonInvocation,
+        "xkbcommon-xkbcomp": XkbcommonToXkbcompInvocation,
         "xkbcomp": XkbCompInvocation,
-        "xkbcomp-reformat": XkbCompReformatInvocation,
+        "xkbcomp-xkbcommon": XkbCompToXkbcommonInvocation,
     }
     parser.add_argument(
         "--tool",


### PR DESCRIPTION
Fixed compat interpretations serialization to meet X11’s xkbcomp requirements:
- interpretations should not be empty
- there should be at least one interpretation

The fixes implied a big bunch of test file updates, thus numerous files modified by this MR.

I compiled all xkeyboard-config before publishing 1.9.0, but I did not check enough X11 compatibility. So this MR also update the xkeyboard-config script to test xkbcommon → xkbcomp chaining on the whole keyboard layout database. I did not detect further errors.

@bluetech @whot This requires a minor release: 1.9.2. I’ll do this tomorrow.

Fixes #750