### PR TITLE
compose: Fix sequence not fully overriden

### DIFF
--- a/changes/api/+compose-misoverriding.bugfix.md
+++ b/changes/api/+compose-misoverriding.bugfix.md
@@ -1,0 +1,2 @@
+*Compose*: fixed sequence not fully overriden if the new sequence has no
+keysym or string.

--- a/test/compose.c
+++ b/test/compose.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 
 #include "xkbcommon/xkbcommon-compose.h"
+#include "xkbcommon/xkbcommon-keysyms.h"
 
 #include "test.h"
 #include "src/utf8.h"
@@ -413,12 +414,36 @@ test_conflicting(struct xkb_context *ctx)
         XKB_KEY_B,              XKB_COMPOSE_FEED_ACCEPTED,  XKB_COMPOSE_COMPOSED,   "foo",  XKB_KEY_B,
         XKB_KEY_NoSymbol));
 
-    // new same length as old #3
+    // new same length as old #3: overwritable string: do not allocate
     assert(test_compose_seq_buffer(ctx,
         "<A> <B>      :  \"foo\"  A \n"
-        "<A> <B>      :  \"bar\"  A \n",
+        "<A> <B>      :  \"qu\"   A \n",
         XKB_KEY_A,              XKB_COMPOSE_FEED_ACCEPTED,  XKB_COMPOSE_COMPOSING,  "",     XKB_KEY_NoSymbol,
-        XKB_KEY_B,              XKB_COMPOSE_FEED_ACCEPTED,  XKB_COMPOSE_COMPOSED,   "bar",  XKB_KEY_A,
+        XKB_KEY_B,              XKB_COMPOSE_FEED_ACCEPTED,  XKB_COMPOSE_COMPOSED,   "qu",   XKB_KEY_A,
+        XKB_KEY_NoSymbol));
+
+    // new same length as old #4: no-overwritable string: allocate
+    assert(test_compose_seq_buffer(ctx,
+        "<A> <B>      :  \"foo\"  A \n"
+        "<A> <B>      :  \"quux\" A \n",
+        XKB_KEY_A,              XKB_COMPOSE_FEED_ACCEPTED,  XKB_COMPOSE_COMPOSING,  "",     XKB_KEY_NoSymbol,
+        XKB_KEY_B,              XKB_COMPOSE_FEED_ACCEPTED,  XKB_COMPOSE_COMPOSED,   "quux", XKB_KEY_A,
+        XKB_KEY_NoSymbol));
+
+    // new same length as old #5: ensure string is reset
+    assert(test_compose_seq_buffer(ctx,
+        "<A> <B>      :  \"foo\"  A \n"
+        "<A> <B>      :           B \n",
+        XKB_KEY_A,              XKB_COMPOSE_FEED_ACCEPTED,  XKB_COMPOSE_COMPOSING,  "",     XKB_KEY_NoSymbol,
+        XKB_KEY_B,              XKB_COMPOSE_FEED_ACCEPTED,  XKB_COMPOSE_COMPOSED,   "B",    XKB_KEY_B,
+        XKB_KEY_NoSymbol));
+
+    // new same length as old #6: ensure keysym is reset
+    assert(test_compose_seq_buffer(ctx,
+        "<A> <B>      :  \"foo\"  A \n"
+        "<A> <B>      :  \"bar\"    \n",
+        XKB_KEY_A,              XKB_COMPOSE_FEED_ACCEPTED,  XKB_COMPOSE_COMPOSING,  "",     XKB_KEY_NoSymbol,
+        XKB_KEY_B,              XKB_COMPOSE_FEED_ACCEPTED,  XKB_COMPOSE_COMPOSED,   "bar",  XKB_KEY_NoSymbol,
         XKB_KEY_NoSymbol));
 }
 


### PR DESCRIPTION
Previously if a new sequence did not produce a keysym or a string, the corresponding property was not overriden, possibly leaking the previous entry.

- Fixed by always writting all the properties.
- Also try to reuse the previous string entry, if possible, so that we avoid allocating.

Discovered while reviewing #570. Probably not an issue in practice if following the standard system Compose file syntax: string + keysym.