### PR TITLE
actions: Add VoidAction(), mirroring NoSymbol/VoidSymbol.

### DIFF
--- a/changes/api/622.feature.md
+++ b/changes/api/622.feature.md
@@ -1,0 +1,5 @@
+Added `VoidAction()` action to match the keysym pair `NoSymbol`/`VoidSymbol`.
+It enables erasing a previous action and breaks latches.
+
+This is a libxkbcommon extension. When serializing it will be converted to
+`LockControls(controls=none,affect=neither)` for backward compatibility.

--- a/doc/keymap-format-text-v1.md
+++ b/doc/keymap-format-text-v1.md
@@ -2555,16 +2555,17 @@ In order to define and use a modifier, one must:
 
 The following table provide an overview of the available actions:
 
-| Category | Action              | Alias            | Description                        |
+| Category | Action name         | Alias            | Description                        |
 |----------|---------------------|------------------|------------------------------------|
-|          | `NoAction`          |                  | Do nothing.                        |
-| [Modifier action] | `SetMods`           |                  | Modifies the _depressed_ modifiers |
+| [Ineffectual action] | [`NoAction`][no-action]|   | **Default action**: *implicitly* do nothing. |
+| ^        | [`VoidAction`][void-action]|           | *Explicitly* do nothing.           |
+| [Modifier action] | `SetMods`  |                  | Modifies the _depressed_ modifiers |
 | ^        | `LatchMods`         |                  | Modifies the _latched_ modifiers   |
 | ^        | `LockMods`          |                  | Modifies the _locked_ modifiers    |
-| [Group action] | `SetGroup`          |                  | <span class="todo">TODO</span> |
+| [Group action] | `SetGroup`    |                  | <span class="todo">TODO</span> |
 | ^        | `LatchGroup`        |                  | <span class="todo">TODO</span> |
 | ^        | `LockGroup`         |                  | <span class="todo">TODO</span> |
-| [Legacy action] | `MovePointer`       | `MovePtr`        | <span class="todo">TODO</span> |
+| [Legacy action] | `MovePointer`| `MovePtr`        | <span class="todo">TODO</span> |
 | ^        | `PointerButton`     | `PtrBtn`         | <span class="todo">TODO</span> |
 | ^        | `LockPointerButton` | `LockPtrBtn`     | <span class="todo">TODO</span> |
 | ^        | `SetPointerDefault` | `SetPtrDflt`     | <span class="todo">TODO</span> |
@@ -2574,10 +2575,35 @@ The following table provide an overview of the available actions:
 | ^        | `SwitchScreen`      |                  | <span class="todo">TODO</span> |
 | ^        | `Private`           |                  | <span class="todo">TODO</span> |
 
+[no-action]: @ref no-action
+[void-action]: @ref void-action
+
 Common syntax:
 - Boolean values:
   - `true`, `yes`, `on`
   - `false`, `no`, `off`
+
+### Ineffectual actions {#ineffectual-actions}
+
+[ineffectual action]: @ref ineffectual-actions
+
+<dl>
+<dt>`NoAction` @anchor no-action</dt>
+<dd>
+**Default action**: *implicitly* do nothing.
+Does *not* override previous actions and is dropped.
+</dd>
+<dt>`VoidAction` @anchor void-action</dt>
+<dd>
+*Explicitly* do nothing.
+*Does* override previous actions and is not dropped.
+
+@note This is a libxkbcommon *extension*. In order to maintain backward-compatibility,
+it serializes to `LockControls(controls=none,affect=neither)`.
+
+@since 1.10.0
+</dd>
+</dl>
 
 ### Modifiers actions {#modifiers-actions}
 

--- a/src/keymap-priv.c
+++ b/src/keymap-priv.c
@@ -147,12 +147,13 @@ action_equal(const union xkb_action *a, const union xkb_action *b)
         return false;
 
     /* Ensure we support all action types */
-    static_assert(ACTION_TYPE_INTERNAL == 16 &&
+    static_assert(ACTION_TYPE_INTERNAL == 17 &&
                   ACTION_TYPE_INTERNAL + 1 == _ACTION_TYPE_NUM_ENTRIES,
                   "Missing action type");
 
     switch (a->type) {
     case ACTION_TYPE_NONE:
+    case ACTION_TYPE_VOID:
         return true;
     case ACTION_TYPE_MOD_SET:
     case ACTION_TYPE_MOD_LATCH:

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -77,6 +77,7 @@ static_assert(_XKB_MOD_INDEX_NUM_ENTRIES == 8, "Invalid X11 core modifiers");
 
 enum xkb_action_type {
     ACTION_TYPE_NONE = 0,
+    ACTION_TYPE_VOID, /* libxkbcommon extension */
     ACTION_TYPE_MOD_SET,
     ACTION_TYPE_MOD_LATCH,
     ACTION_TYPE_MOD_LOCK,

--- a/src/state.c
+++ b/src/state.c
@@ -301,6 +301,7 @@ xkb_action_breaks_latch(const union xkb_action *action,
 {
     switch (action->type) {
     case ACTION_TYPE_NONE:
+    case ACTION_TYPE_VOID:
     case ACTION_TYPE_PTR_BUTTON:
     case ACTION_TYPE_PTR_LOCK:
     case ACTION_TYPE_CTRL_SET:

--- a/src/text.c
+++ b/src/text.c
@@ -138,6 +138,7 @@ const LookupEntry useModMapValueNames[] = {
 
 const LookupEntry actionTypeNames[] = {
     { "NoAction", ACTION_TYPE_NONE },
+    { "VoidAction", ACTION_TYPE_VOID },
     { "SetMods", ACTION_TYPE_MOD_SET },
     { "LatchMods", ACTION_TYPE_MOD_LATCH },
     { "LockMods", ACTION_TYPE_MOD_LOCK },

--- a/src/xkbcomp/action.c
+++ b/src/xkbcomp/action.c
@@ -709,6 +709,7 @@ typedef bool (*actionHandler)(struct xkb_context *ctx,
 
 static const actionHandler handleAction[_ACTION_TYPE_NUM_ENTRIES] = {
     [ACTION_TYPE_NONE] = HandleNoAction,
+    [ACTION_TYPE_VOID] = HandleNoAction,
     [ACTION_TYPE_MOD_SET] = HandleSetLatchLockMods,
     [ACTION_TYPE_MOD_LATCH] = HandleSetLatchLockMods,
     [ACTION_TYPE_MOD_LOCK] = HandleSetLatchLockMods,

--- a/src/xkbcomp/keymap-dump.c
+++ b/src/xkbcomp/keymap-dump.c
@@ -489,6 +489,18 @@ write_action(struct xkb_keymap *keymap, struct buf *buf,
         write_buf(buf, "%sNoAction()%s", prefix, suffix);
         break;
 
+    case ACTION_TYPE_VOID:
+        /*
+         * VoidAction() is a libxkbcommon extension.
+         * Use LockControls as a backward-compatible fallback.
+         * We cannot serialize it to `NoAction()`, as it would be dropped in
+         * e.g. the context of multiple actions.
+         * We better not use `Private` either, because it could still be
+         * interpreted by X11.
+         */
+        write_buf(buf, "%sLockControls(controls=none,affect=neither)%s", prefix, suffix);
+        break;
+
     default:
         write_buf(buf,
                   "%s%s(type=0x%02x,data[0]=0x%02x,data[1]=0x%02x,data[2]=0x%02x,data[3]=0x%02x,data[4]=0x%02x,data[5]=0x%02x,data[6]=0x%02x)%s",

--- a/test/buffercomp.c
+++ b/test/buffercomp.c
@@ -1507,6 +1507,25 @@ test_unicode_keysyms(struct xkb_context *ctx, bool update_output_files)
 }
 
 static void
+test_void_action(struct xkb_context *ctx, bool update_output_files)
+{
+    const char keymap_str[] =
+        "xkb_keymap {\n"
+        "  xkb_keycodes { <> = 1; };\n"
+        "  xkb_symbols {\n"
+        /* Check that we can overwrite NoAction, but not the contrary */
+        "   key <> { [NoAction()] };\n"
+        "   key <> { [VoidAction()] };\n"
+        "   key <> { [NoAction()] };\n"
+        "  };\n"
+        "};";
+    assert(test_compile_output(ctx, compile_buffer, NULL, __func__,
+                               keymap_str, sizeof(keymap_str),
+                               GOLDEN_TESTS_OUTPUTS "voidaction",
+                               update_output_files));
+}
+
+static void
 test_prebuilt_keymap_roundtrip(struct xkb_context *ctx, bool update_output_files)
 {
     /* Load in a prebuilt keymap, make sure we can compile it from memory,
@@ -1588,6 +1607,7 @@ main(int argc, char *argv[])
     test_empty_compound_statements(ctx, update_output_files);
     test_escape_sequences(ctx, update_output_files);
     test_unicode_keysyms(ctx, update_output_files);
+    test_void_action(ctx, update_output_files);
     test_prebuilt_keymap_roundtrip(ctx, update_output_files);
     test_keymap_from_rules(ctx);
 

--- a/test/data/keymaps/symbols-multi-actions.xkb
+++ b/test/data/keymaps/symbols-multi-actions.xkb
@@ -211,32 +211,32 @@ xkb_symbols {
 	key <10>                 {
 		repeat= No,
 		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1), Private(type=0x0f,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) } ]
+		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1), Private(type=0x10,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) } ]
 	};
 	key <11>                 {
 		repeat= No,
 		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [     SetMods(modifiers=Control), {             SetGroup(group=+1), Private(type=0x0f,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) } ]
+		actions[Group1]= [     SetMods(modifiers=Control), {             SetGroup(group=+1), Private(type=0x10,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) } ]
 	};
 	key <12>                 {
 		repeat= No,
 		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, Private(type=0x0f,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) ]
+		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, Private(type=0x10,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) ]
 	};
 	key <13>                 {
 		repeat= No,
 		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, { Private(type=0x0f,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00), Private(type=0x0f,data[0]=0x62,data[1]=0x61,data[2]=0x72,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) } ]
+		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, { Private(type=0x10,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00), Private(type=0x10,data[0]=0x62,data[1]=0x61,data[2]=0x72,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) } ]
 	};
 	key <14>                 {
 		repeat= No,
 		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, Private(type=0x0f,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00), { Private(type=0x0f,data[0]=0x62,data[1]=0x61,data[2]=0x72,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00),     SetMods(modifiers=Control) },                     NoAction() ]
+		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, Private(type=0x10,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00), { Private(type=0x10,data[0]=0x62,data[1]=0x61,data[2]=0x72,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00),     SetMods(modifiers=Control) },                     NoAction() ]
 	};
 	key <15>                 {
 		repeat= No,
 		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, { Private(type=0x0f,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00), Private(type=0x0f,data[0]=0x62,data[1]=0x61,data[2]=0x72,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) },     SetMods(modifiers=Control),                     NoAction() ]
+		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, { Private(type=0x10,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00), Private(type=0x10,data[0]=0x62,data[1]=0x61,data[2]=0x72,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) },     SetMods(modifiers=Control),                     NoAction() ]
 	};
 };
 

--- a/test/data/keymaps/voidaction
+++ b/test/data/keymaps/voidaction
@@ -1,0 +1,30 @@
+xkb_keymap {
+xkb_keycodes {
+	minimum = 1;
+	maximum = 255;
+	<>                   = 1;
+};
+
+xkb_types {
+	type "default" {
+		modifiers= none;
+	};
+};
+
+xkb_compatibility {
+	interpret.useModMapMods= AnyLevel;
+	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
+};
+
+xkb_symbols {
+	key <>                   {
+		repeat= No,
+		symbols[Group1]= [                       NoSymbol ],
+		actions[Group1]= [ LockControls(controls=none,affect=neither) ]
+	};
+};
+
+};

--- a/test/state.c
+++ b/test/state.c
@@ -2599,6 +2599,31 @@ test_multiple_actions(struct xkb_context *ctx)
     xkb_keymap_unref(keymap);
 }
 
+static void
+test_void_action(struct xkb_context *ctx)
+{
+    const char keymap_str[] =
+        "xkb_keymap {\n"
+        "  xkb_keycodes { <> = 1; };\n"
+        "  xkb_symbols  { key <> { [VoidAction()], [VoidAction()] }; };\n"
+        "};";
+    struct xkb_keymap *keymap = test_compile_buffer(ctx, keymap_str,
+                                                    sizeof(keymap_str));
+    assert(keymap);
+    struct xkb_state *state = xkb_state_new(keymap);
+    assert(state);
+
+    xkb_state_update_latched_locked(state, 0x1, 0x1, true, 1, 0, 0, false, 0);
+    assert(xkb_state_serialize_layout(state, XKB_STATE_LAYOUT_EFFECTIVE) == 1);
+    assert(xkb_state_serialize_mods(state, XKB_STATE_MODS_EFFECTIVE) == 0x1);
+    xkb_state_update_key(state, 1, XKB_KEY_DOWN);
+    assert(xkb_state_serialize_layout(state, XKB_STATE_LAYOUT_EFFECTIVE) == 0);
+    assert(xkb_state_serialize_mods(state, XKB_STATE_MODS_EFFECTIVE) == 0);
+
+    xkb_state_unref(state);
+    xkb_keymap_unref(keymap);
+}
+
 int
 main(void)
 {
@@ -2643,6 +2668,7 @@ main(void)
     test_caps_keysym_transformation(context);
     test_leds(context);
     test_multiple_actions(context);
+    test_void_action(context);
 
     xkb_context_unref(context);
     return EXIT_SUCCESS;


### PR DESCRIPTION
Added `VoidAction()` action to match the keysym pair `NoSymbol` / `VoidSymbol`.

It enables erasing a previous action and breaks latches.

This is a libxkbcommon extension. When serializing it will be converted to `LockControls(controls=none,affect=neither)` for backward compatibility. We cannot serialize it to `NoAction()`, as it would be dropped in e.g. the context of multiple actions.

Fixes #622

@mahkoh @Jules-Bertholet 