### PR TITLE
Deprecate legacy modifiers names

### DIFF
--- a/changes/README.md
+++ b/changes/README.md
@@ -12,9 +12,10 @@ There are 3 sections types:
 - Tools: `changes/tools`
 - Build System: `changes/build`
 
-There are 3 news fragments types:
+There are 4 news fragments types:
 
 - Breaking changes: `.breaking`
+- Deprecated: `.deprecated`
 - New: `.feature`
 - Fixes: `.bugfix`
 

--- a/changes/api/538.deprecated.md
+++ b/changes/api/538.deprecated.md
@@ -1,0 +1,5 @@
+The following modifiers names in `xkbcommon/xkbcommon-names.h` are now deprecated
+and will be removed in a future version:
+- `XKB_MOD_NAME_ALT`: use `XKB_VMOD_NAME_ALT` instead.
+- `XKB_MOD_NAME_LOGO`: use `XKB_VMOD_NAME_SUPER` instead.
+- `XKB_MOD_NAME_NUM`: use `XKB_VMOD_NAME_NUM` instead.

--- a/include/xkbcommon/xkbcommon-names.h
+++ b/include/xkbcommon/xkbcommon-names.h
@@ -76,6 +76,8 @@
  * Usual [*virtual* modifiers][virtual modifiers] mappings to
  * [*real* modifiers][real modifiers].
  *
+ * @deprecated Use @ref virtual-modifier-names instead
+ *
  * [virtual modifiers]: @ref virtual-modifier-def
  * [real modifiers]: @ref real-modifier-def
  *
@@ -85,6 +87,9 @@
  * Usual [*real* modifier][real modifier] for the
  * [*virtual* modifier][virtual modifier] `Alt`.
  *
+ * @deprecated Use `::XKB_VMOD_NAME_ALT` instead.
+ * @since 1.10: deprecated
+ *
  * [virtual modifier]: @ref virtual-modifier-def
  * [real modifier]: @ref real-modifier-def
  */
@@ -93,6 +98,9 @@
  * Usual [*real* modifier][real modifier] for the
  * [*virtual* modifier][virtual modifier] `Super`.
  *
+ * @deprecated Use `::XKB_VMOD_NAME_SUPER` instead.
+ * @since 1.10: deprecated
+ *
  * [virtual modifier]: @ref virtual-modifier-def
  * [real modifier]: @ref real-modifier-def
  */
@@ -100,6 +108,9 @@
 /**
  * Usual [*real* modifier][real modifier] for the
  * [*virtual* modifier][virtual modifier] `NumLock`.
+ *
+ * @deprecated Use `::XKB_VMOD_NAME_NUM` instead.
+ * @since 1.10: deprecated
  *
  * [virtual modifier]: @ref virtual-modifier-def
  * [real modifier]: @ref real-modifier-def

--- a/include/xkbcommon/xkbcommon-names.h
+++ b/include/xkbcommon/xkbcommon-names.h
@@ -13,7 +13,21 @@
  * @brief Predefined names for common modifiers and LEDs.
  */
 
-/* *Real* modifiers names are hardcoded in libxkbcommon */
+/**
+ * @defgroup modifier-names Predefined names for common modifiers and LEDs
+ *
+ * @{
+ */
+
+/**
+ * @defgroup real-modifier-names Real modifiers names
+ *
+ * [*Real* modifiers][real modifier] names are hardcoded in libxkbcommon.
+ *
+ * [real modifier]: @ref real-modifier-def
+ *
+ * @{
+ */
 #define XKB_MOD_NAME_SHIFT      "Shift"
 #define XKB_MOD_NAME_CAPS       "Lock"
 #define XKB_MOD_NAME_CTRL       "Control"
@@ -22,31 +36,98 @@
 #define XKB_MOD_NAME_MOD3       "Mod3"
 #define XKB_MOD_NAME_MOD4       "Mod4"
 #define XKB_MOD_NAME_MOD5       "Mod5"
+/** @} */
 
-/* Usual virtual modifiers mappings to real modifiers */
-#define XKB_MOD_NAME_ALT        "Mod1" /* Alt */
-#define XKB_MOD_NAME_LOGO       "Mod4" /* Super */
-#define XKB_MOD_NAME_NUM        "Mod2" /* NumLock */
-
-/* Common *virtual* modifiers, encoded in xkeyboard-config in the compat and
- * symbols files. They have been stable since the beginning of the project and
- * are unlikely to ever change. */
+/**
+ * @defgroup virtual-modifier-names Virtual modifiers names
+ *
+ * Common [*virtual* modifiers][virtual modifiers], encoded in [xkeyboard-config]
+ * in the [compat] and [symbols] files. They have been stable since the beginning
+ * of the project and are unlikely to ever change.
+ *
+ * [virtual modifiers]: @ref virtual-modifier-def
+ * [xkeyboard-config]: https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config
+ * [compat]: @ref the-xkb_compat-section
+ * [symbols]: @ref the-xkb_symbols-section
+ *
+ * @{
+ */
+/** @since 1.8.0 */
 #define XKB_VMOD_NAME_ALT       "Alt"
+/** @since 1.8.0 */
 #define XKB_VMOD_NAME_HYPER     "Hyper"
+/** @since 1.8.0 */
 #define XKB_VMOD_NAME_LEVEL3    "LevelThree"
+/** @since 1.8.0 */
 #define XKB_VMOD_NAME_LEVEL5    "LevelFive"
+/** @since 1.8.0 */
 #define XKB_VMOD_NAME_META      "Meta"
+/** @since 1.8.0 */
 #define XKB_VMOD_NAME_NUM       "NumLock"
+/** @since 1.8.0 */
 #define XKB_VMOD_NAME_SCROLL    "ScrollLock"
+/** @since 1.8.0 */
 #define XKB_VMOD_NAME_SUPER     "Super"
+/** @} */
 
-/* LEDs names are encoded in xkeyboard-config, in the keycodes and compat files.
- * They have been stable since the beginning of the project and are unlikely to
- * ever change. */
+/**
+ * @defgroup legacy-virtual-modifier-names Legacy virtual modifier names
+ *
+ * Usual [*virtual* modifiers][virtual modifiers] mappings to
+ * [*real* modifiers][real modifiers].
+ *
+ * [virtual modifiers]: @ref virtual-modifier-def
+ * [real modifiers]: @ref real-modifier-def
+ *
+ * @{
+ */
+/**
+ * Usual [*real* modifier][real modifier] for the
+ * [*virtual* modifier][virtual modifier] `Alt`.
+ *
+ * [virtual modifier]: @ref virtual-modifier-def
+ * [real modifier]: @ref real-modifier-def
+ */
+#define XKB_MOD_NAME_ALT        "Mod1"
+/**
+ * Usual [*real* modifier][real modifier] for the
+ * [*virtual* modifier][virtual modifier] `Super`.
+ *
+ * [virtual modifier]: @ref virtual-modifier-def
+ * [real modifier]: @ref real-modifier-def
+ */
+#define XKB_MOD_NAME_LOGO       "Mod4"
+/**
+ * Usual [*real* modifier][real modifier] for the
+ * [*virtual* modifier][virtual modifier] `NumLock`.
+ *
+ * [virtual modifier]: @ref virtual-modifier-def
+ * [real modifier]: @ref real-modifier-def
+ */
+#define XKB_MOD_NAME_NUM        "Mod2"
+/** @} */
+
+/**
+ * @defgroup led-names LEDs names
+ *
+ * LEDs names are encoded in [xkeyboard-config], in the [keycodes] and [compat]
+ * files. They have been stable since the beginning of the project and are
+ * unlikely to ever change.
+ *
+ * [xkeyboard-config]: https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config
+ * [keycodes]: @ref the-xkb_keycodes-section
+ * [compat]: @ref the-xkb_compat-section
+ *
+ * @{
+ */
 #define XKB_LED_NAME_NUM        "Num Lock"
 #define XKB_LED_NAME_CAPS       "Caps Lock"
 #define XKB_LED_NAME_SCROLL     "Scroll Lock"
+/** @since 1.8.0 */
 #define XKB_LED_NAME_COMPOSE    "Compose"
 #define XKB_LED_NAME_KANA       "Kana"
+/** @} */
+
+/** @} */
 
 #endif

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -36,6 +36,11 @@ name = "Breaking changes"
 showcontent = true
 
 [[tool.towncrier.type]]
+directory = "deprecated"
+name = "Deprecated"
+showcontent = true
+
+[[tool.towncrier.type]]
 directory = "feature"
 name = "New"
 showcontent = true


### PR DESCRIPTION
The following modifiers names in `xkbcommon/xkbcommon-names.h` are now deprecated:
- `XKB_MOD_NAME_ALT`: use `XKB_VMOD_NAME_ALT` instead.
- `XKB_MOD_NAME_LOGO`: use `XKB_VMOD_NAME_SUPER` instead.
- `XKB_MOD_NAME_NUM`: use `XKB_VMOD_NAME_NUM` instead.

Fixes #538
Closes #712