### PR TITLE
Remove deprecated modifiers names

### DIFF
--- a/changes/api/+remove-deprecated-vmod-names.breaking.md
+++ b/changes/api/+remove-deprecated-vmod-names.breaking.md
@@ -1,0 +1,4 @@
+The following deprecated modifiers names in `xkbcommon/xkbcommon-names.h` were removed:
+- `XKB_MOD_NAME_ALT`: use `XKB_VMOD_NAME_ALT` instead.
+- `XKB_MOD_NAME_LOGO`: use `XKB_VMOD_NAME_SUPER` instead.
+- `XKB_MOD_NAME_NUM`: use `XKB_VMOD_NAME_NUM` instead.

--- a/include/xkbcommon/xkbcommon-names.h
+++ b/include/xkbcommon/xkbcommon-names.h
@@ -71,54 +71,6 @@
 /** @} */
 
 /**
- * @defgroup legacy-virtual-modifier-names Legacy virtual modifier names
- *
- * Usual [*virtual* modifiers][virtual modifiers] mappings to
- * [*real* modifiers][real modifiers].
- *
- * @deprecated Use @ref virtual-modifier-names instead
- *
- * [virtual modifiers]: @ref virtual-modifier-def
- * [real modifiers]: @ref real-modifier-def
- *
- * @{
- */
-/**
- * Usual [*real* modifier][real modifier] for the
- * [*virtual* modifier][virtual modifier] `Alt`.
- *
- * @deprecated Use `::XKB_VMOD_NAME_ALT` instead.
- * @since 1.10: deprecated
- *
- * [virtual modifier]: @ref virtual-modifier-def
- * [real modifier]: @ref real-modifier-def
- */
-#define XKB_MOD_NAME_ALT        "Mod1"
-/**
- * Usual [*real* modifier][real modifier] for the
- * [*virtual* modifier][virtual modifier] `Super`.
- *
- * @deprecated Use `::XKB_VMOD_NAME_SUPER` instead.
- * @since 1.10: deprecated
- *
- * [virtual modifier]: @ref virtual-modifier-def
- * [real modifier]: @ref real-modifier-def
- */
-#define XKB_MOD_NAME_LOGO       "Mod4"
-/**
- * Usual [*real* modifier][real modifier] for the
- * [*virtual* modifier][virtual modifier] `NumLock`.
- *
- * @deprecated Use `::XKB_VMOD_NAME_NUM` instead.
- * @since 1.10: deprecated
- *
- * [virtual modifier]: @ref virtual-modifier-def
- * [real modifier]: @ref real-modifier-def
- */
-#define XKB_MOD_NAME_NUM        "Mod2"
-/** @} */
-
-/**
  * @defgroup led-names LEDs names
  *
  * LEDs names are encoded in [xkeyboard-config], in the [keycodes] and [compat]

--- a/test/modifiers.c
+++ b/test/modifiers.c
@@ -66,11 +66,6 @@ test_modifiers_names(struct xkb_context *context)
     assert(test_real_mod(keymap, XKB_MOD_NAME_MOD4, XKB_MOD_INDEX_MOD4, Mod4Mask));
     assert(test_real_mod(keymap, XKB_MOD_NAME_MOD5, XKB_MOD_INDEX_MOD5, Mod5Mask));
 
-    /* Usual virtual mods mappings */
-    assert(test_real_mod(keymap, XKB_MOD_NAME_ALT,  XKB_MOD_INDEX_MOD1, Mod1Mask));
-    assert(test_real_mod(keymap, XKB_MOD_NAME_NUM,  XKB_MOD_INDEX_MOD2, Mod2Mask));
-    assert(test_real_mod(keymap, XKB_MOD_NAME_LOGO, XKB_MOD_INDEX_MOD4, Mod4Mask));
-
     /* Virtual modifiers
      * The indexes depends on the keymap files */
     assert(test_virtual_mod(keymap, XKB_VMOD_NAME_ALT,    XKB_MOD_INDEX_MOD5 + 2,  Mod1Mask));


### PR DESCRIPTION
We should not keep them forever. 2 releases after deprecation should give enough time to migrate.