### PR TITLE
Add tests for pure virtual modifiers

### DIFF
--- a/test/data/compat/basic
+++ b/test/data/compat/basic
@@ -47,3 +47,53 @@ default xkb_compatibility "basic" {
 	modifiers= Shift;
     };
 };
+
+xkb_compatibility "pure-virtual-modifiers" {
+
+    virtual_modifiers  NumLock,AltGr,Alt;
+
+    interpret.repeat= False;
+    setMods.clearLocks= True;
+    latchMods.clearLocks= True;
+    latchMods.latchToLock= True;
+
+    interpret Shift_Lock {
+	action= LockMods(modifiers=Shift);
+    };
+
+    interpret Num_Lock {
+	virtualModifier= NumLock;
+	action= LockMods(modifiers=NumLock);
+    };
+
+    interpret Shift_L {
+	action= SetMods(modifiers=Shift);
+    };
+
+    interpret Shift_R {
+	action= SetMods(modifiers=Shift);
+    };
+
+    interpret Control_L {
+	action= SetMods(modifiers=Control);
+    };
+
+    interpret Control_R {
+	action= SetMods(modifiers=Control);
+    };
+
+    interpret Alt_L {
+	action= SetMods(modifiers=Alt);
+    };
+
+    interpret Alt_R {
+	action= SetMods(modifiers=Alt);
+    };
+};
+
+xkb_compatibility "invalid-pure-virtual-modifiers" {
+    virtual_modifiers Alt;
+    interpret Alt_R + Alt {
+	action= SetMods(modifiers=Alt);
+    };
+};

--- a/test/data/keymaps/pure-virtual-mods.xkb
+++ b/test/data/keymaps/pure-virtual-mods.xkb
@@ -1,0 +1,300 @@
+xkb_keymap {
+xkb_keycodes "test" {
+	minimum = 8;
+	maximum = 255;
+
+	<TLDE> = 49;
+	<AE01> = 10;
+	<AE02> = 11;
+	<AE03> = 12;
+	<AE04> = 13;
+	<AE05> = 14;
+	<AE06> = 15;
+	<AE07> = 16;
+	<AE08> = 17;
+	<AE09> = 18;
+	<AE10> = 19;
+	<AE11> = 20;
+	<AE12> = 21;
+	<BKSP> = 22;
+
+	<TAB> = 23;
+	<AD01> = 24;
+	<AD02> = 25;
+	<AD03> = 26;
+	<AD04> = 27;
+	<AD05> = 28;
+	<AD06> = 29;
+	<AD07> = 30;
+	<AD08> = 31;
+	<AD09> = 32;
+	<AD10> = 33;
+	<AD11> = 34;
+	<AD12> = 35;
+	<BKSL> = 51;
+	<RTRN> = 36;
+
+	<CAPS> = 66;
+	<AC01> = 38;
+	<AC02> = 39;
+	<AC03> = 40;
+	<AC04> = 41;
+	<AC05> = 42;
+	<AC06> = 43;
+	<AC07> = 44;
+	<AC08> = 45;
+	<AC09> = 46;
+	<AC10> = 47;
+	<AC11> = 48;
+	alias <AC12> = <BKSL>;
+
+	<LFSH> = 50;
+	<LSGT> = 94;
+	<AB01> = 52;
+	<AB02> = 53;
+	<AB03> = 54;
+	<AB04> = 55;
+	<AB05> = 56;
+	<AB06> = 57;
+	<AB07> = 58;
+	<AB08> = 59;
+	<AB09> = 60;
+	<AB10> = 61;
+	<RTSH> = 62;
+
+	<LVL3>  = 92;
+	<RALT> = 108;
+};
+
+xkb_types "complete" {
+	// Define >20 virtual modifiers. This lead to overcome the X11 limit of
+	// 16 virtual modifiers.
+	virtual_modifiers
+		LevelThree = 0x00000100,
+		ModA       = 0x00000200,
+		ModB       = 0x00000400,
+		ModC       = 0x00000800,
+		ModD       = 0x00001000,
+		ModE       = 0x00002000,
+		ModF       = 0x00004000,
+		ModG       = 0x00008000,
+		ModH       = 0x00010000,
+		ModI       = 0x00020000,
+		ModJ       = 0x00040000,
+		ModK       = 0x00080000,
+		ModL       = 0x00100000,
+		ModM       = 0x00200000,
+		ModN       = 0x00400000,
+		ModO       = 0x00800000,
+		ModP       = 0x01000000,
+		ModQ       = 0x02000000,
+		ModR       = 0x04000000,
+		ModS       = 0x08000000,
+		ModT       = 0x10000000,
+		ModU       = 0x20000000,
+		ModV       = 0x40000000;
+
+	type "ONE_LEVEL" {
+		modifiers= none;
+		level_name[Level1]= "Any";
+	};
+	type "TWO_LEVEL" {
+		modifiers= Shift;
+		map[Shift]= 2;
+		level_name[1]= "Base";
+		level_name[2]= "Shift";
+	};
+	type "TEST" {
+		modifiers=
+			Shift + LevelThree +
+			ModA + ModB + ModC + ModD + ModE + ModF + ModG +
+			ModH + ModI + ModJ + ModK + ModL + ModM + ModN +
+			ModO + ModP + ModQ + ModR + ModS + ModT + ModU + ModV;
+		map[ModA]= 2;
+		map[ModB]= 3;
+		map[ModC]= 4;
+		map[ModD]= 5;
+		map[ModE]= 6;
+		map[ModF]= 7;
+		map[ModG]= 8;
+		map[ModH]= 9;
+		map[ModI]= 10;
+		map[ModJ]= 11;
+		map[ModK]= 12;
+		map[ModL]= 13;
+		map[ModM]= 14;
+		map[ModN]= 15;
+		map[ModO]= 16;
+		map[ModP]= 17;
+		map[ModQ]= 18;
+		map[ModR]= 19;
+		map[ModS]= 20;
+		map[ModT]= 21;
+		map[ModU]= 22;
+		map[ModV]= 23;
+		map[ModV+Shift]= 24;
+		map[ModA+ModS]= 25;
+		map[ModA+ModQ]= 26;
+		map[LevelThree+ModA]= 27;
+		map[LevelThree+ModA+ModS]= 28;
+		map[ModA+ModB+ModC]= 29;
+
+		level_name[1]= "1";
+		level_name[2]= "2";
+		level_name[3]= "3";
+		level_name[4]= "4";
+		level_name[5]= "5";
+		level_name[6]= "6";
+		level_name[7]= "7";
+		level_name[8]= "8";
+		level_name[9]= "9";
+		level_name[10]= "10";
+		level_name[11]= "11";
+		level_name[12]= "12";
+		level_name[13]= "13";
+		level_name[14]= "14";
+		level_name[15]= "15";
+		level_name[16]= "16";
+		level_name[17]= "17";
+		level_name[18]= "18";
+		level_name[19]= "19";
+		level_name[20]= "20";
+		level_name[21]= "21";
+		level_name[22]= "22";
+		level_name[23]= "23";
+		level_name[24]= "24";
+		level_name[25]= "25";
+		level_name[26]= "26";
+		level_name[27]= "27";
+		level_name[28]= "28";
+		level_name[29]= "29";
+	};
+};
+xkb_compatibility "complete" {
+	virtual_modifiers LevelThree, ModA, ModB, ModC, ModD;
+
+	interpret.useModMapMods= AnyLevel;
+	interpret.repeat= False;
+	interpret.locking= False;
+
+	interpret Any+AnyOf(all) {
+		action= SetMods(modifiers=modMapMods,clearLocks);
+	};
+
+	interpret ISO_Level3_Shift+AnyOf(all) {
+		virtualModifier= LevelThree;
+		useModMapMods=level1;
+		action= SetMods(modifiers=LevelThree,clearLocks);
+	};
+	interpret a {
+		action= SetMods(modifiers=ModA,clearLocks);
+	};
+	interpret b {
+		action= SetMods(modifiers=ModB,clearLocks);
+	};
+	interpret c {
+		action= SetMods(modifiers=ModC,clearLocks);
+	};
+	interpret d {
+		action= SetMods(modifiers=ModD,clearLocks);
+	};
+	interpret e {
+		action= SetMods(modifiers=ModE,clearLocks);
+	};
+	interpret f {
+		action= SetMods(modifiers=ModF,clearLocks);
+	};
+	interpret g {
+		action= SetMods(modifiers=ModG,clearLocks);
+	};
+	interpret h {
+		action= SetMods(modifiers=ModH,clearLocks);
+	};
+	interpret i {
+		action= SetMods(modifiers=ModI,clearLocks);
+	};
+	interpret j {
+		action= SetMods(modifiers=ModJ,clearLocks);
+	};
+	interpret k {
+		action= SetMods(modifiers=ModK,clearLocks);
+	};
+	interpret l {
+		action= SetMods(modifiers=ModL,clearLocks);
+	};
+	interpret m {
+		action= SetMods(modifiers=ModM,clearLocks);
+	};
+	interpret n {
+		action= SetMods(modifiers=ModN,clearLocks);
+	};
+	interpret o {
+		action= SetMods(modifiers=ModO,clearLocks);
+	};
+	interpret p {
+		action= SetMods(modifiers=ModP,clearLocks);
+	};
+	interpret q {
+		action= SetMods(modifiers=ModQ,clearLocks);
+	};
+	interpret r {
+		action= SetMods(modifiers=ModR,clearLocks);
+	};
+	interpret s {
+		action= SetMods(modifiers=ModS,clearLocks);
+	};
+	interpret t {
+		action= SetMods(modifiers=ModT,clearLocks);
+	};
+	interpret u {
+		action= SetMods(modifiers=ModU,clearLocks);
+	};
+	interpret v {
+		action= SetMods(modifiers=ModV,clearLocks);
+	};
+};
+xkb_symbols {
+	name[group1]="Test";
+
+	key <LFSH> 	{ [Shift_L] };
+	key <RALT> 	{ [ISO_Level3_Shift] };
+	key <LVL3> 	{ [ISO_Level3_Shift] };
+	modmap Shift	{ <LFSH> };
+	modmap Mod5	{ <LVL3>, <RALT> };
+
+	key <AD01>	{[	 q,	 Q	]};
+	key <AD02>	{[	 w,	 W	]};
+	key <AD03>	{[	 e,	 E	]};
+	key <AD04>	{[	 r,	 R	]};
+	key <AD05>	{[	 t,	 T	]};
+	key <AD06>	{[	 y,	 Y	]};
+	key <AD07>	{[	 u,	 U	]};
+	key <AD08>	{[	 i,	 I	]};
+	key <AD09>	{[	 o,	 O	]};
+	key <AD10>	{[	 p,	 P	]};
+
+	key <AC01>	{[	 a,	 A	]};
+	key <AC02>	{[	 s,	 S	]};
+	key <AC03>	{[	 d,	 D	]};
+	key <AC04>	{[	 f,	 F	]};
+	key <AC05>	{[	 g,	 G	]};
+	key <AC06>	{[	 h,	 H	]};
+	key <AC07>	{[	 j,	 J	]};
+	key <AC08>	{[	 k,	 K	]};
+	key <AC09>	{[	 l,	 L	]};
+
+	key <AB01>	{[	 z,	 Z	]};
+	key <AB02>	{[	 x,	 X	]};
+	key <AB03>	{[	 c,	 C	]};
+	key <AB04>	{[	 v,	 V	]};
+	key <AB05>	{[	 b,	 B	]};
+	key <AB06>	{[	 n,	 N	]};
+	key <AB07>	{[	 m,	 M	]};
+
+	key.type[1] = "TEST";
+	key <AD02> {
+		[ w, a, b, c, d, e, f, g, h, i, j, k, l, m, n
+		, o, p, q, r, s, t, u, v, V, 1, 2, 3, 4, 5 ]
+	};
+};
+};

--- a/test/data/rules/evdev-pure-virtual-mods
+++ b/test/data/rules/evdev-pure-virtual-mods
@@ -1,0 +1,32 @@
+// Special rules to test pure virtual modifiers.
+
+// Needed for a test involving `applealu_ansi`.
+! $macvendorlayouts = ch de dk fi fr gb is it latam nl no pt se us
+! $applealu = applealu_ansi applealu_iso applealu_jis
+
+! model		layout			=	symbols
+ $applealu	$macvendorlayouts	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l%(v)
+  *		*			=	pc(pc105-pure-virtual-modifiers)+%l%(v)
+
+! model		layout[1]	=	symbols
+  *		*		=	pc(pc105-pure-virtual-modifiers)+%l[1]%(v[1])
+
+! model				=	types
+  *				=	virtual_modifiers(ordered_explicit_mapping)+complete
+
+! model				=	types
+  $macs				=	+numpad(mac)
+  $applealu			=	+numpad(mac)
+  $nokiamodels			=	+nokia
+
+! model		layout		=	compat
+  *		*		=	complete+basic(pure-virtual-modifiers)
+
+! model		layout[1]	=	compat
+  *		*		=	complete+basic(pure-virtual-modifiers)
+
+// The rules in the current file will *not* be overridden by the
+// following include, because the keymap sections do not start with
+// an explicit merge operator. E.g. `[pc(x), pc]` is merged as `pc(x)`,
+// while `[pc, +us]` is merged as `pc+us`.
+! include evdev

--- a/test/data/symbols/pc
+++ b/test/data/symbols/pc
@@ -1,5 +1,4 @@
-default partial alphanumeric_keys modifier_keys
-xkb_symbols "pc105" {
+xkb_symbols "pc105-pure-virtual-modifiers" {
 
     key <ESC>  {	[ Escape		]	};
 
@@ -31,35 +30,40 @@ xkb_symbols "pc105" {
     key <RWIN> {	[ Super_R		]	};
     key <MENU> {	[ Menu			]	};
 
-    // Beginning of modifier mappings.
-    modifier_map Shift  { Shift_L, Shift_R };
-    modifier_map Lock   { Caps_Lock };
-    modifier_map Control{ Control_L, Control_R };
-    modifier_map Mod2   { Num_Lock };
-    modifier_map Mod4   { Super_L, Super_R };
-
     // Fake keys for virtual<->real modifiers mapping:
     key <LVL3> {	[ ISO_Level3_Shift	]	};
     key <MDSW> {	[ Mode_switch 		]	};
-    modifier_map Mod5   { <LVL3>, <MDSW> };
 
     key <ALT>  {	[ NoSymbol, Alt_L	]	};
-    include "altwin(meta_alt)"
+    key <LALT> { [ Alt_L, Meta_L ] };
+    key <RALT> { type[Group1] = "TWO_LEVEL",
+                 symbols[Group1] = [ Alt_R, Meta_R ] };
 
     key <META> {	[ NoSymbol, Meta_L	]	};
-    modifier_map Mod1   { <META> };
 
     key <SUPR> {	[ NoSymbol, Super_L	]	};
-    modifier_map Mod4   { <SUPR> };
 
     key <HYPR> {	[ NoSymbol, Hyper_L	]	};
-    modifier_map Mod4   { <HYPR> };
     // End of modifier mappings.
 
     key <OUTP> { [ XF86Display ] };
     key <KITG> { [ XF86KbdLightOnOff ] };
     key <KIDN> { [ XF86KbdBrightnessDown ] };
     key <KIUP> { [ XF86KbdBrightnessUp ] };
+};
+
+default partial alphanumeric_keys modifier_keys
+xkb_symbols "pc105" {
+    include "pc(pc105-pure-virtual-modifiers)"
+
+    // Beginning of modifier mappings.
+    modifier_map Shift  { Shift_L, Shift_R };
+    modifier_map Lock   { Caps_Lock };
+    modifier_map Control{ Control_L, Control_R };
+    modifier_map Mod1   { <META>, Alt_L, Alt_R, Meta_L, Meta_R };
+    modifier_map Mod2   { Num_Lock };
+    modifier_map Mod4   { <SUPR>, <HYPR>, Super_L, Super_R };
+    modifier_map Mod5   { <LVL3>, <MDSW> };
 };
 
 hidden partial alphanumeric_keys

--- a/test/data/types/virtual_modifiers
+++ b/test/data/types/virtual_modifiers
@@ -1,0 +1,11 @@
+default xkb_types "ordered_explicit_mapping" {
+	virtual_modifiers
+		Alt = 0x100,
+		Meta = 0x200,
+		Super = 0x400,
+		Hyper = 0x800,
+		NumLock = 0x1000,
+		LevelThree = 0x2000,
+		LevelFive = 0x4000,
+		ScrollLock = 0x8000;
+};

--- a/test/keyseq.c
+++ b/test/keyseq.c
@@ -1084,20 +1084,13 @@ test_simultaneous_modifier_clear(struct xkb_context *context)
     xkb_keymap_unref(keymap);
 }
 
-int
-main(void)
+static void
+test_keymaps(struct xkb_context *ctx, const char* rules)
 {
-    test_init();
-
-    struct xkb_context *ctx = test_get_context(CONTEXT_NO_FLAG);
     struct xkb_keymap *keymap;
 
     assert(ctx);
 
-    test_simultaneous_modifier_clear(ctx);
-    test_group_latch(ctx);
-    test_mod_latch(ctx);
-    test_explicit_actions(ctx);
 
     keymap = test_compile_rules(ctx, "evdev", "evdev",
                                 "us,il,ru,de", ",,phonetic,neo",
@@ -1376,7 +1369,7 @@ main(void)
                         KEY_V,           BOTH,  XKB_KEY_p,               FINISH));
 
     xkb_keymap_unref(keymap);
-    keymap = test_compile_rules(ctx, "evdev", "", "de", "neo", "");
+    keymap = test_compile_rules(ctx, rules, "", "de", "neo", "");
     assert(keymap);
     assert(test_key_seq(keymap,
                         /* Level 5. */
@@ -1428,7 +1421,7 @@ main(void)
 
 
     xkb_keymap_unref(keymap);
-    keymap = test_compile_rules(ctx, "evdev", "", "us,il,ru", "",
+    keymap = test_compile_rules(ctx, rules, "", "us,il,ru", "",
                                 "grp:alt_shift_toggle_bidir,grp:menu_toggle");
     assert(keymap);
 
@@ -1467,7 +1460,7 @@ main(void)
                         KEY_H,         BOTH, XKB_KEY_h,              FINISH));
 
     xkb_keymap_unref(keymap);
-    keymap = test_compile_rules(ctx, "evdev", "", "us,il,ru", "",
+    keymap = test_compile_rules(ctx, rules, "", "us,il,ru", "",
                                 "grp:switch,grp:lswitch,grp:menu_toggle");
     assert(keymap);
 
@@ -1510,7 +1503,7 @@ main(void)
                         KEY_H,         BOTH, XKB_KEY_h,                 FINISH));
 
     xkb_keymap_unref(keymap);
-    keymap = test_compile_rules(ctx, "evdev", "", "us", "euro", "");
+    keymap = test_compile_rules(ctx, rules, "", "us", "euro", "");
     assert(keymap);
 
     assert(test_key_seq(keymap,
@@ -1530,7 +1523,7 @@ main(void)
                         KEY_Z,         BOTH, XKB_KEY_y,                 FINISH));
 
     xkb_keymap_unref(keymap);
-    keymap = test_compile_rules(ctx, "evdev", "applealu_ansi", "us", "",
+    keymap = test_compile_rules(ctx, rules, "applealu_ansi", "us", "",
                                 "terminate:ctrl_alt_bksp");
     assert(keymap);
 
@@ -1550,6 +1543,26 @@ main(void)
                         KEY_A,         BOTH, XKB_KEY_a,                 FINISH));
 
     xkb_keymap_unref(keymap);
+}
+
+int
+main(void)
+{
+    test_init();
+
+    struct xkb_context *ctx = test_get_context(CONTEXT_NO_FLAG);
+    assert(ctx);
+
+    /* Usual rules */
+    test_keymaps(ctx, "evdev");
+    /* Special rules to make no use of modmaps */
+    test_keymaps(ctx, "evdev-pure-virtual-mods");
+
+    test_simultaneous_modifier_clear(ctx);
+    test_group_latch(ctx);
+    test_mod_latch(ctx);
+    test_explicit_actions(ctx);
+
     xkb_context_unref(ctx);
     return EXIT_SUCCESS;
 }

--- a/test/modifiers.c
+++ b/test/modifiers.c
@@ -8,10 +8,11 @@
 #include <assert.h>
 #include <stdlib.h>
 
+#include "xkbcommon/xkbcommon.h"
+#include "evdev-scancodes.h"
 #include "test.h"
 #include "keymap.h"
 #include "utils.h"
-#include "xkbcommon/xkbcommon.h"
 
 /* Standard real modifier masks */
 enum real_mod_mask {
@@ -526,6 +527,119 @@ test_virtual_modifiers_mapping_hack(struct xkb_context *context)
     xkb_keymap_unref(keymap);
 }
 
+static void
+test_pure_virtual_modifiers(struct xkb_context *context)
+{
+    struct xkb_keymap *keymap;
+
+    /* Test definition of >20 pure virtual modifiers.
+     * We superate the X11 limit of 16 virtual modifiers. */
+    keymap = test_compile_file(context, "keymaps/pure-virtual-mods.xkb");
+    assert(keymap);
+
+    assert(test_key_seq(keymap,
+                        KEY_W,          BOTH,  XKB_KEY_w,        NEXT,
+                        KEY_A,          DOWN,  XKB_KEY_a,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_a,        NEXT,
+                        KEY_A,          UP,    XKB_KEY_a,        NEXT,
+                        KEY_B,          DOWN,  XKB_KEY_b,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_b,        NEXT,
+                        KEY_B,          UP,    XKB_KEY_b,        NEXT,
+                        KEY_C,          DOWN,  XKB_KEY_c,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_c,        NEXT,
+                        KEY_C,          UP,    XKB_KEY_c,        NEXT,
+                        KEY_D,          DOWN,  XKB_KEY_d,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_d,        NEXT,
+                        KEY_D,          UP,    XKB_KEY_d,        NEXT,
+                        KEY_E,          DOWN,  XKB_KEY_e,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_e,        NEXT,
+                        KEY_E,          UP,    XKB_KEY_e,        NEXT,
+                        KEY_F,          DOWN,  XKB_KEY_f,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_f,        NEXT,
+                        KEY_F,          UP,    XKB_KEY_f,        NEXT,
+                        KEY_G,          DOWN,  XKB_KEY_g,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_g,        NEXT,
+                        KEY_G,          UP,    XKB_KEY_g,        NEXT,
+                        KEY_H,          DOWN,  XKB_KEY_h,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_h,        NEXT,
+                        KEY_H,          UP,    XKB_KEY_h,        NEXT,
+                        KEY_I,          DOWN,  XKB_KEY_i,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_i,        NEXT,
+                        KEY_I,          UP,    XKB_KEY_i,        NEXT,
+                        KEY_J,          DOWN,  XKB_KEY_j,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_j,        NEXT,
+                        KEY_J,          UP,    XKB_KEY_j,        NEXT,
+                        KEY_K,          DOWN,  XKB_KEY_k,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_k,        NEXT,
+                        KEY_K,          UP,    XKB_KEY_k,        NEXT,
+                        KEY_L,          DOWN,  XKB_KEY_l,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_l,        NEXT,
+                        KEY_L,          UP,    XKB_KEY_l,        NEXT,
+                        KEY_M,          DOWN,  XKB_KEY_m,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_m,        NEXT,
+                        KEY_M,          UP,    XKB_KEY_m,        NEXT,
+                        KEY_N,          DOWN,  XKB_KEY_n,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_n,        NEXT,
+                        KEY_N,          UP,    XKB_KEY_n,        NEXT,
+                        KEY_O,          DOWN,  XKB_KEY_o,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_o,        NEXT,
+                        KEY_O,          UP,    XKB_KEY_o,        NEXT,
+                        KEY_P,          DOWN,  XKB_KEY_p,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_p,        NEXT,
+                        KEY_P,          UP,    XKB_KEY_p,        NEXT,
+                        KEY_Q,          DOWN,  XKB_KEY_q,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_q,        NEXT,
+                        KEY_Q,          UP,    XKB_KEY_q,        NEXT,
+                        KEY_R,          DOWN,  XKB_KEY_r,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_r,        NEXT,
+                        KEY_R,          UP,    XKB_KEY_r,        NEXT,
+                        KEY_S,          DOWN,  XKB_KEY_s,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_s,        NEXT,
+                        KEY_S,          UP,    XKB_KEY_s,        NEXT,
+                        KEY_T,          DOWN,  XKB_KEY_t,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_t,        NEXT,
+                        KEY_T,          UP,    XKB_KEY_t,        NEXT,
+                        KEY_U,          DOWN,  XKB_KEY_u,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_u,        NEXT,
+                        KEY_U,          UP,    XKB_KEY_u,        NEXT,
+                        KEY_V,          DOWN,  XKB_KEY_v,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_v,        NEXT,
+                        KEY_LEFTSHIFT,  DOWN,  XKB_KEY_Shift_L,  NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_V,        NEXT,
+                        KEY_LEFTSHIFT,  UP,    XKB_KEY_Shift_L,  NEXT,
+                        KEY_V,          UP,    XKB_KEY_v,        NEXT,
+                        KEY_A,          DOWN,  XKB_KEY_a,        NEXT,
+                        KEY_S,          DOWN,  XKB_KEY_s,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_1,        NEXT,
+                        KEY_RIGHTALT,   DOWN,  XKB_KEY_ISO_Level3_Shift, NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_4,        NEXT,
+                        KEY_S,          UP,    XKB_KEY_s,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_3,        NEXT,
+                        KEY_RIGHTALT,   UP,    XKB_KEY_ISO_Level3_Shift, NEXT,
+                        KEY_Q,          DOWN,  XKB_KEY_q,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_2,        NEXT,
+                        KEY_Q,          UP,    XKB_KEY_q,        NEXT,
+                        KEY_B,          DOWN,  XKB_KEY_b,        NEXT,
+                        KEY_C,          DOWN,  XKB_KEY_c,        NEXT,
+                        KEY_W,          BOTH,  XKB_KEY_5,        NEXT,
+                        KEY_C,          UP,    XKB_KEY_c,        NEXT,
+                        KEY_B,          UP,    XKB_KEY_b,        NEXT,
+                        KEY_A,          UP,    XKB_KEY_a,        NEXT,
+                        KEY_Y,          BOTH,  XKB_KEY_y,        FINISH));
+    xkb_keymap_unref(keymap);
+
+    /* Test invalid interpret using a virtual modifier */
+    const char keymap_str[] =
+        "xkb_keymap {"
+        "  xkb_keycodes { include \"evdev\" };"
+        "  xkb_types { include \"complete\" };"
+        "  xkb_compat { include \"complete+basic(invalid-pure-virtual-modifiers)\" };"
+        "  xkb_symbols { include \"pc(pc105-pure-virtual-modifiers)\" };"
+        "};";
+    keymap = test_compile_string(context, keymap_str);
+    assert(!keymap);
+}
+
 int
 main(void)
 {
@@ -538,6 +652,7 @@ main(void)
     test_modifiers_names(context);
     test_explicit_virtual_modifiers(context);
     test_virtual_modifiers_mapping_hack(context);
+    test_pure_virtual_modifiers(context);
 
     xkb_context_unref(context);
 


### PR DESCRIPTION
These tests come from #450, but they work without the new feature of #450 (namely, automatically assigning explicit vmod *canonical* mapping for unmapped vmods), if using explicit virtual mod mappings.