### PR TITLE
doc: Reformat release notes and include them in the HTML doc

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-libxkbcommon [1.9.2] - 2025-05-07
+libxkbcommon [1.9.2] – 2025-05-07
 =================================
 
 [1.9.2]: https://github.com/xkbcommon/libxkbcommon/tree/xkbcommon-1.9.2
@@ -15,7 +15,7 @@ libxkbcommon [1.9.2] - 2025-05-07
   ([#758](https://github.com/xkbcommon/libxkbcommon/issues/758))
 
 
-libxkbcommon [1.9.1] - 2025-05-02
+libxkbcommon [1.9.1] – 2025-05-02
 =================================
 
 [1.9.1]: https://github.com/xkbcommon/libxkbcommon/tree/xkbcommon-1.9.1
@@ -26,11 +26,10 @@ libxkbcommon [1.9.1] - 2025-05-02
 
 - X11: Fixed capitalization transformation not set properly, resulting in
   some keys (e.g. arrows, Home, etc.) not working when Caps Lock is on.
-
   ([#740](https://github.com/xkbcommon/libxkbcommon/issues/740))
 
 
-libxkbcommon [1.9.0] - 2025-04-26
+libxkbcommon [1.9.0] – 2025-04-26
 =================================
 
 [1.9.0]: https://github.com/xkbcommon/libxkbcommon/tree/xkbcommon-1.9.0
@@ -50,15 +49,14 @@ libxkbcommon [1.9.0] - 2025-04-26
     ```c
     key <> { [a, A, NoSymbol] };
     ```
-  - Compilation with xkbcommon \< 1.9.0:
+  - Compilation with libxkbcommon \< 1.9.0:
     ```c
     key <> {
       type= "FOUR_LEVEL_SEMIALPHABETIC",
       [a, A, NoSymbol, NoSymbol]
     };
     ```
-
-  - Compilation with xkbcommon ≥ 1.9.0:
+  - Compilation with libxkbcommon ≥ 1.9.0:
     ```c
     key <> {
       type= "ALPHABETIC",
@@ -68,12 +66,15 @@ libxkbcommon [1.9.0] - 2025-04-26
 
 ### New
 
-- Added function `xkb_components_names_from_rules()` to compute
+- Added function `xkb_components_names_from_rules()` to compute<!--!
+  @rawHtml -->
   <abbr title="Keycodes, Compatibility, Geometry, Symbols, Types">KcCGST</abbr>
   keymap components from
   <abbr title="Rules, Model, Layout, Variant, Options">RMLVO</abbr> names resolution.
-  This mainly for *debugging* purposes and to enable the `--kccgst` option in the tools.
-  ([#669](https://github.com/xkbcommon/libxkbcommon/issues/669))
+  <!--! @endRawHtml -->
+
+  This mainly for *debugging* purposes and to enable the `--kccgst` option in
+  the tools. ([#669](https://github.com/xkbcommon/libxkbcommon/issues/669))
 - Added the following *wild cards* to the **rules** file syntax, in addition to
   the current `*` legacy wild card:
   - `<none>`: Match *empty* value.
@@ -84,8 +85,8 @@ libxkbcommon [1.9.0] - 2025-04-26
   section is now legal. The missing components will still be serialized explicitly
   in order to maintain backward compatibility.
 - Added support for further empty compound statements:
-  - `xkb_types`: `type \"xxx\" {};`
-  - `xkb_compat`: `interpret x {};` and `indicator \"xxx\" {};`.
+  - `xkb_types`: `type "xxx" {};`
+  - `xkb_compat`: `interpret x {};` and `indicator "xxx" {};`.
 
   Such statements are initialized using the current defaults, i.e. the
   factory implicit defaults or some explicit custom defaults (e.g.
@@ -102,13 +103,13 @@ libxkbcommon [1.9.0] - 2025-04-26
   ([#552](https://github.com/xkbcommon/libxkbcommon/issues/552))
 - `xkb_utf32_to_keysym`: Allow [Unicode noncharacters].
   ([#715](https://github.com/xkbcommon/libxkbcommon/issues/715))
-- `xkb_keysym_from_name`:
+- `xkb_keysym_from_name()`:
   - Unicode format `UNNNN`: allow control characters C0 and C1 and use
-    `xkb_utf32_to_keysym` for the conversion when `NNNN < 0x100`, for
+    `xkb_utf32_to_keysym()` for the conversion when `NNNN < 0x100`, for
     backward compatibility.
   - Numeric hexadecimal format `0xNNNN`: *unchanged*. Contrary to the Unicode
     format, it does not normalize any keysym values in order to enable roundtrip
-    with `xkb_keysym_get_name`.
+    with `xkb_keysym_get_name()`.
 
   [Unicode noncharacters]: https://en.wikipedia.org/wiki/Universal_Character_Set_characters#Noncharacters
 
@@ -129,8 +130,8 @@ libxkbcommon [1.9.0] - 2025-04-26
   - An empty string `""` denotes the keysym `NoSymbol`.
 - Enable displaying bidirectional text in XKB files using the following Unicode
   code points, wherever a white space can be used:
-  - U+200E LEFT-TO-RIGHT MARK
-  - U+200F RIGHT-TO-LEFT MARK
+  - `U+200E` LEFT-TO-RIGHT MARK
+  - `U+200F` RIGHT-TO-LEFT MARK
 
 ### Fixes
 
@@ -185,16 +186,21 @@ libxkbcommon [1.9.0] - 2025-04-26
 
 ### New
 
-- `xkbcli compile-keymap`: Added `--kccgst` option to display the result of
-  <abbr title="Rules, Model, Layout, Variant, Options">RMLVO</abbr> names resolution to
-  <abbr title="Keycodes, Compatibility, Geometry, Symbols, Types">KcCGST</abbr> components.
+- `xkbcli compile-keymap`: Added `--kccgst` option to display the result of<!--!
+  @rawHtml -->
+  <abbr title="Rules, Model, Layout, Variant, Options">RMLVO</abbr>
+  names resolution to
+  <abbr title="Keycodes, Compatibility, Geometry, Symbols, Types">KcCGST</abbr>
+  components.
+  <!--! @endRawHtml -->
 
   This option has the same function than `setxkbmap -print`. This is particularly
-  useful for debugging issues with the rules. ([#669](https://github.com/xkbcommon/libxkbcommon/issues/669))
+  useful for debugging issues with the rules.
+  ([#669](https://github.com/xkbcommon/libxkbcommon/issues/669))
 - Honor user locale in all tools.
 
 
-libxkbcommon [1.8.1] - 2025-03-12
+libxkbcommon [1.8.1] – 2025-03-12
 =================================
 
 [1.8.1]: https://github.com/xkbcommon/libxkbcommon/tree/xkbcommon-1.8.1
@@ -226,10 +232,11 @@ libxkbcommon [1.8.1] - 2025-03-12
 ### New
 
 - Source files are now annotated with SPDX short license identifiers.
-  The LICENSE file was updated to accommodate this. ([#628](https://github.com/xkbcommon/libxkbcommon/issues/628))
+  The LICENSE file was updated to accommodate this.
+  ([#628](https://github.com/xkbcommon/libxkbcommon/issues/628))
 
 
-libxkbcommon [1.8.0] - 2025-02-04
+libxkbcommon [1.8.0] – 2025-02-04
 =================================
 
 [1.8.0]: https://github.com/xkbcommon/libxkbcommon/tree/xkbcommon-1.8.0
@@ -299,7 +306,7 @@ libxkbcommon [1.8.0] - 2025-02-04
   ([#486](https://github.com/xkbcommon/libxkbcommon/issues/486))
 
 - Updated keysyms using latest [xorgproto]
-  (commit: `d7ea44d5f04cc476dee83ef439a847172f7a6bd1`):
+  \(commit: `d7ea44d5f04cc476dee83ef439a847172f7a6bd1`):
 
     Additions:
 
@@ -372,7 +379,7 @@ libxkbcommon [1.8.0] - 2025-02-04
   keymap to a string.
   ([#511](https://github.com/xkbcommon/libxkbcommon/issues/511))
 
-- `xkb_keymap_new_from_names`: Allow only one group per key in symbols sections.
+- `xkb_keymap_new_from_names()`: Allow only one group per key in symbols sections.
   While the original issue was [fixed in `xkeyboard-config`][xkeyboard-config-253]
   project, the previous handling in `libxkbcommon` of extra key groups was deemed
   unintuitive.
@@ -427,13 +434,13 @@ libxkbcommon [1.8.0] - 2025-02-04
 
 - The following functions now allow to query also *virtual* modifiers, so they work
   with *any* modifiers (real *and* virtual):
-  - `xkb_state_mod_index_is_active`
-  - `xkb_state_mod_indices_are_active`
-  - `xkb_state_mod_name_is_active`
-  - `xkb_state_mod_names_are_active`
-  - `xkb_state_mod_index_is_consumed`
-  - `xkb_state_mod_index_is_consumed2`
-  - `xkb_state_mod_mask_remove_consumed`
+  - `xkb_state_mod_index_is_active()`
+  - `xkb_state_mod_indices_are_active()`
+  - `xkb_state_mod_name_is_active()`
+  - `xkb_state_mod_names_are_active()`
+  - `xkb_state_mod_index_is_consumed()`
+  - `xkb_state_mod_index_is_consumed2()`
+  - `xkb_state_mod_mask_remove_consumed()`
 
   Warning: they may overmatch in case there are overlappings virtual-to-real
   modifiers mappings.
@@ -494,7 +501,7 @@ libxkbcommon [1.8.0] - 2025-02-04
   ([#481](https://github.com/xkbcommon/libxkbcommon/issues/481))
 
 
-libxkbcommon [1.7.0] - 2024-03-24
+libxkbcommon [1.7.0] – 2024-03-24
 =================================
 
 [1.7.0]: https://github.com/xkbcommon/libxkbcommon/tree/xkbcommon-1.7.0
@@ -509,7 +516,8 @@ API
 
 ### Fixes
 
-- Updated keysyms using latest [xorgproto] (commit: `cd33097fc779f280925c6d6bbfbd5150f93ca5bc`):
+- Updated keysyms using latest [xorgproto]
+  \(commit: `cd33097fc779f280925c6d6bbfbd5150f93ca5bc`):
 
   For the sake of compatibility, this reintroduces some deleted keysyms and
   postpones the effective deprecation of others, that landed in xkbcommon 1.6.0.
@@ -569,9 +577,9 @@ API
   Contributed by Mikhail Gusarov.
 
 - Rules: Fixed a bug where variant indexes were ignored with the layout index
-  used instead. They are practically always the same, but don't have to be.
+  used instead. They are practically always the same, but don’t have to be.
 
-  Contributed by @wysiwys.
+  Contributed by \@wysiwys.
 
 - Compose: Fixed a segfault with `xkb_compose_table_iterator_next` when used on an
   empty table.
@@ -611,7 +619,7 @@ Build system
 
 - Documentation is no longer built by default; it requires `-Denable-docs=true`.
 
-libxkbcommon 1.6.0 - 2023-10-08
+libxkbcommon 1.6.0 – 2023-10-08
 ==================
 
 API
@@ -632,12 +640,12 @@ API
 
 - Add Compose iterator API to iterate the entries in a compose table:
 
-  - `xkb_compose_table_entry_sequence`
-  - `xkb_compose_table_entry_keysym`
-  - `xkb_compose_table_entry_utf8`
-  - `xkb_compose_table_iterator_new`
-  - `xkb_compose_table_iterator_free`
-  - `xkb_compose_table_iterator_next`
+  - `xkb_compose_table_entry_sequence()`
+  - `xkb_compose_table_entry_keysym()`
+  - `xkb_compose_table_entry_utf8()`
+  - `xkb_compose_table_iterator_new()`
+  - `xkb_compose_table_iterator_free()`
+  - `xkb_compose_table_iterator_next()`
 
 - *Structured log messages* with a message registry. There is an *ongoing* work
   to assign unique identifiers to log messages and add a corresponding error
@@ -666,7 +674,8 @@ API
 - Add support for `modifier_map None { … }`. This feature is missing compared to
   the X11 implementation. It allows to reset the modifier map of a key.
 
-- Update keysyms using latest [xorgproto] (commit: `1c8128d72df22843a2022576850bc5ab5e3a46ea`):
+- Update keysyms using latest [xorgproto]
+  \(commit: `1c8128d72df22843a2022576850bc5ab5e3a46ea`):
 
   - Additions:
 
@@ -765,7 +774,7 @@ Build system
 
 - Improve Windows compilation.
 
-libxkbcommon 1.5.0 - 2023-01-02
+libxkbcommon 1.5.0 – 2023-01-02
 ==================
 
 - Add `xkb_context` flag `XKB_CONTEXT_NO_SECURE_GETENV` and `rxkb_context` flag
@@ -775,8 +784,8 @@ libxkbcommon 1.5.0 - 2023-01-02
   makes xkbcommon use `getenv()` instead.
 
   This is useful for some clients that have relatively benign capabilities set,
-  like CAP_SYS_NICE, that also want to use e.g. the XKB configuration from the
-  environment and user configs in XDG_CONFIG_HOME.
+  like `CAP_SYS_NICE`, that also want to use e.g. the XKB configuration from the
+  environment and user configs in `$XDG_CONFIG_HOME`.
 
   Contributed by Ronan Pigott.
 
@@ -789,13 +798,13 @@ libxkbcommon 1.5.0 - 2023-01-02
 
 - Fix some issues when including xkbcommon as a meson subproject.
 
-- meson>=0.51 is now required.
+- meson\>=0.51 is now required.
 
 - New API:
-  XKB_CONTEXT_NO_SECURE_GETENV
-  RXKB_CONTEXT_NO_SECURE_GETENV
+  `XKB_CONTEXT_NO_SECURE_GETENV`
+  `RXKB_CONTEXT_NO_SECURE_GETENV`
 
-libxkbcommon 1.4.1 - 2022-05-21
+libxkbcommon 1.4.1 – 2022-05-21
 ==================
 
 - Fix compose sequence overriding (common prefix) not working correctly.
@@ -804,12 +813,12 @@ libxkbcommon 1.4.1 - 2022-05-21
   Contributed by Weng Xuetian.
 
 - Remove various bogus currency sign (particulary Euro and Korean Won) entries
-  from the keysym <-> Unicode mappings. They prevented the real
+  from the keysym ↔ Unicode mappings. They prevented the real
   keysyms/codepoints for these from mapping correctly.
 
   Contributed by Sam Lantinga and Simon Ser.
 
-libxkbcommon 1.4.0 - 2022-02-04
+libxkbcommon 1.4.0 – 2022-02-04
 ==================
 
 - Add `enable-tools` option to Meson build (on by default) to allow disabling
@@ -817,7 +826,7 @@ libxkbcommon 1.4.0 - 2022-02-04
 
   Contributed by Alex Xu (Hello71).
 
-- In `xkbcli list`, fix "YAML Norway problem" in output.
+- In `xkbcli list`, fix “YAML Norway problem” in output.
 
   Contributed by Peter Hutterer.
 
@@ -826,7 +835,7 @@ libxkbcommon 1.4.0 - 2022-02-04
 
   Contributed by M Hickford.
 
-- In libxkbregistry, don't call `xmlCleanupParser()` - it's not supposed to
+- In libxkbregistry, don’t call `xmlCleanupParser()` - it’s not supposed to
   be called by libraries.
 
   Contributed by Peter Hutterer.
@@ -835,7 +844,7 @@ libxkbcommon 1.4.0 - 2022-02-04
 
   Contributed by Peter Hutterer.
 
-libxkbcommon 1.3.1 - 2021-09-10
+libxkbcommon 1.3.1 – 2021-09-10
 ==================
 
 - In `xkbcli interactive-x11`, use the Esc keysym instead of the Esc keycode
@@ -846,12 +855,12 @@ libxkbcommon 1.3.1 - 2021-09-10
 - In `xkbcli how-to-type`, add `--keysym` argugment for how to type a keysym
   instead of a Unicode codepoint.
 
-- Fix a crash in `xkb_x11_keymap_new_from_device` error handling given some
+- Fix a crash in `xkb_x11_keymap_new_from_device()` error handling given some
   invalid keymaps. Regressed in 1.2.0.
 
   Reported by Zack Weinberg. Tested by Uli Schlachter.
 
-libxkbcommon 1.3.0 - 2021-05-01
+libxkbcommon 1.3.0 – 2021-05-01
 ==================
 
 - Change `xkbcli list` to output YAML, instead of the previous ad-hoc format.
@@ -859,13 +868,13 @@ libxkbcommon 1.3.0 - 2021-05-01
   This allows to more easily process the information in a programmetic way, for
   example
 
-    xkbcli list | yq -r ".layouts[].layout"
+      xkbcli list | yq -r ".layouts[].layout"
 
   Contributed by Peter Hutterer.
 
 - Optimize a certain part of keymap compilation (atom interning).
 
-- Fix segmentation fault in case-insensitive `xkb_keysym_from_name` for certain
+- Fix segmentation fault in case-insensitive `xkb_keysym_from_name()` for certain
   values like the empty string.
 
   Contributed by Isaac Freund.
@@ -883,14 +892,14 @@ libxkbcommon 1.3.0 - 2021-05-01
 
   Contributed by Adrian Perez de Castro.
 
-libxkbcommon 1.2.1 - 2021-04-07
+libxkbcommon 1.2.1 – 2021-04-07
 ==================
 
 - Fix `xkb_x11_keymap_new_from_device()` failing when the keymap contains key
   types with missing level names, like the one used by the `numpad:mac` option
-  in xkeyboard-config. Regressed in 1.2.0.
+  in [xkeyboard-config]. Regressed in 1.2.0.
 
-libxkbcommon 1.2.0 - 2021-04-03
+libxkbcommon 1.2.0 – 2021-04-03
 ==================
 
 - `xkb_x11_keymap_new_from_device()` is much faster. It now performs only 2
@@ -902,7 +911,7 @@ libxkbcommon 1.2.0 - 2021-04-03
 
 - Keysym names of the form `0x12AB` and `U12AB` are parsed more strictly.
   Previously the hexadecimal part was parsed with `strtoul()`, now only up
-  to 8 hexadecimal digits (0-9A-Fa-f) are allowed.
+  to 8 hexadecimal digits (`0-9A-Fa-f`) are allowed.
 
 - Compose files now have a size limit (65535 internal nodes). Further sequences
   are discared and a warning is issued.
@@ -916,48 +925,48 @@ libxkbcommon 1.2.0 - 2021-04-03
 
 - The build now requires a C11 compiler (uses anonymous structs/unions).
 
-libxkbcommon 1.1.0 - 2021-02-27
+libxkbcommon 1.1.0 – 2021-02-27
 ==================
 
 - Publish the `xkb-format-text-v1.md` file in the HTML documentation. This file
   existed for a long time but only in the Git repository.
   Link: https://xkbcommon.org/doc/current/md_doc_keymap_format_text_v1.html
 
-- Add partial documentation for xkb_symbols to xkb-format-text-v1.md.
+- Add partial documentation for `xkb_symbols` to `xkb-format-text-v1.md`.
 
   Contributed by Simon Zeni.
 
 - Update keysym definitions to latest xorgproto. In particular, this adds many
   special keysyms corresponding to Linux evdev keycodes.
 
-  Contributed by Peter Hutterer <@who-t.net>.
+  Contributed by Peter Hutterer <\@who-t.net>.
 
 - New API:
-  Too many XKB_KEY_* definitions to list here.
+  Too many `XKB_KEY_*` definitions to list here.
 
-libxkbcommon 1.0.3 - 2020-11-23
+libxkbcommon 1.0.3 – 2020-11-23
 ==================
 
-- Fix (hopefully) a segfault in xkb_x11_keymap_new_from_device() in some
+- Fix (hopefully) a segfault in `xkb_x11_keymap_new_from_device()` in some
   unclear situation (bug introduced in 1.0.2).
 
-- Fix keymaps created with xkb_x11_keymap_new_from_device() don't have level
+- Fix keymaps created with `xkb_x11_keymap_new_from_device()` don’t have level
   names (bug introduced in 0.8.0).
 
-libxkbcommon 1.0.2 - 2020-11-20
+libxkbcommon 1.0.2 – 2020-11-20
 ==================
 
 - Fix a bug where a keysym that cannot be resolved in a keymap gets compiled to
-  a garbage keysym. Now it is set to XKB_KEY_NoSymbol instead.
+  a garbage keysym. Now it is set to `XKB_KEY_NoSymbol` instead.
 
-- Improve the speed of xkb_x11_keymap_new_from_device() on repeated calls in the
-  same xkb_context().
+- Improve the speed of `xkb_x11_keymap_new_from_device()` on repeated calls in the
+  same `xkb_context()`.
 
 
-libxkbcommon 1.0.1 - 2020-09-11
+libxkbcommon 1.0.1 – 2020-09-11
 ==================
 
-- Fix the tool-option-parsing test failing.
+- Fix the `tool-option-parsing` test failing.
 
 - Remove requirement for pytest in the tool-option-parsing test.
 
@@ -965,29 +974,29 @@ libxkbcommon 1.0.1 - 2020-09-11
 
 - Some portability and test isolation fixes.
 
-libxkbcommon 1.0.0 - 2020-09-05
+libxkbcommon 1.0.0 – 2020-09-05
 ==================
 
-Note: this release is API and ABI compatible with previous releases -- the
+Note: this release is API and ABI compatible with previous releases –the
 major version bump is only an indication of stability.
 
 - Add libxkbregistry as configure-time optional library. libxkbregistry is a C
   library that lists available XKB models, layouts and variants for a given
-  ruleset. This is a separate library (libxkbregistry.so, pkgconfig file
-  xkbregistry.pc) and aimed at tools that provide a listing of available
+  ruleset. This is a separate library (`libxkbregistry.so`, pkgconfig file
+  `xkbregistry.pc`) and aimed at tools that provide a listing of available
   keyboard layouts to the user. See the Documentation for details on the API.
 
-  Contributed by Peter Hutterer <@who-t.net>.
+  Contributed by Peter Hutterer <\@who-t.net>.
 
 - Better support custom user configuration:
 
     * Allow including XKB files from other paths.
 
-      Previously, a 'symbols/us' file in path A would shadow the same file in
+      Previously, a `symbols/us` file in path A would shadow the same file in
       path B. This is suboptimal, we rarely need to hide the system files - we
       care mostly about *extending* them. By continuing to check other lookup
-      paths, we make it possible for a XDG_CONFIG_HOME/xkb/symbols/us file to
-      have sections including those from /usr/share/X11/xkb/symbols/us.
+      paths, we make it possible for a `$XDG_CONFIG_HOME/xkb/symbols/us` file to
+      have sections including those from `/usr/share/X11/xkb/symbols/us`.
 
       Note that this is not possible for rules files, which need to be manually
       controlled to get the right bits resolved.
@@ -996,110 +1005,107 @@ major version bump is only an indication of stability.
 
       This completes the usual triplet of configuration locations available for
       most processes:
-      - vendor-provided data files in /usr/share/X11/xkb
-      - system-specific data files in /etc/xkb
-      - user-specific data files in $XDG_CONFIG_HOME/xkb
+      - vendor-provided data files in `/usr/share/X11/xkb`
+      - system-specific data files in `/etc/xkb`
+      - user-specific data files in `$XDG_CONFIG_HOME/xkb`
 
       The default lookup order user, system, vendor, just like everything else
       that uses these conventions.
 
-      For include directives in rules files, the '%E' resolves to that path.
+      For include directives in rules files, the `%E` resolves to that path.
 
     * Add a new section to the documentation for custom user configuration.
 
-  Contributed by Peter Hutterer <@who-t.net>.
+  Contributed by Peter Hutterer <\@who-t.net>.
 
 - Add an `xkbcli` command-line utility.
 
   This tool offers various subcommands for introspection and debugging.
   Currently the available subcommands are:
 
-  list
-    List available rules, models, layouts, variants and options
-
-  interactive-wayland
-    Interactive debugger for XKB keymaps for Wayland
-
-  interactive-x11
-    Interactive debugger for XKB keymaps for X11
-
-  interactive-evdev
-    Interactive debugger for XKB keymaps for evdev (Linux)
-
-  compile-keymap
-    Compile an XKB keymap
-
-  how-to-type
-    See separate entry below.
+  <dl>
+  <dt>list</dt>
+  <dd>List available rules, models, layouts, variants and options</dd>
+  <dt>interactive-wayland</dt>
+  <dd>Interactive debugger for XKB keymaps for Wayland</dd>
+  <dt>interactive-x11</dt>
+  <dd>Interactive debugger for XKB keymaps for X11</dd>
+  <dt>interactive-evdev</dt>
+  <dd>Interactive debugger for XKB keymaps for evdev (Linux)</dd>
+  <dt>compile-keymap</dt>
+  <dd>Compile an XKB keymap</dd>
+  <dt>how-to-type</dt>
+  <dd>See separate entry below.</dd>
+  </dl>
 
   See the manpages for usage information.
 
-  Contributed by Peter Hutterer <@who-t.net>.
+  Contributed by Peter Hutterer <\@who-t.net>.
 
 - Add `xkb_utf32_to_keysym()` to translate a Unicode codepoint to a keysym.
   When a special keysym (`XKB_KEY_` constant) for the codepoint exists, it is
   returned, otherwise the direct encoding is used, if permissible.
 
-  Contributed by Jaroslaw Kubik <@froglogic.com>.
+  Contributed by Jaroslaw Kubik <\@froglogic.com>.
 
 - Add `xkb_keymap_key_get_mods_for_level()` which retrieves sets of modifiers
   which produce a given shift level in a given key+layout.
 
-  Contributed by Jaroslaw Kubik <@froglogic.com>.
+  Contributed by Jaroslaw Kubik <\@froglogic.com>.
 
 - Add `xkbcli how-to-type` command, which, using `xkb_utf32_to_keysym()`
   and `xkb_keymap_key_get_mods_for_level()` and other APIs, prints out all
   the ways to produce a given keysym.
 
-  For example, how to type `?` (codepoint 63) in a us,de keymap?
+  For example, how to type `?` (codepoint 63) in a `us,de` keymap?
 
-    $ xkbcli how-to-type --layout us,de 63 | column -ts $'\t'
-    keysym: question (0x3f)
-    KEYCODE  KEY NAME  LAYOUT#  LAYOUT NAME   LEVEL#  MODIFIERS
-    20       AE11      2        German        2       [ Shift ]
-    20       AE11      2        German        2       [ Shift Lock ]
-    61       AB10      1        English (US)  2       [ Shift ]
+      $ xkbcli how-to-type --layout us,de 63 | column -ts $'\t'
+      keysym: question (0x3f)
+      KEYCODE  KEY NAME  LAYOUT#  LAYOUT NAME   LEVEL#  MODIFIERS
+      20       AE11      2        German        2       [ Shift ]
+      20       AE11      2        German        2       [ Shift Lock ]
+      61       AB10      1        English (US)  2       [ Shift ]
 
 - Add a new section to the documentation describing the format of the XKB
   rules file.
 
-- Search for Compose in $XDG_CONFIG_HOME/XCompose (fallback to
-  ~/.config/XCompose) before trying $HOME/.XCompose.
+- Search for Compose in `$XDG_CONFIG_HOME/XCompose` (fallback to
+  `~/.config/XCompose`) before trying `$HOME/.XCompose`.
 
-  Note that libX11 still only searches in $HOME/.XCompose.
+  Note that libX11 still only searches in `$HOME/.XCompose`.
 
-  Contributed by Emmanuel Gil Peyrot <@linkmauve.fr>.
+  Contributed by Emmanuel Gil Peyrot <\@linkmauve.fr>.
 
-- Bump meson requirement to >= 0.49.0.
+- Bump meson requirement to \>= 0.49.0.
 
 - Fix build with byacc.
 
 - Fix building X11 tests on PE targets.
 
-  Contributed by Jon Turney <@dronecode.org.uk>
+  Contributed by Jon Turney <\@dronecode.org.uk>
 
 - The tests no longer rely on bash, only Python (which is already used by
   meson).
 
 - New API:
-  xkb_utf32_to_keysym
-  xkb_keymap_key_get_mods_for_level
-  XKB_KEY_XF86FullScreen
+  `xkb_utf32_to_keysym`
+  `xkb_keymap_key_get_mods_for_level`
+  `XKB_KEY_XF86FullScreen`
 
 
-libxkbcommon 0.10.0 - 2020-01-18
+libxkbcommon 0.10.0 – 2020-01-18
 ===================
 
 - (security) Fix quadratic complexity in the XKB file parser. See commit
   message 7c42945e04a2107827a057245298dedc0475cc88 for details.
 
-- Add $XDG_CONFIG_HOME/xkb to the default search path. If $XDG_CONFIG_HOME
-  is not set, $HOME/.config/xkb is used. If $HOME is not set, the path is not
+- Add `$XDG_CONFIG_HOME/xkb` to the default search path. If `$XDG_CONFIG_HOME`
+  is not set, `$HOME/.config/xkb` is used. If `$HOME` is not set, the path is not
   added.
 
   The XDG path is looked up before the existing default search path $HOME/.xkb.
 
-  Contributed by Peter Hutterer <@who-t.net>.
+  Contributed by Peter Hutterer <\@who-t.net>.
 
 - Add support for include statements in XKB rules files.
 
@@ -1110,15 +1116,15 @@ libxkbcommon 0.10.0 - 2020-01-18
 
       ! include %S/evdev
 
-  Two directives are supported, %H to $HOME and %S for the system-installed
-  rules directory (usually /usr/share/X11/xkb/rules).
+  Two directives are supported, `%H` to `$HOME` and `%S` for the system-installed
+  rules directory (usually `/usr/share/X11/xkb/rules`).
 
   See commit message ca033a29d2ca910fd17b1ae287cb420205bdddc8 and
   doc/rules-format.txt in the xkbcommon source code for more information.
 
-  Contributed by Peter Hutterer <@who-t.net>.
+  Contributed by Peter Hutterer <\@who-t.net>.
 
-- Downgrade "Symbol added to modifier map for multiple modifiers" log to a
+- Downgrade “Symbol added to modifier map for multiple modifiers” log to a
   warning.
 
   This error message was too annoying to be shown by default. When working on
@@ -1127,7 +1133,7 @@ libxkbcommon 0.10.0 - 2020-01-18
 
 - Support building on Windows using the meson MSVC backend.
 
-  Contributed by Adrian Perez de Castro <@igalia.com>.
+  Contributed by Adrian Perez de Castro <\@igalia.com>.
 
 - Fix bug where the merge mode only applied to the first vmod in a
   `virtual_modifiers` statement. Given
@@ -1150,54 +1156,54 @@ libxkbcommon 0.10.0 - 2020-01-18
 
       interpret ISO_Level3_Shift+AnyOf(all,extraneous) { ... };
 
-  Previously, extraneous (and further) was ignored. Now it's rejected.
+  Previously, extraneous (and further) was ignored. Now it’s rejected.
 
 - Correctly handle capitalization of the ssharp keysym.
 
 - Speed up and improve the internal `xkeyboard-config` tool. This tool
-  compiles all layout/variant combinations in the xkeyboard-config dataset
+  compiles all layout/variant combinations in the [xkeyboard-config] dataset
   and reports any issues it finds.
 
-  Contributed by Peter Hutterer <@who-t.net>.
+  Contributed by Peter Hutterer <\@who-t.net>.
 
-- Speed up "atoms" (string interning). This code goes back at least to X11R1
+- Speed up “atoms” (string interning). This code goes back at least to X11R1
   (released 1987).
 
 
-libxkbcommon 0.9.1 - 2019-10-19
+libxkbcommon 0.9.1 – 2019-10-19
 ==================
 
 - Fix context creation failing when run in privileged processes as defined by
   `secure_getenv(3)`, e.g. GDM.
 
 
-libxkbcommon 0.9.0 - 2019-10-19
+libxkbcommon 0.9.0 – 2019-10-19
 ==================
 
-- Move ~/.xkb to before XKB_CONFIG_ROOT (the system XKB path, usually
-  /usr/share/X11/xkb) in the default include path. This enables the user
+- Move `~/.xkb` to before `XKB_CONFIG_ROOT` (the system XKB path, usually
+  `/usr/share/X11/xkb`) in the default include path. This enables the user
   to have full control of the keymap definitions, instead of only augmenting
   them.
 
 - Remove the Autotools build system. Use the meson build system instead.
 
 - Fix invalid names used for levels above 8 when dumping keymaps. Previously,
-  e.g. "Level20" was dumped, but only up to "Level8" is accepted by the
-  parser. Now "20" is dumped.
+  e.g. `Level20` was dumped, but only up to `Level8` is accepted by the
+  parser. Now `20` is dumped.
 
-- Change level references to always be dumped as e.g. "5" instead of "Level5".
+- Change level references to always be dumped as e.g. `5` instead of `Level5`.
 
-  Change group references to always be dumped capitalized e.g. "Group3" instead
-  of "group3". Previously it was inconsistent.
+  Change group references to always be dumped capitalized e.g. `Group3` instead
+  of `group3`. Previously it was inconsistent.
 
-  These changes affect the output of xkb_keymap_get_as_string().
+  These changes affect the output of `xkb_keymap_get_as_string()`.
 
 - Fix several build issues on macOS/Darwin, Solaris, NetBSD, cross compilation.
 
-- Port the interactive-wayland test program to the stable version of xdg-shell.
+- Port the `interactive-wayland` test program to the stable version of `xdg-shell`.
 
 
-libxkbcommon 0.8.4 - 2019-02-22
+libxkbcommon 0.8.4 – 2019-02-22
 ==================
 
 - Fix build of xkbcommon-x11 static library with meson.
@@ -1205,18 +1211,18 @@ libxkbcommon 0.8.4 - 2019-02-22
 - Fix building using meson from the tarball generated by autotools.
 
 
-libxkbcommon 0.8.3 - 2019-02-08
+libxkbcommon 0.8.3 – 2019-02-08
 ==================
 
 - Fix build of static libraries with meson.
   (Future note: xkbcommon-x11 was *not* fixed in this release.)
 
 - New API:
-  XKB_KEY_XF86MonBrightnessCycle
-  XKB_KEY_XF86RotationLockToggle
+  `XKB_KEY_XF86MonBrightnessCycle`
+  `XKB_KEY_XF86RotationLockToggle`
 
 
-libxkbcommon 0.8.2 - 2018-08-05
+libxkbcommon 0.8.2 – 2018-08-05
 ==================
 
 - Fix various problems found with fuzzing (see commit messages for
@@ -1226,7 +1232,7 @@ libxkbcommon 0.8.2 - 2018-08-05
       in the XKB text format parser.
 
 
-libxkbcommon 0.8.1 - 2018-08-03
+libxkbcommon 0.8.1 – 2018-08-03
 ==================
 
 - Fix various problems found in the meson build (see commit messages for more
@@ -1237,7 +1243,7 @@ libxkbcommon 0.8.1 - 2018-08-03
     - Fix compilation of the x11 tests and demos when XCB is installed in a
       non-standard location.
 
-    - Fix xkbcommon-x11.pc missing the Requires specification.
+    - Fix `xkbcommon-x11.pc` missing the Requires specification.
 
 - Fix various problems found with fuzzing and Coverity (see commit messages for
   more details):
@@ -1249,42 +1255,43 @@ libxkbcommon 0.8.1 - 2018-08-03
       tokens appear (the tokens are still parsed for backward compatibility).
 
     - Fix NULL-dereference in the XKB text format parser when parsing an
-      xkb_geometry section.
+      `xkb_geometry` section.
 
     - Fix an infinite loop in the Compose text format parser on some inputs.
 
-    - Fix an invalid free() when using multiple keysyms.
+    - Fix an invalid `free()` when using multiple keysyms.
 
 - Replace the Unicode characters for the leftanglebracket and rightanglebracket
   keysyms from the deprecated LEFT/RIGHT-POINTING ANGLE BRACKET to
   MATHEMATICAL LEFT/RIGHT ANGLE BRACKET.
 
-- Reject out-of-range Unicode codepoints in xkb_keysym_to_utf8 and
-  xkb_keysym_to_utf32.
+- Reject out-of-range Unicode codepoints in `xkb_keysym_to_utf8()` and
+  `xkb_keysym_to_utf32()`.
 
 
-libxkbcommon 0.8.0 - 2017-12-15
+libxkbcommon 0.8.0 – 2017-12-15
 ==================
 
-- Added xkb_keysym_to_{upper,lower} to perform case-conversion directly on
+- Added `xkb_keysym_to_{upper,lower}` to perform case-conversion directly on
   keysyms. This is useful in some odd cases, but working with the Unicode
   representations should be preferred when possible.
 
-- Added Unicode conversion rules for the signifblank and permille keysyms.
+- Added Unicode conversion rules for the `signifblank` and `permille` keysyms.
 
 - Fixed a bug in the parsing of XKB key type definitions where the number
   of levels were determined by the number of level *names*. Keymaps which
   omit level names were hence miscompiled.
 
-  This regressed in version 0.4.3. Keymaps from xkeyboard-config were not
-  affected since they don't omit level names.
+  This regressed in version 0.4.3. Keymaps from [xkeyboard-config] were not
+  affected since they don’t omit level names.
 
 - New API:
-  xkb_keysym_to_upper()
-  xkb_keysym_to_lower()
+  `xkb_keysym_to_upper()`
+  `xkb_keysym_to_lower()`
 
+[xkeyboard-config]: https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/
 
-libxkbcommon 0.7.2 - 2017-08-04
+libxkbcommon 0.7.2 – 2017-08-04
 ==================
 
 - Added a Meson build system as an alternative to existing autotools build
@@ -1294,60 +1301,60 @@ libxkbcommon 0.7.2 - 2017-08-04
   Please try to convert to it and report any problems.
 
   See http://mesonbuild.com/Quick-guide.html for basic usage, the
-  meson_options.txt for the project-specific configuration options,
+  `meson_options.txt` for the project-specific configuration options,
   and the PACKAGING file for more details.
 
   There are some noteworthy differences compared to the autotools build:
 
   - Feature auto-detection is not performed. By default, all features are
-    enabled (currently: docs, x11, wayland). The build fails if any of
+    enabled (currently: `docs`, `x11`, `wayland`). The build fails if any of
     the required dependencies are not available. To disable a feature,
-    pass -Denable-<feature>=false to meson.
+    pass `-Denable-<feature>=false` to meson.
 
   - The libraries are either installed as shared or static, as specified
-    by the -Ddefault_library=shared/static option. With autotools, both
+    by the `-Ddefault_library=shared/static` option. With autotools, both
     versions are installed by default.
 
-  - xorg-util-macros is not used.
+  - `xorg-util-macros` is not used.
 
   - A parser generator (bison/byacc) is always required - there is no
     fallback to pre-generated output bundled in the tarball, as there is
     in autotools.
 
-- Removed Android.mk support.
+- Removed `Android.mk` support.
 
-- Removed the *-uninstalled.pc pkgconfig files.
+- Removed the `*-uninstalled.pc` pkgconfig files.
 
-- Ported the interactive-wayland demo program to v6 of the xdg-shell
+- Ported the `interactive-wayland` demo program to v6 of the `xdg-shell`
   protocol.
 
 - Added new keysym definitions from xproto.
 
 - New API:
-  XKB_KEY_XF86Keyboard
-  XKB_KEY_XF86WWAN
-  XKB_KEY_XF86RFKill
-  XKB_KEY_XF86AudioPreset
+  `XKB_KEY_XF86Keyboard`
+  `XKB_KEY_XF86WWAN`
+  `XKB_KEY_XF86RFKill`
+  `XKB_KEY_XF86AudioPreset`
 
 
-libxkbcommon 0.7.1 - 2017-01-18
+libxkbcommon 0.7.1 – 2017-01-18
 ==================
 
-- Fixed various reported problems when the current locale is tr_TR.UTF-8.
+- Fixed various reported problems when the current locale is `tr_TR.UTF-8`.
 
-  The function xkb_keysym_from_name() used to perform case-insensitive
+  The function `xkb_keysym_from_name()` used to perform case-insensitive
   string comparisons in a locale-dependent way, but required it to to
-  work as in the C/ASCII locale (the so called "Turkish i problem").
+  work as in the C/ASCII locale (the so called “Turkish i problem”).
 
   The function is now no longer affected by the current locale.
 
 - Fixed compilation in NetBSD.
 
 
-libxkbcommon 0.7.0 - 2016-11-11
+libxkbcommon 0.7.0 – 2016-11-11
 ==================
 
-- Added support for different "modes" of calculating consumed modifiers.
+- Added support for different “modes” of calculating consumed modifiers.
   The existing mode, based on the XKB standard, has proven to be
   unintuitive in various shortcut implementations.
 
@@ -1360,25 +1367,25 @@ libxkbcommon 0.7.0 - 2016-11-11
 - Fixed a compilation error on GNU Hurd.
 
 - New API:
-  enum xkb_consumed_mode
-  XKB_CONSUMED_MODE_XKB
-  XKB_CONSUMED_MODE_GTK
-  xkb_state_key_get_consumed_mods2
-  xkb_state_mod_index_is_consumed2
+  `enum xkb_consumed_mode`
+  `XKB_CONSUMED_MODE_XKB`
+  `XKB_CONSUMED_MODE_GTK`
+  `xkb_state_key_get_consumed_mods2()`
+  `xkb_state_mod_index_is_consumed2()`
 
 
-libxkbcommon 0.6.1 - 2016-04-08
+libxkbcommon 0.6.1 – 2016-04-08
 ==================
 
 - Added LICENSE to distributed files in tarball releases.
 
-- Minor typo fix in xkb_keymap_get_as_string() documentation.
+- Minor typo fix in `xkb_keymap_get_as_string()` documentation.
 
 
-libxkbcommon 0.6.0 - 2016-03-16
+libxkbcommon 0.6.0 – 2016-03-16
 ==================
 
-- If the XKB_CONFIG_ROOT environment variable is set, it is used as the XKB
+- If the `XKB_CONFIG_ROOT` environment variable is set, it is used as the XKB
   configuration root instead of the path determined at build time.
 
 - Tests and benchmarks now build correctly on OSX.
@@ -1387,23 +1394,23 @@ libxkbcommon 0.6.0 - 2016-03-16
   these names are limited to at most 4 characters, and are thus somewhat
   obscure, but might still be useful (xkbcommon lifts the 4 character limit).
 
-  The new functions xkb_keymap_key_get_name() and xkb_keymap_key_by_name()
+  The new functions `xkb_keymap_key_get_name()` and `xkb_keymap_key_by_name()`
   can be used to get the name of a key or find a key by name.  Note that
   a key may have aliases.
 
 - Documentation improvements.
 
 - New API:
-  xkb_keymap_key_by_name()
-  xkb_keymap_key_get_name()
+  `xkb_keymap_key_by_name()`
+  `xkb_keymap_key_get_name()`
 
 
-libxkbcommon 0.5.0 - 2014-10-18
+libxkbcommon 0.5.0 – 2014-10-18
 ==================
 
 - Added support for Compose/dead keys in a new module (included in
   libxkbcommon). See the documentation or the
-  xkbcommon/xkbcommon-compose.h header file for more details.
+  `xkbcommon/xkbcommon-compose.h` header file for more details.
 
 - Improved and reordered some sections of the documentation.
 
@@ -1413,17 +1420,17 @@ libxkbcommon 0.5.0 - 2014-10-18
 
 - A warning is emitted by default about RMLVO values which are not used
   during keymap compilation, which are most often a user misconfiguration.
-  For example, "terminate:ctrl_alt_backspace" instead of
-  "terminate:ctrl_alt_bksp".
+  For example, `terminate:ctrl_alt_backspace` instead of
+  `terminate:ctrl_alt_bksp`.
 
 - Added symbol versioning for libxkbcommon and libxkbcommon-x11.
   Note: binaries compiled against this and future versions will not be
   able to link against the previous versions of the library.
 
-- Removed several compatablity symbols from the binary (the API isn't
+- Removed several compatablity symbols from the binary (the API isn’t
   affected). This affects binaries which
 
-  1. Were compiled against a pre-stable (<0.2.0) version of libxkbcommon, and
+  1. Were compiled against a pre-stable (\<0.2.0) version of libxkbcommon, and
   2. Are linked against the this or later version of libxkbcommon.
 
   Such a scenario is likely to fail already.
@@ -1435,31 +1442,31 @@ libxkbcommon 0.5.0 - 2014-10-18
 
 - Build fixes from OpenBSD.
 
-- Fixed a bug where key type entries such as "map[None] = Level2;" were
+- Fixed a bug where key type entries such as `map[None] = Level2;` were
   ignored.
 
 - New API:
-  XKB_COMPOSE_*
-  xkb_compose_*
+  `XKB_COMPOSE_*`
+  `xkb_compose_*`
 
 
-libxkbcommon 0.4.3 - 2014-08-19
+libxkbcommon 0.4.3 – 2014-08-19
 ==================
 
-- Fixed a bug which caused xkb_x11_keymap_new_from_device() to misrepresent
+- Fixed a bug which caused `xkb_x11_keymap_new_from_device()` to misrepresent
   modifiers for some keymaps.
 
   https://github.com/xkbcommon/libxkbcommon/issues/9
 
-- Fixed a bug which caused xkb_x11_keymap_new_from_device() to ignore XKB
-  PrivateAction's.
+- Fixed a bug which caused `xkb_x11_keymap_new_from_device()` to ignore XKB
+  `PrivateAction`’s.
 
-- Modifiers are now always fully resolved after xkb_state_update_mask().
+- Modifiers are now always fully resolved after `xkb_state_update_mask()`.
   Previously the given state components were used as-is, without
   considering virtual modifier mappings.
-  Note: this only affects non-standard uses of xkb_state_update_mask().
+  Note: this only affects non-standard uses of `xkb_state_update_mask()`.
 
-- Added a test for xkbcommon-x11, "x11comp". The test uses the system's
+- Added a test for xkbcommon-x11, `x11comp`. The test uses the system’s
   Xvfb server and xkbcomp. If they do not exist or fail, the test is
   skipped.
 
@@ -1467,13 +1474,13 @@ libxkbcommon 0.4.3 - 2014-08-19
   The fix required changes which are currently incompatible with byacc.
 
 
-libxkbcommon 0.4.2 - 2014-05-15
+libxkbcommon 0.4.2 – 2014-05-15
 ==================
 
-- Fixed a bug where explicitly passing "--enable-x11" to ./configure would
+- Fixed a bug where explicitly passing `--enable-x11` to `./configure` would
   in fact disable it (regressed in 0.4.1).
 
-- Added @since version annotations to the API documentation for everything
+- Added `@since` version annotations to the API documentation for everything
   introduced after the initial stable release (0.2.0).
 
 - Added a section to the documentation about keysym transformations, and
@@ -1484,28 +1491,28 @@ libxkbcommon 0.4.2 - 2014-05-15
   the entire compilation succeeds.
   Note: this was a minor correctness issue inherited from xkbcomp.
 
-- Fix an out-of-bounds array access in src/x11/util.c:adopt_atoms()
+- Fix an out-of-bounds array access in `src/x11/util.c:adopt_atoms()`
   error-handling code.
   Note: it seems impossible to trigger in the current code since the input
   size cannot exceed the required size.
 
 
-libxkbcommon 0.4.1 - 2014-03-27
+libxkbcommon 0.4.1 – 2014-03-27
 ==================
 
 - Converted README to markdown and added a Quick Guide to the
   documentation, which breezes through the most common parts of
   xkbcommon.
 
-- Added two new functions, xkb_state_key_get_utf{8,32}(). They
-  combine the operations of xkb_state_key_get_syms() and
-  xkb_keysym_to_utf{8,32}(), and provide a nicer interface for it
-  (espcially for multiple-keysyms-per-level).
+- Added two new functions, `xkb_state_key_get_utf{8,32}()`. They
+  combine the operations of `xkb_state_key_get_syms()` and
+  `xkb_keysym_to_utf{8,32}()`, and provide a nicer interface for it
+  (especially for multiple-keysyms-per-level).
 
-- The xkb_state_key_get_utf{8,32}() functions now apply Control
+- The `xkb_state_key_get_utf{8,32}()` functions now apply Control
   transformation: when the Control modifier is active, the string
   is converted to an appropriate control character.
-  This matches the behavior of libX11's XLookupString(3), and
+  This matches the behavior of libX11’s `XLookupString(3)`, and
   required by the XKB specification:
   https://www.x.org/releases/current/doc/kbproto/xkbproto.html#Interpreting_the_Control_Modifier
 
@@ -1523,100 +1530,100 @@ libxkbcommon 0.4.1 - 2014-03-27
 - Reduce memory usage during keymap compilation some more.
 
 - New API:
-  xkb_state_key_get_consumed_mods()
-  xkb_state_key_get_utf8()
-  xkb_state_key_get_utf32()
+  `xkb_state_key_get_consumed_mods()`
+  `xkb_state_key_get_utf8()`
+  `xkb_state_key_get_utf32()`
 
 - Deprecated API:
-  XKB_MAP_COMPILE_PLACEHOLDER, XKB_MAP_NO_FLAGS
-    use XKB_KEYMAP_NO_FLAGS instead.
+  `XKB_MAP_COMPILE_PLACEHOLDER,` `XKB_MAP_NO_FLAGS`
+    use `XKB_KEYMAP_NO_FLAGS` instead.
 
 - Bug fixes.
 
 
-libxkbcommon 0.4.0 - 2014-02-02
+libxkbcommon 0.4.0 – 2014-02-02
 ==================
 
-- Add a new add-on library, xkbcommon-x11, to support creating keymaps
+- Add a new add-on library, `xkbcommon-x11`, to support creating keymaps
   with the XKB X11 protocol, by querying the X server directly.
-  See the xkbcommon/xkbcommon-x11.h header file for more details.
-  This library requires libxcb-xkb >= 1.10, and is enabled by default.
-  It can be disabled with the --disable-x11 configure switch.
+  See the `xkbcommon/xkbcommon-x11.h` header file for more details.
+  This library requires `libxcb-xkb >= 1.10`, and is enabled by default.
+  It can be disabled with the `--disable-x11` configure switch.
   Distributions are encouraged to split the necessary files for this
-  library (libxkbcommon-x11.so, xkbcommon-x11.pc, xkbcommon/xkbcommon-x11.h)
+  library (`libxkbcommon-x11.so`, `xkbcommon-x11.pc`, `xkbcommon/xkbcommon-x11.h`)
   to a separate package, such that the main package does not depend on
   X11 libraries.
 
-- Fix the keysym <-> name lookup table to not require huge amounts of
+- Fix the keysym ↔ name lookup table to not require huge amounts of
   relocations.
 
-- Fix a bug in the keysym <-> name lookup, whereby lookup might fail in
+- Fix a bug in the keysym ↔ name lookup, whereby lookup might fail in
   some rare cases.
 
 - Reduce memory usage during keymap compilation.
 
 - New API:
   New keysyms from xproto 7.0.25 (German T3 layout keysyms).
-  XKB_MOD_NAME_NUM for the usual NumLock modifier.
-  xkb_x11_* types and functions, XKB_X11_* constants.
+  `XKB_MOD_NAME_NUM` for the usual NumLock modifier.
+  `xkb_x11_*` types and functions, `XKB_X11_*` constants.
 
 
-libxkbcommon 0.3.2 - 2013-11-22
+libxkbcommon 0.3.2 – 2013-11-22
 ==================
 
-- Log messages from the library now look like "xkbcommon: ERROR" by
-  default, instead of xkbcomp-like "Error:   ".
+- Log messages from the library now look like `xkbcommon: ERROR` by
+  default, instead of xkbcomp-like `Error:   `.
 
 - Apply capitalization transformation on keysyms in
-  xkb_keysym_get_one_sym(), to match the behavior specified in the XKB
+  `xkb_keysym_get_one_sym()`, to match the behavior specified in the XKB
   specification:
   https://www.x.org/releases/current/doc/kbproto/xkbproto.html#Interpreting_the_Lock_Modifier
 
 - Support byacc for generating the parser, in addition to Bison.
 
 - New API:
-  XKB_KEY_XF86AudioMicMute keysym from xproto 7.0.24.
-  XKB_KEYSYM_NO_FLAGS
-  XKB_CONTEXT_NO_FLAGS
-  XKB_MAP_COMPILE_NO_FLAGS
+  `XKB_KEY_XF86AudioMicMute` keysym from xproto 7.0.24.
+  `XKB_KEYSYM_NO_FLAGS`
+  `XKB_CONTEXT_NO_FLAGS`
+  `XKB_MAP_COMPILE_NO_FLAGS`
 
 - Bug fixes.
 
 
-libxkbcommon 0.3.1 - 2013-06-03
+libxkbcommon 0.3.1 – 2013-06-03
 ==================
 
 - Replace the flex scanner with a hand-written one. flex is no longer
   a build requirement.
 
 - New API:
-  xkb_keymap_min_keycode()
-  xkb_keymap_max_keycode()
-  xkb_keymap_key_for_each()
+  `xkb_keymap_min_keycode()`
+  `xkb_keymap_max_keycode()`
+  `xkb_keymap_key_for_each()`
 
 
-libxkbcommon 0.3.0 - 2013-04-01
+libxkbcommon 0.3.0 – 2013-04-01
 ==================
 
-- Allow passing NULL to *_unref() functions; do nothing instead of
+- Allow passing NULL to `*_unref()` functions; do nothing instead of
   crashing.
 
-- The functions xkb_keymap_num_levels_for_key() and
-  xkb_keymap_get_syms_by_level() now allow out-of-range values for the
-  'layout' parameter. The functions now wrap the value around the number
+- The functions `xkb_keymap_num_levels_for_key()` and
+  `xkb_keymap_get_syms_by_level()` now allow out-of-range values for the
+  `layout` parameter. The functions now wrap the value around the number
   of layouts instead of failing.
 
-- The function xkb_keysym_get_name() now types unicode keysyms in
-  uppercase and 0-padding, to match the format used by XKeysymToString().
+- The function `xkb_keysym_get_name()` now types unicode keysyms in
+  uppercase and 0-padding, to match the format used by `XKeysymToString()`.
 
 - Building Linux-specific tests is no longer attempted on non-Linux
   environments.
 
-- The function xkb_keymap_new_from_names() now accepts a NULL value for
-  the 'names' parameter, instead of failing. This is equivalent to passing
-  a 'struct xkb_rule_names' with all fields set to NULL.
+- The function `xkb_keymap_new_from_names()` now accepts a NULL value for
+  the `names` parameter, instead of failing. This is equivalent to passing
+  a `struct xkb_rule_names` with all fields set to NULL.
 
 - New API:
-  xkb_keymap_new_from_buffer()
+  `xkb_keymap_new_from_buffer()`
 
 - Bug fixes.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # libxkbcommon
 
+<!--
+NOTE: This file is carefully formatted to support both Github and Doxygen.
+They handle line breaks differently!
+-->
+
 **libxkbcommon** is a keyboard keymap compiler and support library which
 processes a reduced subset of keymaps as defined by the [XKB] \(X Keyboard
-Extension) specification.  It also contains a module for handling *Compose*
+Extension) specification. It also contains a module for handling *Compose*
 and dead keys, a separate *registry* library for listing available keyboard
-layouts and a fair set of <abbr title="Command-Line Interface">CLI</abbr>
-*tools*.
+layouts and a fair set of <!--!
+@rawHtml --><abbr title="Command-Line Interface">CLI</abbr><!--!
+@endRawHtml --> *tools*.
 
 [XKB]: doc/introduction-to-xkb.md
 
@@ -20,7 +26,7 @@ layouts and a fair set of <abbr title="Command-Line Interface">CLI</abbr>
 
 ## Building
 
-libxkbcommon is built with [Meson](http://mesonbuild.com/):
+libxkbcommon is built with [Meson](http://mesonbuild.com):
 
 ```bash
 meson setup build
@@ -33,9 +39,9 @@ using the X11 keyboard configuration resource files thusly:
 
 ```bash
 meson setup build \
-    -Denable-x11=false \
-    -Dxkb-config-root=/usr/share/X11/xkb \
-    -Dx-locale-root=/usr/share/X11/locale
+      -Denable-x11=false \
+      -Dxkb-config-root=/usr/share/X11/xkb \
+      -Dx-locale-root=/usr/share/X11/locale
 meson compile -C build
 ```
 
@@ -54,27 +60,29 @@ See the [API Documentation](https://xkbcommon.org/doc/current/topics.html).
 
 ## Tools
 
+<!--! @rawHtml -->
 Libxkbcommon has a fair set of <abbr title="Command-Line Interface">CLI</abbr>
-*tools*, grouped under the `xkbcli` application:
+<code>tools</code>, grouped under the <code>xkbcli</code> application:
+<!--! @endRawHtml -->
 
 <dl>
-<dt>`xkbcli compile-keymap`</dt>
+<dt><code>xkbcli compile-keymap</code></dt>
 <dd>Compile an XKB keymap</dd>
-<dt>`xkbcli compile-compose`</dt>
+<dt><code>xkbcli compile-compose</code></dt>
 <dd>Compile a compose file</dd>
-<dt>`xkbcli how-to-type`</dt>
+<dt><code>xkbcli how-to-type</code></dt>
 <dd>Show how to type a given Unicode codepoint</dd>
-<dt>`xkbcli interactive-wayland`</dt>
+<dt><code>xkbcli interactive-wayland</code></dt>
 <dd>Interactive debugger for XKB keymaps for Wayland</dd>
-<dt>`xkbcli interactive-x11`</dt>
+<dt><code>xkbcli interactive-x11</code></dt>
 <dd>Interactive debugger for XKB keymaps for X11</dd>
-<dt>`xkbcli interactive-evdev`</dt>
+<dt><code>xkbcli interactive-evdev</code></dt>
 <dd>Interactive debugger for XKB keymaps for evdev</dd>
-<dt>`xkbcli dump-keymap-wayland`</dt>
+<dt><code>xkbcli dump-keymap-wayland</code></dt>
 <dd>Dump a XKB keymap from a Wayland compositor</dd>
-<dt>`xkbcli dump-keymap-x11`</dt>
+<dt><code>xkbcli dump-keymap-x11</code></dt>
 <dd>Dump a XKB keymap from a X server</dd>
-<dt>`xkbcli list`</dt>
+<dt><code>xkbcli list</code></dt>
 <dd>List available layouts and more</dd>
 </dl>
 
@@ -102,11 +110,9 @@ See [Compatibility](doc/compatibility.md) notes.
 
 ## Development
 
-An extremely rudimentary homepage can be found at
-    https://xkbcommon.org
+An project’s homepage can be found at https://xkbcommon.org.
 
-xkbcommon is maintained in git at
-    https://github.com/xkbcommon/libxkbcommon
+xkbcommon is maintained in git at: https://github.com/xkbcommon/libxkbcommon
 
 Patches are always welcome, and may be sent to either
 <xorg-devel@lists.x.org> or <wayland-devel@lists.freedesktop.org>

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ layouts and a fair set of <!--!
   a *custom layout* or option.
 - [Quick Guide](doc/quick-guide.md): introduction on how to use this library.
 - [Tools](./README.md#tools): introduction to the `xkbcli` application.
+- [Release notes](doc/release-notes.md).
 - [Frequently Asked Question (FAQ)](doc/faq.md).
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ The maintainers are:
 - [Ran Benita](mailto:ran@unusedvar.com)
 - [Pierre Le Marre](mailto:dev@wismill.eu)
 
+## License
+
+See the [LICENSE](doc/license.md) file.
+
 ## Credits
 
 Many thanks are due to Dan Nicholson for his heroic work in getting xkbcommon

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -32,7 +32,7 @@ FILE_PATTERNS          = *.c \
                          *.h
 
 # These are included in other file but we do not want them as standalone
-EXCLUDE                = NEWS.md meson_options.txt
+EXCLUDE                = LICENSE NEWS.md meson_options.txt
 
 RECURSIVE              = YES
 
@@ -56,8 +56,6 @@ GENERATE_TREEVIEW      = NO
 FULL_SIDEBAR           = NO
 
 HTML_EXTRA_STYLESHEET  = doc/doxygen-extra.css
-
-HTML_EXTRA_FILES       = meson_options.txt
 
 HTML_COLORSTYLE        = TOGGLE
 

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -59,6 +59,8 @@ HTML_EXTRA_STYLESHEET  = doc/doxygen-extra.css
 
 HTML_EXTRA_FILES       = meson_options.txt
 
+HTML_COLORSTYLE        = TOGGLE
+
 TIMESTAMP              = NO
 
 ENUM_VALUES_PER_LINE   = 1

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -70,7 +70,10 @@ DOTFILE_DIRS           = doc/diagrams
 
 DOT_IMAGE_FORMAT       = svg
 
+# Workaround HTML tags not supported by Doxygen
 ALIASES                += figure="@htmlonly[block]<figure>@endhtmlonly"
 ALIASES                += endfigure="@htmlonly[block]</figure>@endhtmlonly"
 ALIASES                += figcaption="@htmlonly[block]<figcaption>@endhtmlonly"
 ALIASES                += endfigcaption="@htmlonly[block]</figcaption>@endhtmlonly"
+ALIASES                += rawHtml="@htmlonly<!--"
+ALIASES                += endRawHtml="-->@endhtmlonly"

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -31,6 +31,9 @@ INPUT                  = @INPUT@
 FILE_PATTERNS          = *.c \
                          *.h
 
+# These are included in other file but we do not want them as standalone
+EXCLUDE                = NEWS.md meson_options.txt
+
 RECURSIVE              = YES
 
 USE_MDFILE_AS_MAINPAGE = README.md

--- a/doc/doxygen-extra.css
+++ b/doc/doxygen-extra.css
@@ -1,3 +1,8 @@
+html.dark-mode {
+    --page-background-color: #000410;
+    --fragment-background-color: #192027;
+}
+
 div#top, div.header, div.contents {
     margin-left: auto;
     margin-right: auto;
@@ -28,12 +33,25 @@ a[href^="https://"]::after
     width: 11px;
     height: 11px;
     margin-left: 4px;
+    background-color: var(--page-link-color);
     /* Bootstrap icon: https://icons.getbootstrap.com/icons/box-arrow-up-right/ */
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' class='bi bi-box-arrow-up-right' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z'/%3E%3Cpath fill-rule='evenodd' d='M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z'/%3E%3C/svg%3E");
-    background-position: center;
-    background-repeat: no-repeat;
-    background-size: contain;
+    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' class='bi bi-box-arrow-up-right' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z'/%3E%3Cpath fill-rule='evenodd' d='M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z'/%3E%3C/svg%3E");
+    mask-position: center;
+    mask-repeat: no-repeat;
+    mask-size: contain;
     display: inline-block;
+}
+
+code {
+    padding: .2em .4em;
+    margin: 0;
+    vertical-align: baseline;
+    font-family: var(--font-family-monospace);
+    font-size: 85%;
+    white-space: break-spaces;
+    background-color: var(--fragment-background-color);
+    color: var(--fragment-foreground-color);
+    border-radius: 6px;
 }
 
 /*******************************************************************************

--- a/doc/license.md
+++ b/doc/license.md
@@ -1,0 +1,3 @@
+# License {#detailed-license}
+
+@include{txt} LICENSE

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,0 +1,5 @@
+# Release notes {#release-notes}
+
+@tableofcontents{html:1}
+
+@include{doc} NEWS.md

--- a/meson.build
+++ b/meson.build
@@ -1096,6 +1096,7 @@ You can disable the documentation with -Denable-docs=false.''')
 
     doxygen_input = [
         'README.md',
+        'NEWS.md',
         'meson_options.txt',
         'doc/debugging.md',
         'doc/diagrams/xkb-configuration.dot',
@@ -1110,6 +1111,7 @@ You can disable the documentation with -Denable-docs=false.''')
         'doc/rules-format.md',
         'doc/keymap-format-text-v1.md',
         'doc/message-registry.md',
+        'doc/release-notes.md',
         'include/xkbcommon/xkbcommon.h',
         'include/xkbcommon/xkbcommon-compose.h',
         'include/xkbcommon/xkbcommon-keysyms.h',

--- a/meson.build
+++ b/meson.build
@@ -1159,23 +1159,6 @@ You can disable the documentation with -Denable-docs=false.''')
             build_by_default: true,
         )
     endif
-    # Fix HTML tags unknown to Doxygen
-    sed_program = find_program('sed', required: false)
-    if sed_program.found()
-        doxygen_html_fix = find_program('scripts/doxygen-html-fix')
-        custom_target(
-            'doc-html-tags-fix',
-            input: doc_gen,
-            output: 'html-fake',
-            command: [
-                doxygen_html_fix,
-                meson.current_build_dir()/'html',
-                sed_program,
-            ],
-            install: false,
-            build_by_default: true,
-        )
-    endif
 endif
 
 configure_file(output: 'config.h', configuration: configh_data)

--- a/meson.build
+++ b/meson.build
@@ -1096,6 +1096,7 @@ You can disable the documentation with -Denable-docs=false.''')
 
     doxygen_input = [
         'README.md',
+        'LICENSE',
         'NEWS.md',
         'meson_options.txt',
         'doc/debugging.md',
@@ -1112,6 +1113,7 @@ You can disable the documentation with -Denable-docs=false.''')
         'doc/keymap-format-text-v1.md',
         'doc/message-registry.md',
         'doc/release-notes.md',
+        'doc/license.md',
         'include/xkbcommon/xkbcommon.h',
         'include/xkbcommon/xkbcommon-compose.h',
         'include/xkbcommon/xkbcommon-keysyms.h',

--- a/scripts/doxygen-html-fix
+++ b/scripts/doxygen-html-fix
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Fix the following HTML tag unknown to Doxygen:
-# - <abbr>: see https://github.com/doxygen/doxygen/issues/11574
-
-find "$1" -name "*.html" -type f -exec \
-     "$2" -iE 's/&lt;abbr title="\(.*\)"&gt;\(.*\)&lt;\/abbr&gt;/<abbr title="\1">\2<\/abbr>/g' {} +

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -7,7 +7,7 @@ all_bullets = true
 single_file = true
 orphan_prefix = "+"
 title_format = """\
-{name} [{version}] - {project_date}
+{name} [{version}] – {project_date}
 =================================
 
 [{version}]: https://github.com/xkbcommon/libxkbcommon/tree/xkbcommon-{version}\


### PR DESCRIPTION
Our changelog deserves a better exposition.

Also:
- Added license as well.
- Added a workaround for Doxygen’s limitations on HTML tags. Hopefully this is fixed for good.
- Improved CSS.
