### PR TITLE
dump: Always use numeric group indexes

### DIFF
--- a/src/xkbcomp/keymap-dump.c
+++ b/src/xkbcomp/keymap-dump.c
@@ -721,8 +721,7 @@ write_key(struct xkb_keymap *keymap, struct buf *buf, struct buf *buf2,
                     continue;
 
                 const struct xkb_key_type * const type = key->groups[group].type;
-                /* TODO: This will require using integer indexes when > 4 */
-                write_buf(buf, "\n\t\ttype[Group%"PRIu32"]= ", group + 1);
+                write_buf(buf, "\n\t\ttype[%"PRIu32"]= ", group + 1);
                 write_buf_string_literal(
                   buf, xkb_atom_text(keymap->ctx, type->name));
                 copy_to_buf(buf, ",");
@@ -770,8 +769,7 @@ write_key(struct xkb_keymap *keymap, struct buf *buf, struct buf *buf2,
         break;
 
     case RANGE_REDIRECT:
-        /* TODO: This will require using integer indexes when > 4 */
-        write_buf(buf, "\n\t\tgroupsRedirect= Group%"PRIu32",",
+        write_buf(buf, "\n\t\tgroupsRedirect= %"PRIu32",",
                     key->out_of_range_group_number + 1);
         break;
 
@@ -803,14 +801,12 @@ write_key(struct xkb_keymap *keymap, struct buf *buf, struct buf *buf2,
         for (xkb_layout_index_t group = 0; group < key->num_groups; group++) {
             if (group != 0)
                 copy_to_buf(buf, ",");
-            /* TODO: This will require using integer indexes when > 4 */
-            write_buf(buf, "\n\t\tsymbols[Group%"PRIu32"]= [ ", group + 1);
+            write_buf(buf, "\n\t\tsymbols[%"PRIu32"]= [ ", group + 1);
             if (!write_keysyms(keymap, buf, buf2, key, group, show_actions))
                 return false;
             copy_to_buf(buf, " ]");
             if (show_actions) {
-                /* TODO: This will require using integer indexes when > 4 */
-                write_buf(buf, ",\n\t\tactions[Group%"PRIu32"]= [ ", group + 1);
+                write_buf(buf, ",\n\t\tactions[%"PRIu32"]= [ ", group + 1);
                 if (!write_actions(keymap, buf, buf2, key, group))
                     return false;
                 copy_to_buf(buf, " ]");
@@ -838,8 +834,7 @@ write_symbols(struct xkb_keymap *keymap, struct buf *buf)
 
     for (group = 0; group < keymap->num_group_names; group++)
         if (keymap->group_names[group]) {
-            /* TODO: This will require using integer indexes when > 4 */
-            write_buf(buf, "\tname[Group%"PRIu32"]=", group + 1);
+            write_buf(buf, "\tname[%"PRIu32"]=", group + 1);
             write_buf_string_literal(
                 buf, xkb_atom_text(keymap->ctx, keymap->group_names[group]));
             copy_to_buf(buf, ";\n");

--- a/test/buffercomp.c
+++ b/test/buffercomp.c
@@ -931,6 +931,61 @@ test_interpret(struct xkb_context *ctx, bool update_output_files)
     }
 }
 
+static void
+test_group_indexes_names(struct xkb_context *ctx, bool update_output_files)
+{
+    const struct {
+        const char* keymap;
+        const char* expected_v1;
+        const char* expected_v2;
+    } keymaps[] = {
+        {
+            .keymap =
+                "xkb_keymap {\n"
+                "  xkb_keycodes {\n"
+                "    <> = 1;\n"
+                "    indicator 1 = \"1\";\n"
+                "    indicator 2 = \"2\";\n"
+                "  };\n"
+                "  xkb_compat {\n"
+                "    interpret a { action = SetGroup(group=Group1);  };\n"
+                "    interpret b { action = SetGroup(group=-Group2); };\n"
+                "    interpret c { action = SetGroup(group=+Group3); };\n"
+                "    indicator \"1\" { groups = Group4; };\n"
+                "    indicator \"2\" { groups = All-Group1; };\n"
+                "  };\n"
+                "  xkb_symbols {\n"
+                "    name[Group1] = \"1\";\n"
+                "    name[Group2] = \"2\";\n"
+                "    name[Group3] = \"3\";\n"
+                "    name[Group4] = \"4\";\n"
+                "    key <> {\n"
+                "      groupsredirect=Group4,\n"
+                "      symbols[Group1]=[a],\n"
+                "      symbols[Group2]=[b],\n"
+                "      symbols[Group3]=[c],\n"
+                "      symbols[Group4]=[d]\n"
+                "    };\n"
+                "  };\n"
+                "};",
+            .expected_v1 = GOLDEN_TESTS_OUTPUTS "group-index-names-1.xkb",
+            .expected_v2 = GOLDEN_TESTS_OUTPUTS "group-index-names-1.xkb"
+        },
+    };
+
+    for (unsigned int k = 0; k < ARRAY_SIZE(keymaps); k++) {
+        fprintf(stderr, "------\n*** %s: #%u ***\n", __func__, k);
+        assert(test_compile_output(ctx, XKB_KEYMAP_FORMAT_TEXT_V1,
+                                   compile_buffer, NULL, __func__,
+                                   keymaps[k].keymap, strlen(keymaps[k].keymap),
+                                   keymaps[k].expected_v1, update_output_files));
+        assert(test_compile_output(ctx, XKB_KEYMAP_FORMAT_TEXT_V2,
+                                   compile_buffer, NULL, __func__,
+                                   keymaps[k].keymap, strlen(keymaps[k].keymap),
+                                   keymaps[k].expected_v2, update_output_files));
+    }
+}
+
 /* Test various multi-{keysym,action} syntaxes */
 static void
 test_multi_keysyms_actions(struct xkb_context *ctx, bool update_output_files)
@@ -1794,6 +1849,7 @@ main(int argc, char *argv[])
     test_keycodes(ctx, update_output_files);
     test_masks(ctx, update_output_files);
     test_interpret(ctx, update_output_files);
+    test_group_indexes_names(ctx, update_output_files);
     test_multi_keysyms_actions(ctx, update_output_files);
     test_key_keysyms_as_strings(ctx, update_output_files);
     test_invalid_symbols_fields(ctx);

--- a/test/data/keymaps/empty-compound-statements.xkb
+++ b/test/data/keymaps/empty-compound-statements.xkb
@@ -61,16 +61,16 @@ xkb_symbols {
 	key <Q>                  {	[               q ] };
 	key <W>                  {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [        SetMods(modifiers=none) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [        SetMods(modifiers=none) ]
 	};
 	key <E>                  {
 		type= "t1",
-		symbols[Group1]= [               e ]
+		symbols[1]= [               e ]
 	};
 	key <U>                  {
-		symbols[Group1]= [        NoSymbol ],
-		symbols[Group2]= [               u ]
+		symbols[1]= [        NoSymbol ],
+		symbols[2]= [               u ]
 	};
 	key <I>                  {	[               i ] };
 	key <A>                  {
@@ -81,17 +81,17 @@ xkb_symbols {
 	};
 	key <F>                  {
 		type= "t2",
-		symbols[Group1]= [        NoSymbol,        NoSymbol ]
+		symbols[1]= [        NoSymbol,        NoSymbol ]
 	};
 	key <G>                  {
 		type= "t2",
-		symbols[Group1]= [        NoSymbol,        NoSymbol ]
+		symbols[1]= [        NoSymbol,        NoSymbol ]
 	};
 	key <H>                  {
-		type[Group1]= "t1",
-		type[Group2]= "t2",
-		symbols[Group1]= [        NoSymbol ],
-		symbols[Group2]= [        NoSymbol,        NoSymbol ]
+		type[1]= "t1",
+		type[2]= "t2",
+		symbols[1]= [        NoSymbol ],
+		symbols[2]= [        NoSymbol,        NoSymbol ]
 	};
 	key <X>                  {
 		virtualMods= M1
@@ -105,19 +105,19 @@ xkb_symbols {
 	key <B>                  {
 		type= "t2",
 		virtualMods= none,
-		symbols[Group1]= [        NoSymbol,        NoSymbol ]
+		symbols[1]= [        NoSymbol,        NoSymbol ]
 	};
 	key <N>                  {
 		type= "t1",
 		virtualMods= none,
-		symbols[Group1]= [        NoSymbol ]
+		symbols[1]= [        NoSymbol ]
 	};
 	key <M>                  {
-		type[Group1]= "t1",
-		type[Group2]= "t2",
+		type[1]= "t1",
+		type[2]= "t2",
 		virtualMods= none,
-		symbols[Group1]= [        NoSymbol ],
-		symbols[Group2]= [        NoSymbol,        NoSymbol ]
+		symbols[1]= [        NoSymbol ],
+		symbols[2]= [        NoSymbol,        NoSymbol ]
 	};
 	modifier_map Shift { <Z> };
 	modifier_map Lock { <X> };

--- a/test/data/keymaps/escape-sequences.xkb
+++ b/test/data/keymaps/escape-sequences.xkb
@@ -35,12 +35,12 @@ xkb_compatibility "Le_cÅ_ur_a___ses_raisons_que_la_raison_ne_con_naÃ_t_point" {
 };
 
 xkb_symbols "La_libertÃ__commence_oÃ__lâ__ignorance_finit_" {
-	name[Group1]="\nÿ";
-	name[Group2]="\00427";
+	name[1]="\nÿ";
+	name[2]="\00427";
 
 	key <>                   {
 		type= "%1ğŸºâœ¨ğŸ•Šï¸\0014",
-		symbols[Group1]= [               a,               A ]
+		symbols[1]= [               a,               A ]
 	};
 };
 

--- a/test/data/keymaps/explicit-actions.xkb
+++ b/test/data/keymaps/explicit-actions.xkb
@@ -279,48 +279,48 @@ xkb_compatibility "(unnamed)" {
 };
 
 xkb_symbols "(unnamed)" {
-	name[Group1]="English (US)";
-	name[Group2]="Czech";
-	name[Group3]="German (Neo 2)";
+	name[1]="English (US)";
+	name[2]="Czech";
+	name[3]="German (Neo 2)";
 
 	key <AD05>               {
 		//// repeat=Yes is set with the default *interpretation*, but
 		//// using explicit actions makes the key keep the initial value,
 		//// i.e. repeat=No.
 		//repeat= Yes,
-		symbols[Group1]= [                              t,                              T ],
-		//actions[Group1]= [                     NoAction(),                     NoAction() ],
-		symbols[Group2]= [                    Cyrillic_ie,                    Cyrillic_IE ],
-		actions[Group2]= [                     NoAction(),                     NoAction() ],
-		symbols[Group3]= [                              w,                              W ]//,
-		//actions[Group3]= [                     NoAction(),                     NoAction() ]
+		symbols[1]= [                              t,                              T ],
+		//actions[1]= [                     NoAction(),                     NoAction() ],
+		symbols[2]= [                    Cyrillic_ie,                    Cyrillic_IE ],
+		actions[2]= [                     NoAction(),                     NoAction() ],
+		symbols[3]= [                              w,                              W ]//,
+		//actions[3]= [                     NoAction(),                     NoAction() ]
 	};
 	key <AD06>               {
-		type[Group3]= "EIGHT_LEVEL_ALPHABETIC_LEVEL_FIVE_LOCK",
-		symbols[Group1]= [               y,               Y ],
-		symbols[Group2]= [               z,               Z,       leftarrow,             yen ],
-		symbols[Group3]= [               k,               K,          exclam,     Greek_kappa,      exclamdown,        NoSymbol,        multiply,        NoSymbol ]
+		type[3]= "EIGHT_LEVEL_ALPHABETIC_LEVEL_FIVE_LOCK",
+		symbols[1]= [               y,               Y ],
+		symbols[2]= [               z,               Z,       leftarrow,             yen ],
+		symbols[3]= [               k,               K,          exclam,     Greek_kappa,      exclamdown,        NoSymbol,        multiply,        NoSymbol ]
 	};
 	key <LFSH>               {
-		type[Group3]= "TWO_LEVEL",
-		symbols[Group1]= [         Shift_L ],
-		symbols[Group2]= [         Shift_L ],
-		symbols[Group3]= [         Shift_L,       Caps_Lock ]
+		type[3]= "TWO_LEVEL",
+		symbols[1]= [         Shift_L ],
+		symbols[2]= [         Shift_L ],
+		symbols[3]= [         Shift_L,       Caps_Lock ]
 	};
 	//// This should set the key’s EXPLICIT_INTERP explicit flag and
 	//// the group 2 explicit_actions, but it should still allow to
 	//// interpret the keysyms in groups 1 and 3.
 	key <LALT>               {
-		type[Group1]= "ONE_LEVEL",
-		type[Group2]= "TWO_LEVEL",
-		type[Group3]= "TWO_LEVEL",
+		type[1]= "ONE_LEVEL",
+		type[2]= "TWO_LEVEL",
+		type[3]= "TWO_LEVEL",
 		//repeat= No,
-		symbols[Group1]= [                        Shift_L ],
-		//actions[Group1]= [ SetMods(modifiers=Shift,clearLocks) ],
-		symbols[Group2]= [               ISO_Level3_Shift,                      Multi_key ],
-		actions[Group2]= [  SetMods(modifiers=LevelThree),                     NoAction() ],
-		symbols[Group3]= [               ISO_Level5_Shift,               ISO_Level3_Shift ]//,
-		//actions[Group3]= [ SetMods(modifiers=LevelFive,clearLocks), SetMods(modifiers=LevelThree,clearLocks) ]
+		symbols[1]= [                        Shift_L ],
+		//actions[1]= [ SetMods(modifiers=Shift,clearLocks) ],
+		symbols[2]= [               ISO_Level3_Shift,                      Multi_key ],
+		actions[2]= [  SetMods(modifiers=LevelThree),                     NoAction() ],
+		symbols[3]= [               ISO_Level5_Shift,               ISO_Level3_Shift ]//,
+		//actions[3]= [ SetMods(modifiers=LevelFive,clearLocks), SetMods(modifiers=LevelThree,clearLocks) ]
 	};
 	key <LVL3>               {
 		type= "ONE_LEVEL",
@@ -329,32 +329,32 @@ xkb_symbols "(unnamed)" {
 		//// disable them.
 		//repeat= No,
 		//virtualMods= LevelThree,
-		symbols[Group1]= [               ISO_Level3_Shift ],
-		//actions[Group1]= [ SetMods(modifiers=LevelThree,clearLocks) ],
-		symbols[Group2]= [               ISO_Level3_Shift ],
-		actions[Group2]= [  SetMods(modifiers=LevelThree) ],
-		symbols[Group3]= [               ISO_Level3_Shift ]//,
-		//actions[Group3]= [ SetMods(modifiers=LevelThree,clearLocks) ]
+		symbols[1]= [               ISO_Level3_Shift ],
+		//actions[1]= [ SetMods(modifiers=LevelThree,clearLocks) ],
+		symbols[2]= [               ISO_Level3_Shift ],
+		actions[2]= [  SetMods(modifiers=LevelThree) ],
+		symbols[3]= [               ISO_Level3_Shift ]//,
+		//actions[3]= [ SetMods(modifiers=LevelThree,clearLocks) ]
 	};
 	key <LSGT>               {
-		symbols[Group1]= [            less,         greater,             bar,       brokenbar ],
-		symbols[Group2]= [       backslash,             bar,           slash,        NoSymbol ],
-		symbols[Group3]= [ ISO_Level5_Shift ]
+		symbols[1]= [            less,         greater,             bar,       brokenbar ],
+		symbols[2]= [       backslash,             bar,           slash,        NoSymbol ],
+		symbols[3]= [ ISO_Level5_Shift ]
 	};
 	key <RALT>               {
-		type[Group1]= "TWO_LEVEL",
-		type[Group2]= "ONE_LEVEL",
-		type[Group3]= "ONE_LEVEL",
-		symbols[Group1]= [           Alt_R,          Meta_R ],
-		symbols[Group2]= [ ISO_Level3_Shift ],
-		symbols[Group3]= [ ISO_Level5_Shift ]
+		type[1]= "TWO_LEVEL",
+		type[2]= "ONE_LEVEL",
+		type[3]= "ONE_LEVEL",
+		symbols[1]= [           Alt_R,          Meta_R ],
+		symbols[2]= [ ISO_Level3_Shift ],
+		symbols[3]= [ ISO_Level5_Shift ]
 	};
 	key <COMP>               {	[  ISO_Next_Group,            Menu ] };
 	key <MDSW>               {
 		type= "ONE_LEVEL",
-		symbols[Group1]= [ ISO_Level5_Shift ],
-		symbols[Group2]= [ ISO_Level5_Shift ],
-		symbols[Group3]= [ ISO_Level5_Shift ]
+		symbols[1]= [ ISO_Level5_Shift ],
+		symbols[2]= [ ISO_Level5_Shift ],
+		symbols[3]= [ ISO_Level5_Shift ]
 	};
 	key <ALT>                {	[        NoSymbol,           Alt_L ] };
 	key <META>               {	[        NoSymbol,          Meta_L ] };

--- a/test/data/keymaps/group-index-names-1.xkb
+++ b/test/data/keymaps/group-index-names-1.xkb
@@ -1,0 +1,51 @@
+xkb_keymap {
+xkb_keycodes {
+	minimum = 1;
+	maximum = 255;
+	<>                   = 1;
+	indicator 1 = "1";
+	indicator 2 = "2";
+};
+
+xkb_types {
+	type "default" {
+		modifiers= none;
+	};
+};
+
+xkb_compatibility {
+	interpret.useModMapMods= AnyLevel;
+	interpret.repeat= False;
+	interpret a+AnyOfOrNone(all) {
+		action= SetGroup(group=1);
+	};
+	interpret b+AnyOfOrNone(all) {
+		action= SetGroup(group=-2);
+	};
+	interpret c+AnyOfOrNone(all) {
+		action= SetGroup(group=+3);
+	};
+	indicator "1" {
+		groups= 0x08;
+	};
+	indicator "2" {
+		groups= 0xfe;
+	};
+};
+
+xkb_symbols {
+	name[1]="1";
+	name[2]="2";
+	name[3]="3";
+	name[4]="4";
+
+	key <>                   {
+		groupsRedirect= 4,
+		symbols[1]= [               a ],
+		symbols[2]= [               b ],
+		symbols[3]= [               c ],
+		symbols[4]= [               d ]
+	};
+};
+
+};

--- a/test/data/keymaps/host.xkb
+++ b/test/data/keymaps/host.xkb
@@ -1081,397 +1081,397 @@ xkb_compatibility "complete" {
 };
 
 xkb_symbols "pc_us_pt_2_us_3_inet(evdev)_group(shift_caps_toggle)_compose(ralt)" {
-	name[Group1]="English (US)";
-	name[Group2]="Portuguese";
-	name[Group3]="English (US)";
+	name[1]="English (US)";
+	name[2]="Portuguese";
+	name[3]="English (US)";
 
 	key <ESC>                {	[          Escape ] };
 	key <AE01>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [               1,          exclam ],
-		symbols[Group2]= [               1,          exclam,     onesuperior,      exclamdown ],
-		symbols[Group3]= [               1,          exclam ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [               1,          exclam ],
+		symbols[2]= [               1,          exclam,     onesuperior,      exclamdown ],
+		symbols[3]= [               1,          exclam ]
 	};
 	key <AE02>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [               2,              at ],
-		symbols[Group2]= [               2,        quotedbl,              at,       oneeighth ],
-		symbols[Group3]= [               2,              at ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [               2,              at ],
+		symbols[2]= [               2,        quotedbl,              at,       oneeighth ],
+		symbols[3]= [               2,              at ]
 	};
 	key <AE03>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [               3,      numbersign ],
-		symbols[Group2]= [               3,      numbersign,        sterling,        sterling ],
-		symbols[Group3]= [               3,      numbersign ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [               3,      numbersign ],
+		symbols[2]= [               3,      numbersign,        sterling,        sterling ],
+		symbols[3]= [               3,      numbersign ]
 	};
 	key <AE04>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [               4,          dollar ],
-		symbols[Group2]= [               4,          dollar,         section,          dollar ],
-		symbols[Group3]= [               4,          dollar ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [               4,          dollar ],
+		symbols[2]= [               4,          dollar,         section,          dollar ],
+		symbols[3]= [               4,          dollar ]
 	};
 	key <AE05>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [               5,         percent ],
-		symbols[Group2]= [               5,         percent,         onehalf,    threeeighths ],
-		symbols[Group3]= [               5,         percent ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [               5,         percent ],
+		symbols[2]= [               5,         percent,         onehalf,    threeeighths ],
+		symbols[3]= [               5,         percent ]
 	};
 	key <AE06>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [               6,     asciicircum ],
-		symbols[Group2]= [               6,       ampersand,         notsign,     fiveeighths ],
-		symbols[Group3]= [               6,     asciicircum ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [               6,     asciicircum ],
+		symbols[2]= [               6,       ampersand,         notsign,     fiveeighths ],
+		symbols[3]= [               6,     asciicircum ]
 	};
 	key <AE07>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [               7,       ampersand ],
-		symbols[Group2]= [               7,           slash,       braceleft,    seveneighths ],
-		symbols[Group3]= [               7,       ampersand ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [               7,       ampersand ],
+		symbols[2]= [               7,           slash,       braceleft,    seveneighths ],
+		symbols[3]= [               7,       ampersand ]
 	};
 	key <AE08>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [               8,        asterisk ],
-		symbols[Group2]= [               8,       parenleft,     bracketleft,       trademark ],
-		symbols[Group3]= [               8,        asterisk ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [               8,        asterisk ],
+		symbols[2]= [               8,       parenleft,     bracketleft,       trademark ],
+		symbols[3]= [               8,        asterisk ]
 	};
 	key <AE09>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [               9,       parenleft ],
-		symbols[Group2]= [               9,      parenright,    bracketright,       plusminus ],
-		symbols[Group3]= [               9,       parenleft ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [               9,       parenleft ],
+		symbols[2]= [               9,      parenright,    bracketright,       plusminus ],
+		symbols[3]= [               9,       parenleft ]
 	};
 	key <AE10>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [               0,      parenright ],
-		symbols[Group2]= [               0,           equal,      braceright,          degree ],
-		symbols[Group3]= [               0,      parenright ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [               0,      parenright ],
+		symbols[2]= [               0,           equal,      braceright,          degree ],
+		symbols[3]= [               0,      parenright ]
 	};
 	key <AE11>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [           minus,      underscore ],
-		symbols[Group2]= [      apostrophe,        question,       backslash,    questiondown ],
-		symbols[Group3]= [           minus,      underscore ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [           minus,      underscore ],
+		symbols[2]= [      apostrophe,        question,       backslash,    questiondown ],
+		symbols[3]= [           minus,      underscore ]
 	};
 	key <AE12>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [           equal,            plus ],
-		symbols[Group2]= [        Hangul_A,        Hangul_E,    dead_cedilla,     dead_ogonek ],
-		symbols[Group3]= [           equal,            plus ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [           equal,            plus ],
+		symbols[2]= [        Hangul_A,        Hangul_E,    dead_cedilla,     dead_ogonek ],
+		symbols[3]= [           equal,            plus ]
 	};
 	key <BKSP>               {	[       BackSpace,       BackSpace ] };
 	key <TAB>                {	[             Tab,    ISO_Left_Tab ] };
 	key <AD01>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_SEMIALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               q,               Q ],
-		symbols[Group2]= [               q,               Q,              at,     Greek_OMEGA ],
-		symbols[Group3]= [               q,               Q ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_SEMIALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               q,               Q ],
+		symbols[2]= [               q,               Q,              at,     Greek_OMEGA ],
+		symbols[3]= [               q,               Q ]
 	};
 	key <AD02>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_ALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               w,               W ],
-		symbols[Group2]= [               w,               W,         lstroke,         Lstroke ],
-		symbols[Group3]= [               w,               W ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_ALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               w,               W ],
+		symbols[2]= [               w,               W,         lstroke,         Lstroke ],
+		symbols[3]= [               w,               W ]
 	};
 	key <AD03>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_SEMIALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               e,               E ],
-		symbols[Group2]= [               e,               E,        EuroSign,            cent ],
-		symbols[Group3]= [               e,               E ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_SEMIALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               e,               E ],
+		symbols[2]= [               e,               E,        EuroSign,            cent ],
+		symbols[3]= [               e,               E ]
 	};
 	key <AD04>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_SEMIALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               r,               R ],
-		symbols[Group2]= [               r,               R,       paragraph,      registered ],
-		symbols[Group3]= [               r,               R ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_SEMIALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               r,               R ],
+		symbols[2]= [               r,               R,       paragraph,      registered ],
+		symbols[3]= [               r,               R ]
 	};
 	key <AD05>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_ALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               t,               T ],
-		symbols[Group2]= [               t,               T,          tslash,          Tslash ],
-		symbols[Group3]= [               t,               T ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_ALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               t,               T ],
+		symbols[2]= [               t,               T,          tslash,          Tslash ],
+		symbols[3]= [               t,               T ]
 	};
 	key <AD06>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_SEMIALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               y,               Y ],
-		symbols[Group2]= [               y,               Y,       leftarrow,             yen ],
-		symbols[Group3]= [               y,               Y ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_SEMIALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               y,               Y ],
+		symbols[2]= [               y,               Y,       leftarrow,             yen ],
+		symbols[3]= [               y,               Y ]
 	};
 	key <AD07>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_SEMIALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               u,               U ],
-		symbols[Group2]= [               u,               U,       downarrow,         uparrow ],
-		symbols[Group3]= [               u,               U ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_SEMIALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               u,               U ],
+		symbols[2]= [               u,               U,       downarrow,         uparrow ],
+		symbols[3]= [               u,               U ]
 	};
 	key <AD08>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_SEMIALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               i,               I ],
-		symbols[Group2]= [               i,               I,      rightarrow,        idotless ],
-		symbols[Group3]= [               i,               I ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_SEMIALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               i,               I ],
+		symbols[2]= [               i,               I,      rightarrow,        idotless ],
+		symbols[3]= [               i,               I ]
 	};
 	key <AD09>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_ALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               o,               O ],
-		symbols[Group2]= [               o,               O,          oslash,          Oslash ],
-		symbols[Group3]= [               o,               O ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_ALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               o,               O ],
+		symbols[2]= [               o,               O,          oslash,          Oslash ],
+		symbols[3]= [               o,               O ]
 	};
 	key <AD10>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_ALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               p,               P ],
-		symbols[Group2]= [               p,               P,           thorn,           THORN ],
-		symbols[Group3]= [               p,               P ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_ALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               p,               P ],
+		symbols[2]= [               p,               P,           thorn,           THORN ],
+		symbols[3]= [               p,               P ]
 	};
 	key <AD11>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [     bracketleft,       braceleft ],
-		symbols[Group2]= [            plus,        asterisk,  dead_diaeresis,  dead_abovering ],
-		symbols[Group3]= [     bracketleft,       braceleft ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [     bracketleft,       braceleft ],
+		symbols[2]= [            plus,        asterisk,  dead_diaeresis,  dead_abovering ],
+		symbols[3]= [     bracketleft,       braceleft ]
 	};
 	key <AD12>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [    bracketright,      braceright ],
-		symbols[Group2]= [      dead_acute,      dead_grave,      dead_tilde,     dead_macron ],
-		symbols[Group3]= [    bracketright,      braceright ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [    bracketright,      braceright ],
+		symbols[2]= [      dead_acute,      dead_grave,      dead_tilde,     dead_macron ],
+		symbols[3]= [    bracketright,      braceright ]
 	};
 	key <RTRN>               {	[          Return ] };
 	key <LCTL>               {	[       Control_L ] };
 	key <AC01>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_ALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               a,               A ],
-		symbols[Group2]= [               a,               A,              ae,              AE ],
-		symbols[Group3]= [               a,               A ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_ALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               a,               A ],
+		symbols[2]= [               a,               A,              ae,              AE ],
+		symbols[3]= [               a,               A ]
 	};
 	key <AC02>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_SEMIALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               s,               S ],
-		symbols[Group2]= [               s,               S,          ssharp,         section ],
-		symbols[Group3]= [               s,               S ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_SEMIALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               s,               S ],
+		symbols[2]= [               s,               S,          ssharp,         section ],
+		symbols[3]= [               s,               S ]
 	};
 	key <AC03>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_ALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               d,               D ],
-		symbols[Group2]= [               d,               D,             eth,             ETH ],
-		symbols[Group3]= [               d,               D ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_ALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               d,               D ],
+		symbols[2]= [               d,               D,             eth,             ETH ],
+		symbols[3]= [               d,               D ]
 	};
 	key <AC04>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_SEMIALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               f,               F ],
-		symbols[Group2]= [               f,               F,         dstroke,     ordfeminine ],
-		symbols[Group3]= [               f,               F ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_SEMIALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               f,               F ],
+		symbols[2]= [               f,               F,         dstroke,     ordfeminine ],
+		symbols[3]= [               f,               F ]
 	};
 	key <AC05>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_ALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               g,               G ],
-		symbols[Group2]= [               g,               G,             eng,             ENG ],
-		symbols[Group3]= [               g,               G ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_ALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               g,               G ],
+		symbols[2]= [               g,               G,             eng,             ENG ],
+		symbols[3]= [               g,               G ]
 	};
 	key <AC06>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_ALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               h,               H ],
-		symbols[Group2]= [               h,               H,         hstroke,         Hstroke ],
-		symbols[Group3]= [               h,               H ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_ALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               h,               H ],
+		symbols[2]= [               h,               H,         hstroke,         Hstroke ],
+		symbols[3]= [               h,               H ]
 	};
 	key <AC07>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_SEMIALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               j,               J ],
-		symbols[Group2]= [               j,               J,       dead_hook,       dead_horn ],
-		symbols[Group3]= [               j,               J ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_SEMIALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               j,               J ],
+		symbols[2]= [               j,               J,       dead_hook,       dead_horn ],
+		symbols[3]= [               j,               J ]
 	};
 	key <AC08>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_SEMIALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               k,               K ],
-		symbols[Group2]= [               k,               K,             kra,       ampersand ],
-		symbols[Group3]= [               k,               K ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_SEMIALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               k,               K ],
+		symbols[2]= [               k,               K,             kra,       ampersand ],
+		symbols[3]= [               k,               K ]
 	};
 	key <AC09>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_ALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               l,               L ],
-		symbols[Group2]= [               l,               L,         lstroke,         Lstroke ],
-		symbols[Group3]= [               l,               L ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_ALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               l,               L ],
+		symbols[2]= [               l,               L,         lstroke,         Lstroke ],
+		symbols[3]= [               l,               L ]
 	};
 	key <AC10>               {
-		type[Group2]= "FOUR_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [       semicolon,           colon ],
-		symbols[Group2]= [        ccedilla,        Ccedilla,      dead_acute, dead_doubleacute ],
-		symbols[Group3]= [       semicolon,           colon ]
+		type[2]= "FOUR_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [       semicolon,           colon ],
+		symbols[2]= [        ccedilla,        Ccedilla,      dead_acute, dead_doubleacute ],
+		symbols[3]= [       semicolon,           colon ]
 	};
 	key <AC11>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [      apostrophe,        quotedbl ],
-		symbols[Group2]= [        Hangul_O,     ordfeminine, dead_circumflex,      dead_caron ],
-		symbols[Group3]= [      apostrophe,        quotedbl ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [      apostrophe,        quotedbl ],
+		symbols[2]= [        Hangul_O,     ordfeminine, dead_circumflex,      dead_caron ],
+		symbols[3]= [      apostrophe,        quotedbl ]
 	};
 	key <TLDE>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [           grave,      asciitilde ],
-		symbols[Group2]= [       backslash,             bar,         notsign,         notsign ],
-		symbols[Group3]= [           grave,      asciitilde ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [           grave,      asciitilde ],
+		symbols[2]= [       backslash,             bar,         notsign,         notsign ],
+		symbols[3]= [           grave,      asciitilde ]
 	};
 	key <LFSH>               {	[         Shift_L ] };
 	key <BKSL>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [       backslash,             bar ],
-		symbols[Group2]= [      dead_tilde, dead_circumflex,      dead_grave,      dead_breve ],
-		symbols[Group3]= [       backslash,             bar ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [       backslash,             bar ],
+		symbols[2]= [      dead_tilde, dead_circumflex,      dead_grave,      dead_breve ],
+		symbols[3]= [       backslash,             bar ]
 	};
 	key <AB01>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_SEMIALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               z,               Z ],
-		symbols[Group2]= [               z,               Z,        Hangul_A,            less ],
-		symbols[Group3]= [               z,               Z ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_SEMIALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               z,               Z ],
+		symbols[2]= [               z,               Z,        Hangul_A,            less ],
+		symbols[3]= [               z,               Z ]
 	};
 	key <AB02>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_SEMIALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               x,               X ],
-		symbols[Group2]= [               x,               X,        Hangul_E,         greater ],
-		symbols[Group3]= [               x,               X ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_SEMIALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               x,               X ],
+		symbols[2]= [               x,               X,        Hangul_E,         greater ],
+		symbols[3]= [               x,               X ]
 	};
 	key <AB03>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_SEMIALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               c,               C ],
-		symbols[Group2]= [               c,               C,            cent,       copyright ],
-		symbols[Group3]= [               c,               C ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_SEMIALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               c,               C ],
+		symbols[2]= [               c,               C,            cent,       copyright ],
+		symbols[3]= [               c,               C ]
 	};
 	key <AB04>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_SEMIALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               v,               V ],
-		symbols[Group2]= [               v,               V, leftdoublequotemark, leftsinglequotemark ],
-		symbols[Group3]= [               v,               V ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_SEMIALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               v,               V ],
+		symbols[2]= [               v,               V, leftdoublequotemark, leftsinglequotemark ],
+		symbols[3]= [               v,               V ]
 	};
 	key <AB05>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_SEMIALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               b,               B ],
-		symbols[Group2]= [               b,               B, rightdoublequotemark, rightsinglequotemark ],
-		symbols[Group3]= [               b,               B ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_SEMIALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               b,               B ],
+		symbols[2]= [               b,               B, rightdoublequotemark, rightsinglequotemark ],
+		symbols[3]= [               b,               B ]
 	};
 	key <AB06>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_ALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               n,               N ],
-		symbols[Group2]= [               n,               N,               n,               N ],
-		symbols[Group3]= [               n,               N ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_ALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               n,               N ],
+		symbols[2]= [               n,               N,               n,               N ],
+		symbols[3]= [               n,               N ]
 	};
 	key <AB07>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "FOUR_LEVEL_SEMIALPHABETIC",
-		type[Group3]= "ALPHABETIC",
-		symbols[Group1]= [               m,               M ],
-		symbols[Group2]= [               m,               M,              mu,        Hangul_O ],
-		symbols[Group3]= [               m,               M ]
+		type[1]= "ALPHABETIC",
+		type[2]= "FOUR_LEVEL_SEMIALPHABETIC",
+		type[3]= "ALPHABETIC",
+		symbols[1]= [               m,               M ],
+		symbols[2]= [               m,               M,              mu,        Hangul_O ],
+		symbols[3]= [               m,               M ]
 	};
 	key <AB08>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [           comma,            less ],
-		symbols[Group2]= [           comma,       semicolon,  horizconnector,        multiply ],
-		symbols[Group3]= [           comma,            less ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [           comma,            less ],
+		symbols[2]= [           comma,       semicolon,  horizconnector,        multiply ],
+		symbols[3]= [           comma,            less ]
 	};
 	key <AB09>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [          period,         greater ],
-		symbols[Group2]= [          period,           colon,  periodcentered,        division ],
-		symbols[Group3]= [          period,         greater ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [          period,         greater ],
+		symbols[2]= [          period,           colon,  periodcentered,        division ],
+		symbols[3]= [          period,         greater ]
 	};
 	key <AB10>               {
-		type[Group2]= "FOUR_LEVEL",
-		symbols[Group1]= [           slash,        question ],
-		symbols[Group2]= [           minus,      underscore,   dead_belowdot,   dead_abovedot ],
-		symbols[Group3]= [           slash,        question ]
+		type[2]= "FOUR_LEVEL",
+		symbols[1]= [           slash,        question ],
+		symbols[2]= [           minus,      underscore,   dead_belowdot,   dead_abovedot ],
+		symbols[3]= [           slash,        question ]
 	};
 	key <RTSH>               {	[         Shift_R ] };
 	key <KPMU>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [     KP_Multiply,     KP_Multiply,     KP_Multiply,     KP_Multiply,   XF86ClearGrab ]
+		symbols[1]= [     KP_Multiply,     KP_Multiply,     KP_Multiply,     KP_Multiply,   XF86ClearGrab ]
 	};
 	key <LALT>               {	[           Alt_L,          Meta_L ] };
 	key <SPCE>               {	[           space ] };
 	key <CAPS>               {	[       Caps_Lock,  ISO_Next_Group ] };
 	key <FK01>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [              F1,              F1,              F1,              F1, XF86Switch_VT_1 ]
+		symbols[1]= [              F1,              F1,              F1,              F1, XF86Switch_VT_1 ]
 	};
 	key <FK02>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [              F2,              F2,              F2,              F2, XF86Switch_VT_2 ]
+		symbols[1]= [              F2,              F2,              F2,              F2, XF86Switch_VT_2 ]
 	};
 	key <FK03>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [              F3,              F3,              F3,              F3, XF86Switch_VT_3 ]
+		symbols[1]= [              F3,              F3,              F3,              F3, XF86Switch_VT_3 ]
 	};
 	key <FK04>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [              F4,              F4,              F4,              F4, XF86Switch_VT_4 ]
+		symbols[1]= [              F4,              F4,              F4,              F4, XF86Switch_VT_4 ]
 	};
 	key <FK05>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [              F5,              F5,              F5,              F5, XF86Switch_VT_5 ]
+		symbols[1]= [              F5,              F5,              F5,              F5, XF86Switch_VT_5 ]
 	};
 	key <FK06>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [              F6,              F6,              F6,              F6, XF86Switch_VT_6 ]
+		symbols[1]= [              F6,              F6,              F6,              F6, XF86Switch_VT_6 ]
 	};
 	key <FK07>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [              F7,              F7,              F7,              F7, XF86Switch_VT_7 ]
+		symbols[1]= [              F7,              F7,              F7,              F7, XF86Switch_VT_7 ]
 	};
 	key <FK08>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [              F8,              F8,              F8,              F8, XF86Switch_VT_8 ]
+		symbols[1]= [              F8,              F8,              F8,              F8, XF86Switch_VT_8 ]
 	};
 	key <FK09>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [              F9,              F9,              F9,              F9, XF86Switch_VT_9 ]
+		symbols[1]= [              F9,              F9,              F9,              F9, XF86Switch_VT_9 ]
 	};
 	key <FK10>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [             F10,             F10,             F10,             F10, XF86Switch_VT_10 ]
+		symbols[1]= [             F10,             F10,             F10,             F10, XF86Switch_VT_10 ]
 	};
 	key <NMLK>               {	[        Num_Lock ] };
 	key <SCLK>               {	[     Scroll_Lock ] };
@@ -1480,14 +1480,14 @@ xkb_symbols "pc_us_pt_2_us_3_inet(evdev)_group(shift_caps_toggle)_compose(ralt)"
 	key <KP9>                {	[        KP_Prior,            KP_9 ] };
 	key <KPSU>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [     KP_Subtract,     KP_Subtract,     KP_Subtract,     KP_Subtract,  XF86Prev_VMode ]
+		symbols[1]= [     KP_Subtract,     KP_Subtract,     KP_Subtract,     KP_Subtract,  XF86Prev_VMode ]
 	};
 	key <KP4>                {	[         KP_Left,            KP_4 ] };
 	key <KP5>                {	[        KP_Begin,            KP_5 ] };
 	key <KP6>                {	[        KP_Right,            KP_6 ] };
 	key <KPAD>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [          KP_Add,          KP_Add,          KP_Add,          KP_Add,  XF86Next_VMode ]
+		symbols[1]= [          KP_Add,          KP_Add,          KP_Add,          KP_Add,  XF86Next_VMode ]
 	};
 	key <KP1>                {	[          KP_End,            KP_1 ] };
 	key <KP2>                {	[         KP_Down,            KP_2 ] };
@@ -1496,20 +1496,20 @@ xkb_symbols "pc_us_pt_2_us_3_inet(evdev)_group(shift_caps_toggle)_compose(ralt)"
 	key <KPDL>               {	[       KP_Delete,      KP_Decimal ] };
 	key <LVL3>               {
 		type= "ONE_LEVEL",
-		symbols[Group1]= [ ISO_Level3_Shift ]
+		symbols[1]= [ ISO_Level3_Shift ]
 	};
 	key <LSGT>               {
 		type= "FOUR_LEVEL",
-		symbols[Group1]= [            less,         greater,             bar,       brokenbar ],
-		symbols[Group2]= [            less,         greater,       backslash,       backslash ]
+		symbols[1]= [            less,         greater,             bar,       brokenbar ],
+		symbols[2]= [            less,         greater,       backslash,       backslash ]
 	};
 	key <FK11>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [             F11,             F11,             F11,             F11, XF86Switch_VT_11 ]
+		symbols[1]= [             F11,             F11,             F11,             F11, XF86Switch_VT_11 ]
 	};
 	key <FK12>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [             F12,             F12,             F12,             F12, XF86Switch_VT_12 ]
+		symbols[1]= [             F12,             F12,             F12,             F12, XF86Switch_VT_12 ]
 	};
 	key <KATA>               {	[        Katakana ] };
 	key <HIRA>               {	[        Hiragana ] };
@@ -1520,17 +1520,17 @@ xkb_symbols "pc_us_pt_2_us_3_inet(evdev)_group(shift_caps_toggle)_compose(ralt)"
 	key <RCTL>               {	[       Control_R ] };
 	key <KPDV>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [       KP_Divide,       KP_Divide,       KP_Divide,       KP_Divide,      XF86Ungrab ]
+		symbols[1]= [       KP_Divide,       KP_Divide,       KP_Divide,       KP_Divide,      XF86Ungrab ]
 	};
 	key <PRSC>               {
 		type= "PC_ALT_LEVEL2",
-		symbols[Group1]= [           Print,         Sys_Req ]
+		symbols[1]= [           Print,         Sys_Req ]
 	};
 	key <RALT>               {
-		type[Group1]= "TWO_LEVEL",
-		type[Group2]= "ONE_LEVEL",
-		symbols[Group1]= [       Multi_key,       Multi_key ],
-		symbols[Group2]= [ ISO_Level3_Shift ]
+		type[1]= "TWO_LEVEL",
+		type[2]= "ONE_LEVEL",
+		symbols[1]= [       Multi_key,       Multi_key ],
+		symbols[2]= [ ISO_Level3_Shift ]
 	};
 	key <LNFD>               {	[        Linefeed ] };
 	key <HOME>               {	[            Home ] };
@@ -1551,7 +1551,7 @@ xkb_symbols "pc_us_pt_2_us_3_inet(evdev)_group(shift_caps_toggle)_compose(ralt)"
 	key <I126>               {	[       plusminus ] };
 	key <PAUS>               {
 		type= "PC_CONTROL_LEVEL2",
-		symbols[Group1]= [           Pause,           Break ]
+		symbols[1]= [           Pause,           Break ]
 	};
 	key <I128>               {	[     XF86LaunchA ] };
 	key <I129>               {	[      KP_Decimal,      KP_Decimal ] };
@@ -1660,8 +1660,8 @@ xkb_symbols "pc_us_pt_2_us_3_inet(evdev)_group(shift_caps_toggle)_compose(ralt)"
 	key <I246>               {	[        XF86WLAN ] };
 	key <I247>               {
 		repeat= Yes,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [       SetMods(modifiers=Shift) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [       SetMods(modifiers=Shift) ]
 	};
 	modifier_map Shift { <LFSH>, <RTSH> };
 	modifier_map Lock { <CAPS> };

--- a/test/data/keymaps/include-level3-explicit-default.xkb
+++ b/test/data/keymaps/include-level3-explicit-default.xkb
@@ -41,7 +41,7 @@ xkb_compatibility {
 xkb_symbols "level3" {
 	key <LVL3>               {
 		type= "ONE_LEVEL",
-		symbols[Group1]= [ ISO_Level3_Shift ]
+		symbols[1]= [ ISO_Level3_Shift ]
 	};
 	key <RALT>               {	[ ISO_Level3_Shift, ISO_Level3_Lock ] };
 	modifier_map Mod5 { <LVL3> };

--- a/test/data/keymaps/integers.xkb
+++ b/test/data/keymaps/integers.xkb
@@ -23,10 +23,10 @@ xkb_compatibility {
 xkb_symbols {
 	key <>                   {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              MovePtr(x=0,y=+0) ],
-		symbols[Group2]= [                       NoSymbol ],
-		actions[Group2]= [           MovePtr(x=2,y=32766) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              MovePtr(x=0,y=+0) ],
+		symbols[2]= [                       NoSymbol ],
+		actions[2]= [           MovePtr(x=2,y=32766) ]
 	};
 };
 

--- a/test/data/keymaps/masks-extra-bits.xkb
+++ b/test/data/keymaps/masks-extra-bits.xkb
@@ -26,8 +26,8 @@ xkb_compatibility {
 xkb_symbols {
 	key <a>                  {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [      SetMods(modifiers=0x1100) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [      SetMods(modifiers=0x1100) ]
 	};
 };
 

--- a/test/data/keymaps/merge-modes/augment.xkb
+++ b/test/data/keymaps/merge-modes/augment.xkb
@@ -278,553 +278,553 @@ xkb_symbols "" {
 	key <T004>               {	[     Greek_alpha ] };
 	key <T005>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T006>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T007>               {	[               a ] };
 	key <T008>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2) ]
 	};
 	key <T009>               {
 		repeat= No,
-		symbols[Group1]= [                              a ],
-		actions[Group1]= [              SetGroup(group=2) ]
+		symbols[1]= [                              a ],
+		actions[1]= [              SetGroup(group=2) ]
 	};
 	key <T010>               {	[               a ] };
 	key <T011>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2) ]
 	};
 	key <T012>               {
 		repeat= No,
-		symbols[Group1]= [                              a ],
-		actions[Group1]= [              SetGroup(group=2) ]
+		symbols[1]= [                              a ],
+		actions[1]= [              SetGroup(group=2) ]
 	};
 	key <T013>               {	[               a,        { A, Y } ] };
 	key <T014>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T015>               {
 		repeat= No,
-		symbols[Group1]= [                              a, {                              A,                              Y } ],
-		actions[Group1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                              a, {                              A,                              Y } ],
+		actions[1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T016>               {	[     Greek_alpha,               A ] };
 	key <T017>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T018>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                    Greek_alpha,                              A ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T020>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T021>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                    Greek_alpha,                              A ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T022>               {	[     Greek_alpha,               A ] };
 	key <T023>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T024>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                    Greek_alpha,                              A ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T025>               {	[               a,               A,     Greek_alpha,        NoSymbol ] };
 	key <T026>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2),              SetGroup(group=3),                     NoAction() ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2),              SetGroup(group=3),                     NoAction() ]
 	};
 	key <T027>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              A,                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2),              SetGroup(group=3),                     NoAction() ]
+		symbols[1]= [                              a,                              A,                    Greek_alpha,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2),              SetGroup(group=3),                     NoAction() ]
 	};
 	key <T028>               {	[               a,               A,               a,        NoSymbol ] };
 	key <T029>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2),              SetGroup(group=2),                     NoAction() ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2),              SetGroup(group=2),                     NoAction() ]
 	};
 	key <T030>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              A,                              a,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2),              SetGroup(group=2),                     NoAction() ]
+		symbols[1]= [                              a,                              A,                              a,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2),              SetGroup(group=2),                     NoAction() ]
 	};
 	key <T034>               {	[     Greek_alpha ] };
 	key <T035>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T036>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T037>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T038>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T039>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                    Greek_ALPHA ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                    Greek_ALPHA ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T043>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T044>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T045>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T046>               {	[               a,               A ] };
 	key <T047>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T048>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              A ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              A ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T049>               {	[               a,               A ] };
 	key <T050>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T051>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              A ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              A ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T052>               {	[               a,               A ] };
 	key <T053>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T054>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              A ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              A ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T055>               {	[               a,               A ] };
 	key <T056>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T057>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              A ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              A ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T060>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              X ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              X ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T061>               {	[     Greek_alpha ] };
 	key <T062>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T063>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T064>               {	[     Greek_alpha ] };
 	key <T065>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T066>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T067>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T068>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T069>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                    Greek_ALPHA ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                    Greek_ALPHA ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T070>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T071>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T072>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                    Greek_ALPHA ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                    Greek_ALPHA ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T073>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T074>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T075>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T076>               {	[ { Greek_alpha, Greek_upsilon }, { Greek_ALPHA, Greek_UPSILON } ] };
 	key <T077>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T078>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T079>               {	[               a,               A ] };
 	key <T080>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T081>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              A ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              A ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T085>               {	[               a,               A ] };
 	key <T086>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T087>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              A ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              A ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T088>               {	[               a,               A ] };
 	key <T089>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T090>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              A ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              A ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T091>               {	[               a,               A ] };
 	key <T092>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T093>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              A ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              A ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T094>               {	[               a,               A ] };
 	key <T095>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T096>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              A ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              A ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T097>               {	[               a,               A ] };
 	key <T098>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T099>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              A ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              A ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T103>               {	[        NoSymbol, { Greek_ALPHA, Greek_UPSILON } ] };
 	key <T104>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T105>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol, {                    Greek_ALPHA,                  Greek_UPSILON } ],
-		actions[Group1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol, {                    Greek_ALPHA,                  Greek_UPSILON } ],
+		actions[1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T106>               {	[     Greek_alpha,      Greek_BETA ] };
 	key <T107>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T108>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                     Greek_BETA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                     Greek_BETA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T109>               {	[ { Greek_alpha, Greek_upsilon },        { A, Y } ] };
 	key <T110>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T111>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                              A,                              Y } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                              A,                              Y } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T112>               {	[               a,               B ] };
 	key <T113>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T114>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              B ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              B ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T115>               {	[               a,               B ] };
 	key <T116>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T117>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              B ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              B ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T118>               {	[        { a, y },        { A, Y } ] };
 	key <T119>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T120>               {
 		repeat= No,
-		symbols[Group1]= [ {                              a,                              y }, {                              A,                              Y } ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [ {                              a,                              y }, {                              A,                              Y } ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T121>               {	[        { a, y },        { X, B } ] };
 	key <T122>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
 	};
 	key <T123>               {
 		repeat= No,
-		symbols[Group1]= [ {                              a,                              y }, {                              X,                              B } ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
+		symbols[1]= [ {                              a,                              y }, {                              X,                              B } ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
 	};
 	key <T127>               {	[ { Greek_alpha, Greek_xi }, { Greek_XI, Greek_BETA } ] };
 	key <T128>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T129>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                       Greek_xi }, {                       Greek_XI,                     Greek_BETA } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [ {                    Greek_alpha,                       Greek_xi }, {                       Greek_XI,                     Greek_BETA } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T130>               {	[        { a, y },        { X, A } ] };
 	key <T131>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
 	};
 	key <T132>               {
 		repeat= No,
-		symbols[Group1]= [ {                              a,                              y }, {                              X,                              A } ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
+		symbols[1]= [ {                              a,                              y }, {                              X,                              A } ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
 	};
 	key <T133>               {	[        { a, y },        { X, A } ] };
 	key <T134>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
 	};
 	key <T135>               {
 		repeat= No,
-		symbols[Group1]= [ {                              a,                              y }, {                              X,                              A } ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
+		symbols[1]= [ {                              a,                              y }, {                              X,                              A } ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
 	};
 	key <T136>               {	[        NoSymbol,        { A, Y } ] };
 	key <T137>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T138>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol, {                              A,                              Y } ],
-		actions[Group1]= [                     NoAction(), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                       NoSymbol, {                              A,                              Y } ],
+		actions[1]= [                     NoAction(), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T139>               {	[     Greek_alpha,        { A, Y } ] };
 	key <T140>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T141>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha, {                              A,                              Y } ],
-		actions[Group1]= [              SetGroup(group=3), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                    Greek_alpha, {                              A,                              Y } ],
+		actions[1]= [              SetGroup(group=3), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T142>               {	[               a,               B ] };
 	key <T143>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T144>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              B ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              B ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T145>               {	[               a,               B ] };
 	key <T146>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T147>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              B ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              B ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T150>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T153>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) },              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) },              SetGroup(group=3) ]
 	};
 	key <T156>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T159>               {
 		repeat= No,
-		symbols[Group1]= [                              a, {                              X,                              Y } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=2) ]
+		symbols[1]= [                              a, {                              X,                              Y } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=2) ]
 	};
 	key <T162>               {
 		repeat= No,
-		symbols[Group1]= [ {                              a,                              b },                              X ],
-		actions[Group1]= [              SetGroup(group=3), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [ {                              a,                              b },                              X ],
+		actions[1]= [              SetGroup(group=3), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T165>               {
 		repeat= No,
-		symbols[Group1]= [ {                              a,                              b }, {                              X,                              Y } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [ {                              a,                              b }, {                              X,                              Y } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T168>               {
 		repeat= No,
-		symbols[Group1]= [                              a, {                              X,                              Y } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=2) ]
+		symbols[1]= [                              a, {                              X,                              Y } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=2) ]
 	};
 	key <T171>               {
 		repeat= No,
-		symbols[Group1]= [ {                              a,                              b }, {                              X,                              Y } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [ {                              a,                              b }, {                              X,                              Y } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T174>               {
 		repeat= No,
-		symbols[Group1]= [ {                              a,                              b }, {                              A,                              B } ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [ {                              a,                              b }, {                              A,                              B } ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T177>               {
 		repeat= No,
-		symbols[Group1]= [                              a, {                              A,                              B } ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) },              SetGroup(group=2) ]
+		symbols[1]= [                              a, {                              A,                              B } ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) },              SetGroup(group=2) ]
 	};
 	key <T180>               {
 		repeat= No,
-		symbols[Group1]= [ {                              a,                              b },                              B ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) },              SetGroup(group=2) ]
+		symbols[1]= [ {                              a,                              b },                              B ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) },              SetGroup(group=2) ]
 	};
 	key <T183>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              B ],
-		actions[Group1]= [              SetGroup(group=2),     SetMods(modifiers=Control) ]
+		symbols[1]= [                              a,                              B ],
+		actions[1]= [              SetGroup(group=2),     SetMods(modifiers=Control) ]
 	};
 	key <T186>               {
 		repeat= No,
-		symbols[Group1]= [                              a, {                              A,                              B } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
+		symbols[1]= [                              a, {                              A,                              B } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
 	};
 	key <T189>               {
 		repeat= No,
-		symbols[Group1]= [ {                              A,                              B },                              a ],
-		actions[Group1]= [              SetGroup(group=3), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                              A,                              B },                              a ],
+		actions[1]= [              SetGroup(group=3), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T192>               {
 		repeat= No,
-		symbols[Group1]= [                              a, {                              A,                              B } ],
-		actions[Group1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                              a, {                              A,                              B } ],
+		actions[1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T204>               {
 		repeat= No,
-		symbols[Group1]= [                              A ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                              A ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T207>               {
 		repeat= No,
-		symbols[Group1]= [                              A ],
-		actions[Group1]= [              SetGroup(group=2) ]
+		symbols[1]= [                              A ],
+		actions[1]= [              SetGroup(group=2) ]
 	};
 };
 

--- a/test/data/keymaps/merge-modes/default.xkb
+++ b/test/data/keymaps/merge-modes/default.xkb
@@ -278,553 +278,553 @@ xkb_symbols "" {
 	key <T004>               {	[     Greek_alpha ] };
 	key <T005>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T006>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T007>               {	[               a ] };
 	key <T008>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2) ]
 	};
 	key <T009>               {
 		repeat= No,
-		symbols[Group1]= [                              a ],
-		actions[Group1]= [              SetGroup(group=2) ]
+		symbols[1]= [                              a ],
+		actions[1]= [              SetGroup(group=2) ]
 	};
 	key <T010>               {	[               a ] };
 	key <T011>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2) ]
 	};
 	key <T012>               {
 		repeat= No,
-		symbols[Group1]= [                              a ],
-		actions[Group1]= [              SetGroup(group=2) ]
+		symbols[1]= [                              a ],
+		actions[1]= [              SetGroup(group=2) ]
 	};
 	key <T013>               {	[               a,        { A, Y } ] };
 	key <T014>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T015>               {
 		repeat= No,
-		symbols[Group1]= [                              a, {                              A,                              Y } ],
-		actions[Group1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                              a, {                              A,                              Y } ],
+		actions[1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T016>               {	[     Greek_alpha,               A ] };
 	key <T017>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T018>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                    Greek_alpha,                              A ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T020>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T021>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                    Greek_alpha,                              A ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T022>               {	[     Greek_alpha,               A ] };
 	key <T023>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T024>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                    Greek_alpha,                              A ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T025>               {	[     Greek_alpha,     Greek_ALPHA,     Greek_alpha,        NoSymbol ] };
 	key <T026>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=3),                     NoAction() ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=3),                     NoAction() ]
 	};
 	key <T027>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA,                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=3),                     NoAction() ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA,                    Greek_alpha,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=3),                     NoAction() ]
 	};
 	key <T028>               {	[     Greek_alpha,     Greek_ALPHA,               a,        NoSymbol ] };
 	key <T029>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=2),                     NoAction() ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=2),                     NoAction() ]
 	};
 	key <T030>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA,                              a,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=2),                     NoAction() ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA,                              a,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=2),                     NoAction() ]
 	};
 	key <T034>               {	[     Greek_alpha ] };
 	key <T035>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T036>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T037>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T038>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T039>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                    Greek_ALPHA ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                    Greek_ALPHA ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T043>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T044>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T045>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T046>               {	[               a,               A ] };
 	key <T047>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T048>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              A ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              A ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T049>               {	[     Greek_alpha,               A ] };
 	key <T050>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T051>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                    Greek_alpha,                              A ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T052>               {	[               a,     Greek_ALPHA ] };
 	key <T053>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=3) ]
 	};
 	key <T054>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=3) ]
+		symbols[1]= [                              a,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=3) ]
 	};
 	key <T055>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T056>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T057>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T060>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              X ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              X ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T061>               {	[     Greek_alpha ] };
 	key <T062>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T063>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T064>               {	[     Greek_alpha ] };
 	key <T065>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T066>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T067>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T068>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T069>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                    Greek_ALPHA ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                    Greek_ALPHA ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T070>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T071>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T072>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                    Greek_ALPHA ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                    Greek_ALPHA ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T073>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T074>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T075>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T076>               {	[ { Greek_alpha, Greek_upsilon }, { Greek_ALPHA, Greek_UPSILON } ] };
 	key <T077>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T078>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T079>               {	[     Greek_alpha,               A ] };
 	key <T080>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T081>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                    Greek_alpha,                              A ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T085>               {	[     Greek_alpha,               A ] };
 	key <T086>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T087>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                    Greek_alpha,                              A ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T088>               {	[               a,     Greek_ALPHA ] };
 	key <T089>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=3) ]
 	};
 	key <T090>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=3) ]
+		symbols[1]= [                              a,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=3) ]
 	};
 	key <T091>               {	[               a,     Greek_ALPHA ] };
 	key <T092>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=3) ]
 	};
 	key <T093>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=3) ]
+		symbols[1]= [                              a,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=3) ]
 	};
 	key <T094>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T095>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T096>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T097>               {	[ { Greek_alpha, Greek_upsilon }, { Greek_ALPHA, Greek_UPSILON } ] };
 	key <T098>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T099>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T103>               {	[        NoSymbol, { Greek_ALPHA, Greek_UPSILON } ] };
 	key <T104>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T105>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol, {                    Greek_ALPHA,                  Greek_UPSILON } ],
-		actions[Group1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol, {                    Greek_ALPHA,                  Greek_UPSILON } ],
+		actions[1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T106>               {	[     Greek_alpha,      Greek_BETA ] };
 	key <T107>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T108>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                     Greek_BETA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                     Greek_BETA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T109>               {	[ { Greek_alpha, Greek_upsilon }, { Greek_ALPHA, Greek_UPSILON } ] };
 	key <T110>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T111>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T112>               {	[     Greek_alpha,      Greek_BETA ] };
 	key <T113>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T114>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                     Greek_BETA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                     Greek_BETA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T115>               {	[ { Greek_alpha, Greek_upsilon }, { Greek_XI, Greek_BETA } ] };
 	key <T116>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T117>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                       Greek_XI,                     Greek_BETA } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                       Greek_XI,                     Greek_BETA } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T118>               {	[        { a, y }, { Greek_ALPHA, Greek_UPSILON } ] };
 	key <T119>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T120>               {
 		repeat= No,
-		symbols[Group1]= [ {                              a,                              y }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                              a,                              y }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T121>               {	[     Greek_alpha,      Greek_BETA ] };
 	key <T122>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T123>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                     Greek_BETA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                     Greek_BETA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T127>               {	[ { Greek_alpha, Greek_xi }, { Greek_XI, Greek_BETA } ] };
 	key <T128>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T129>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                       Greek_xi }, {                       Greek_XI,                     Greek_BETA } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [ {                    Greek_alpha,                       Greek_xi }, {                       Greek_XI,                     Greek_BETA } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T130>               {	[        { a, y },        { X, A } ] };
 	key <T131>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
 	};
 	key <T132>               {
 		repeat= No,
-		symbols[Group1]= [ {                              a,                              y }, {                              X,                              A } ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
+		symbols[1]= [ {                              a,                              y }, {                              X,                              A } ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
 	};
 	key <T133>               {	[ { Greek_alpha, Greek_xi }, { Greek_XI, Greek_BETA } ] };
 	key <T134>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T135>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                       Greek_xi }, {                       Greek_XI,                     Greek_BETA } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [ {                    Greek_alpha,                       Greek_xi }, {                       Greek_XI,                     Greek_BETA } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T136>               {	[        NoSymbol,        { A, Y } ] };
 	key <T137>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T138>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol, {                              A,                              Y } ],
-		actions[Group1]= [                     NoAction(), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                       NoSymbol, {                              A,                              Y } ],
+		actions[1]= [                     NoAction(), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T139>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T140>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T141>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T142>               {	[               a,               B ] };
 	key <T143>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T144>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              B ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              B ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T145>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T146>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T147>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T150>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T153>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
 	};
 	key <T156>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
 	};
 	key <T159>               {
 		repeat= No,
-		symbols[Group1]= [                              a, {                              X,                              Y } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=2) ]
+		symbols[1]= [                              a, {                              X,                              Y } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=2) ]
 	};
 	key <T162>               {
 		repeat= No,
-		symbols[Group1]= [ {                              a,                              b },                              X ],
-		actions[Group1]= [              SetGroup(group=3), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [ {                              a,                              b },                              X ],
+		actions[1]= [              SetGroup(group=3), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T165>               {
 		repeat= No,
-		symbols[Group1]= [ {                              a,                              b }, {                              X,                              Y } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [ {                              a,                              b }, {                              X,                              Y } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T168>               {
 		repeat= No,
-		symbols[Group1]= [ {                              x,                              y }, {                              X,                              Y } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                              x,                              y }, {                              X,                              Y } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T171>               {
 		repeat= No,
-		symbols[Group1]= [                              x, {                              X,                              Y } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
+		symbols[1]= [                              x, {                              X,                              Y } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
 	};
 	key <T174>               {
 		repeat= No,
-		symbols[Group1]= [                              x, {                              A,                              B } ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) },              SetGroup(group=3) ]
+		symbols[1]= [                              x, {                              A,                              B } ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) },              SetGroup(group=3) ]
 	};
 	key <T177>               {
 		repeat= No,
-		symbols[Group1]= [ {                              x,                              y }, {                              A,                              B } ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                              x,                              y }, {                              A,                              B } ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T180>               {
 		repeat= No,
-		symbols[Group1]= [                              y, {                              X,                              Y } ],
-		actions[Group1]= [              SetGroup(group=3), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                              y, {                              X,                              Y } ],
+		actions[1]= [              SetGroup(group=3), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T183>               {
 		repeat= No,
-		symbols[Group1]= [                              y,                              X ],
-		actions[Group1]= [        SetMods(modifiers=Mod5),              SetGroup(group=3) ]
+		symbols[1]= [                              y,                              X ],
+		actions[1]= [        SetMods(modifiers=Mod5),              SetGroup(group=3) ]
 	};
 	key <T186>               {
 		repeat= No,
-		symbols[Group1]= [                              a, {                              A,                              B } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
+		symbols[1]= [                              a, {                              A,                              B } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
 	};
 	key <T189>               {
 		repeat= No,
-		symbols[Group1]= [ {                              A,                              B },                              a ],
-		actions[Group1]= [              SetGroup(group=3), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                              A,                              B },                              a ],
+		actions[1]= [              SetGroup(group=3), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T192>               {
 		repeat= No,
-		symbols[Group1]= [ {                              x,                              y },                              X ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
+		symbols[1]= [ {                              x,                              y },                              X ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
 	};
 	key <T204>               {
 		repeat= No,
-		symbols[Group1]= [ {                              A,                              A } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                              A,                              A } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T207>               {
 		repeat= No,
-		symbols[Group1]= [                              Y ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                              Y ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 };
 

--- a/test/data/keymaps/merge-modes/defaults-include.xkb
+++ b/test/data/keymaps/merge-modes/defaults-include.xkb
@@ -73,7 +73,7 @@ xkb_compatibility "merge_modes_defaults" {
 };
 
 xkb_symbols "merge_modes_defaults" {
-	name[Group1]="yyy";
+	name[1]="yyy";
 
 	key <A>                  {	[               a,               A ] };
 	key <S>                  {	[               s,               S ] };
@@ -90,7 +90,7 @@ xkb_symbols "merge_modes_defaults" {
 	key <G>                  {
 		type= "ONE_LEVEL",
 		repeat= Yes,
-		symbols[Group1]= [               g ]
+		symbols[1]= [               g ]
 	};
 	modifier_map Shift { <A> };
 	modifier_map Control { <S> };

--- a/test/data/keymaps/merge-modes/defaults-plain.xkb
+++ b/test/data/keymaps/merge-modes/defaults-plain.xkb
@@ -73,7 +73,7 @@ xkb_compatibility {
 };
 
 xkb_symbols {
-	name[Group1]="yyy";
+	name[1]="yyy";
 
 	key <A>                  {	[               a,               A ] };
 	key <S>                  {	[               s,               S ] };
@@ -90,7 +90,7 @@ xkb_symbols {
 	key <G>                  {
 		type= "ONE_LEVEL",
 		repeat= Yes,
-		symbols[Group1]= [               g ]
+		symbols[1]= [               g ]
 	};
 	modifier_map Shift { <A> };
 	modifier_map Control { <S> };

--- a/test/data/keymaps/merge-modes/override.xkb
+++ b/test/data/keymaps/merge-modes/override.xkb
@@ -278,553 +278,553 @@ xkb_symbols "" {
 	key <T004>               {	[     Greek_alpha ] };
 	key <T005>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T006>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T007>               {	[               a ] };
 	key <T008>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2) ]
 	};
 	key <T009>               {
 		repeat= No,
-		symbols[Group1]= [                              a ],
-		actions[Group1]= [              SetGroup(group=2) ]
+		symbols[1]= [                              a ],
+		actions[1]= [              SetGroup(group=2) ]
 	};
 	key <T010>               {	[               a ] };
 	key <T011>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2) ]
 	};
 	key <T012>               {
 		repeat= No,
-		symbols[Group1]= [                              a ],
-		actions[Group1]= [              SetGroup(group=2) ]
+		symbols[1]= [                              a ],
+		actions[1]= [              SetGroup(group=2) ]
 	};
 	key <T013>               {	[               a,        { A, Y } ] };
 	key <T014>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T015>               {
 		repeat= No,
-		symbols[Group1]= [                              a, {                              A,                              Y } ],
-		actions[Group1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                              a, {                              A,                              Y } ],
+		actions[1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T016>               {	[     Greek_alpha,               A ] };
 	key <T017>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T018>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                    Greek_alpha,                              A ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T020>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T021>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                    Greek_alpha,                              A ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T022>               {	[     Greek_alpha,               A ] };
 	key <T023>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T024>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                    Greek_alpha,                              A ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T025>               {	[     Greek_alpha,     Greek_ALPHA,     Greek_alpha,        NoSymbol ] };
 	key <T026>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=3),                     NoAction() ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=3),                     NoAction() ]
 	};
 	key <T027>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA,                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=3),                     NoAction() ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA,                    Greek_alpha,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=3),                     NoAction() ]
 	};
 	key <T028>               {	[     Greek_alpha,     Greek_ALPHA,               a,        NoSymbol ] };
 	key <T029>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=2),                     NoAction() ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=2),                     NoAction() ]
 	};
 	key <T030>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA,                              a,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=2),                     NoAction() ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA,                              a,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=2),                     NoAction() ]
 	};
 	key <T034>               {	[     Greek_alpha ] };
 	key <T035>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T036>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T037>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T038>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T039>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                    Greek_ALPHA ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                    Greek_ALPHA ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T043>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T044>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T045>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T046>               {	[               a,               A ] };
 	key <T047>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T048>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              A ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              A ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T049>               {	[     Greek_alpha,               A ] };
 	key <T050>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T051>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                    Greek_alpha,                              A ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T052>               {	[               a,     Greek_ALPHA ] };
 	key <T053>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=3) ]
 	};
 	key <T054>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=3) ]
+		symbols[1]= [                              a,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=3) ]
 	};
 	key <T055>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T056>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T057>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T060>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              X ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              X ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T061>               {	[     Greek_alpha ] };
 	key <T062>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T063>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T064>               {	[     Greek_alpha ] };
 	key <T065>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T066>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T067>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T068>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T069>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                    Greek_ALPHA ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                    Greek_ALPHA ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T070>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T071>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T072>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                    Greek_ALPHA ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                    Greek_ALPHA ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T073>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T074>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T075>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T076>               {	[ { Greek_alpha, Greek_upsilon }, { Greek_ALPHA, Greek_UPSILON } ] };
 	key <T077>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T078>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T079>               {	[     Greek_alpha,               A ] };
 	key <T080>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T081>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                    Greek_alpha,                              A ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T085>               {	[     Greek_alpha,               A ] };
 	key <T086>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T087>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                              A ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=2) ]
+		symbols[1]= [                    Greek_alpha,                              A ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=2) ]
 	};
 	key <T088>               {	[               a,     Greek_ALPHA ] };
 	key <T089>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=3) ]
 	};
 	key <T090>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=3) ]
+		symbols[1]= [                              a,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=3) ]
 	};
 	key <T091>               {	[               a,     Greek_ALPHA ] };
 	key <T092>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=3) ]
 	};
 	key <T093>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=3) ]
+		symbols[1]= [                              a,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=3) ]
 	};
 	key <T094>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T095>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T096>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T097>               {	[ { Greek_alpha, Greek_upsilon }, { Greek_ALPHA, Greek_UPSILON } ] };
 	key <T098>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T099>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T103>               {	[        NoSymbol, { Greek_ALPHA, Greek_UPSILON } ] };
 	key <T104>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T105>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol, {                    Greek_ALPHA,                  Greek_UPSILON } ],
-		actions[Group1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol, {                    Greek_ALPHA,                  Greek_UPSILON } ],
+		actions[1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T106>               {	[     Greek_alpha,      Greek_BETA ] };
 	key <T107>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T108>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                     Greek_BETA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                     Greek_BETA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T109>               {	[ { Greek_alpha, Greek_upsilon }, { Greek_ALPHA, Greek_UPSILON } ] };
 	key <T110>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T111>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T112>               {	[     Greek_alpha,      Greek_BETA ] };
 	key <T113>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T114>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                     Greek_BETA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                     Greek_BETA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T115>               {	[ { Greek_alpha, Greek_upsilon }, { Greek_XI, Greek_BETA } ] };
 	key <T116>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T117>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                       Greek_XI,                     Greek_BETA } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                       Greek_XI,                     Greek_BETA } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T118>               {	[        { a, y }, { Greek_ALPHA, Greek_UPSILON } ] };
 	key <T119>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T120>               {
 		repeat= No,
-		symbols[Group1]= [ {                              a,                              y }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                              a,                              y }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T121>               {	[     Greek_alpha,      Greek_BETA ] };
 	key <T122>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T123>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                     Greek_BETA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                     Greek_BETA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T127>               {	[ { Greek_alpha, Greek_xi }, { Greek_XI, Greek_BETA } ] };
 	key <T128>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T129>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                       Greek_xi }, {                       Greek_XI,                     Greek_BETA } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [ {                    Greek_alpha,                       Greek_xi }, {                       Greek_XI,                     Greek_BETA } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T130>               {	[        { a, y },        { X, A } ] };
 	key <T131>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
 	};
 	key <T132>               {
 		repeat= No,
-		symbols[Group1]= [ {                              a,                              y }, {                              X,                              A } ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
+		symbols[1]= [ {                              a,                              y }, {                              X,                              A } ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {     SetMods(modifiers=Control),              SetGroup(group=2) } ]
 	};
 	key <T133>               {	[ { Greek_alpha, Greek_xi }, { Greek_XI, Greek_BETA } ] };
 	key <T134>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T135>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                       Greek_xi }, {                       Greek_XI,                     Greek_BETA } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [ {                    Greek_alpha,                       Greek_xi }, {                       Greek_XI,                     Greek_BETA } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T136>               {	[        NoSymbol,        { A, Y } ] };
 	key <T137>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T138>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol, {                              A,                              Y } ],
-		actions[Group1]= [                     NoAction(), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                       NoSymbol, {                              A,                              Y } ],
+		actions[1]= [                     NoAction(), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T139>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T140>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T141>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T142>               {	[               a,               B ] };
 	key <T143>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T144>               {
 		repeat= No,
-		symbols[Group1]= [                              a,                              B ],
-		actions[Group1]= [              SetGroup(group=2),              SetGroup(group=2) ]
+		symbols[1]= [                              a,                              B ],
+		actions[1]= [              SetGroup(group=2),              SetGroup(group=2) ]
 	};
 	key <T145>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T146>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T147>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T150>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T153>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
 	};
 	key <T156>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
 	};
 	key <T159>               {
 		repeat= No,
-		symbols[Group1]= [                              a, {                              X,                              Y } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=2) ]
+		symbols[1]= [                              a, {                              X,                              Y } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=2) ]
 	};
 	key <T162>               {
 		repeat= No,
-		symbols[Group1]= [ {                              a,                              b },                              X ],
-		actions[Group1]= [              SetGroup(group=3), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [ {                              a,                              b },                              X ],
+		actions[1]= [              SetGroup(group=3), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T165>               {
 		repeat= No,
-		symbols[Group1]= [ {                              a,                              b }, {                              X,                              Y } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [ {                              a,                              b }, {                              X,                              Y } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T168>               {
 		repeat= No,
-		symbols[Group1]= [ {                              x,                              y }, {                              X,                              Y } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                              x,                              y }, {                              X,                              Y } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T171>               {
 		repeat= No,
-		symbols[Group1]= [                              x, {                              X,                              Y } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
+		symbols[1]= [                              x, {                              X,                              Y } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
 	};
 	key <T174>               {
 		repeat= No,
-		symbols[Group1]= [                              x, {                              A,                              B } ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) },              SetGroup(group=3) ]
+		symbols[1]= [                              x, {                              A,                              B } ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) },              SetGroup(group=3) ]
 	};
 	key <T177>               {
 		repeat= No,
-		symbols[Group1]= [ {                              x,                              y }, {                              A,                              B } ],
-		actions[Group1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                              x,                              y }, {                              A,                              B } ],
+		actions[1]= [ {              SetGroup(group=2),     SetMods(modifiers=Control) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T180>               {
 		repeat= No,
-		symbols[Group1]= [                              y, {                              X,                              Y } ],
-		actions[Group1]= [              SetGroup(group=3), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                              y, {                              X,                              Y } ],
+		actions[1]= [              SetGroup(group=3), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T183>               {
 		repeat= No,
-		symbols[Group1]= [                              y,                              X ],
-		actions[Group1]= [        SetMods(modifiers=Mod5),              SetGroup(group=3) ]
+		symbols[1]= [                              y,                              X ],
+		actions[1]= [        SetMods(modifiers=Mod5),              SetGroup(group=3) ]
 	};
 	key <T186>               {
 		repeat= No,
-		symbols[Group1]= [                              a, {                              A,                              B } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
+		symbols[1]= [                              a, {                              A,                              B } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
 	};
 	key <T189>               {
 		repeat= No,
-		symbols[Group1]= [ {                              A,                              B },                              a ],
-		actions[Group1]= [              SetGroup(group=3), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                              A,                              B },                              a ],
+		actions[1]= [              SetGroup(group=3), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T192>               {
 		repeat= No,
-		symbols[Group1]= [ {                              x,                              y },                              X ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
+		symbols[1]= [ {                              x,                              y },                              X ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
 	};
 	key <T204>               {
 		repeat= No,
-		symbols[Group1]= [ {                              A,                              A } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                              A,                              A } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T207>               {
 		repeat= No,
-		symbols[Group1]= [                              Y ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                              Y ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 };
 

--- a/test/data/keymaps/merge-modes/replace.xkb
+++ b/test/data/keymaps/merge-modes/replace.xkb
@@ -278,494 +278,494 @@ xkb_symbols "" {
 	key <T004>               {	[     Greek_alpha ] };
 	key <T005>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T006>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T010>               {	[               a ] };
 	key <T011>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2) ]
 	};
 	key <T012>               {
 		repeat= No,
-		symbols[Group1]= [                              a ],
-		actions[Group1]= [              SetGroup(group=2) ]
+		symbols[1]= [                              a ],
+		actions[1]= [              SetGroup(group=2) ]
 	};
 	key <T013>               {	[               a,        { A, Y } ] };
 	key <T014>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T015>               {
 		repeat= No,
-		symbols[Group1]= [                              a, {                              A,                              Y } ],
-		actions[Group1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
+		symbols[1]= [                              a, {                              A,                              Y } ],
+		actions[1]= [              SetGroup(group=2), {              SetGroup(group=2),     SetMods(modifiers=Control) } ]
 	};
 	key <T016>               {	[     Greek_alpha ] };
 	key <T017>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T018>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T020>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T021>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T022>               {	[     Greek_alpha ] };
 	key <T023>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T024>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T025>               {	[     Greek_alpha,     Greek_ALPHA,     Greek_alpha,        NoSymbol ] };
 	key <T026>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=3),                     NoAction() ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=3),                     NoAction() ]
 	};
 	key <T027>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA,                    Greek_alpha,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=3),                     NoAction() ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA,                    Greek_alpha,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3),              SetGroup(group=3),                     NoAction() ]
 	};
 	key <T028>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T029>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T030>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T034>               {	[     Greek_alpha ] };
 	key <T035>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T036>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T037>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T038>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T039>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                    Greek_ALPHA ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                    Greek_ALPHA ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T043>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T044>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T045>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T049>               {	[     Greek_alpha ] };
 	key <T050>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T051>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T052>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T053>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T054>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                    Greek_ALPHA ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                    Greek_ALPHA ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T055>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T056>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T057>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T060>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                              X ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[1]= [                       NoSymbol,                              X ],
+		actions[1]= [              SetGroup(group=3),                     NoAction() ]
 	};
 	key <T061>               {	[     Greek_alpha ] };
 	key <T062>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T063>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T064>               {	[     Greek_alpha ] };
 	key <T065>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T066>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T067>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T068>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T069>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                    Greek_ALPHA ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                    Greek_ALPHA ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T070>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T071>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T072>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                    Greek_ALPHA ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                    Greek_ALPHA ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T073>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T074>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T075>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T076>               {	[ { Greek_alpha, Greek_upsilon }, { Greek_ALPHA, Greek_UPSILON } ] };
 	key <T077>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T078>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T079>               {	[     Greek_alpha ] };
 	key <T080>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T081>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T085>               {	[     Greek_alpha ] };
 	key <T086>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T087>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 	key <T088>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T089>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T090>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                    Greek_ALPHA ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                    Greek_ALPHA ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T091>               {	[        NoSymbol,     Greek_ALPHA ] };
 	key <T092>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T093>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                    Greek_ALPHA ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                    Greek_ALPHA ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T094>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T095>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T096>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T097>               {	[ { Greek_alpha, Greek_upsilon }, { Greek_ALPHA, Greek_UPSILON } ] };
 	key <T098>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T099>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T103>               {	[        NoSymbol, { Greek_ALPHA, Greek_UPSILON } ] };
 	key <T104>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T105>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol, {                    Greek_ALPHA,                  Greek_UPSILON } ],
-		actions[Group1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol, {                    Greek_ALPHA,                  Greek_UPSILON } ],
+		actions[1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T106>               {	[     Greek_alpha,      Greek_BETA ] };
 	key <T107>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T108>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                     Greek_BETA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                     Greek_BETA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T109>               {	[ { Greek_alpha, Greek_upsilon }, { Greek_ALPHA, Greek_UPSILON } ] };
 	key <T110>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T111>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                    Greek_ALPHA,                  Greek_UPSILON } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T112>               {	[     Greek_alpha,      Greek_BETA ] };
 	key <T113>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T114>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                     Greek_BETA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                     Greek_BETA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T115>               {	[ { Greek_alpha, Greek_upsilon }, { Greek_XI, Greek_BETA } ] };
 	key <T116>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T117>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                       Greek_XI,                     Greek_BETA } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [ {                    Greek_alpha,                  Greek_upsilon }, {                       Greek_XI,                     Greek_BETA } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T118>               {	[        NoSymbol, { Greek_ALPHA, Greek_UPSILON } ] };
 	key <T119>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T120>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol, {                    Greek_ALPHA,                  Greek_UPSILON } ],
-		actions[Group1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol, {                    Greek_ALPHA,                  Greek_UPSILON } ],
+		actions[1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T121>               {	[     Greek_alpha,      Greek_BETA ] };
 	key <T122>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T123>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                     Greek_BETA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                     Greek_BETA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T127>               {	[ { Greek_alpha, Greek_xi }, { Greek_XI, Greek_BETA } ] };
 	key <T128>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T129>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                       Greek_xi }, {                       Greek_XI,                     Greek_BETA } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [ {                    Greek_alpha,                       Greek_xi }, {                       Greek_XI,                     Greek_BETA } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T133>               {	[ { Greek_alpha, Greek_xi }, { Greek_XI, Greek_BETA } ] };
 	key <T134>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T135>               {
 		repeat= No,
-		symbols[Group1]= [ {                    Greek_alpha,                       Greek_xi }, {                       Greek_XI,                     Greek_BETA } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
+		symbols[1]= [ {                    Greek_alpha,                       Greek_xi }, {                       Greek_XI,                     Greek_BETA } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {        SetMods(modifiers=Mod5),              SetGroup(group=3) } ]
 	};
 	key <T139>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T140>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T141>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T145>               {	[     Greek_alpha,     Greek_ALPHA ] };
 	key <T146>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T147>               {
 		repeat= No,
-		symbols[Group1]= [                    Greek_alpha,                    Greek_ALPHA ],
-		actions[Group1]= [              SetGroup(group=3),              SetGroup(group=3) ]
+		symbols[1]= [                    Greek_alpha,                    Greek_ALPHA ],
+		actions[1]= [              SetGroup(group=3),              SetGroup(group=3) ]
 	};
 	key <T150>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T153>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
 	};
 	key <T156>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
 	};
 	key <T159>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol, {                              X,                              Y } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },                     NoAction() ]
+		symbols[1]= [                       NoSymbol, {                              X,                              Y } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },                     NoAction() ]
 	};
 	key <T162>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                              X ],
-		actions[Group1]= [              SetGroup(group=3),                     NoAction() ]
+		symbols[1]= [                       NoSymbol,                              X ],
+		actions[1]= [              SetGroup(group=3),                     NoAction() ]
 	};
 	key <T165>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol, {                              X,                              Y } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },                     NoAction() ]
+		symbols[1]= [                       NoSymbol, {                              X,                              Y } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },                     NoAction() ]
 	};
 	key <T168>               {
 		repeat= No,
-		symbols[Group1]= [ {                              x,                              y }, {                              X,                              Y } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                              x,                              y }, {                              X,                              Y } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) }, {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T171>               {
 		repeat= No,
-		symbols[Group1]= [                              x, {                              X,                              Y } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
+		symbols[1]= [                              x, {                              X,                              Y } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
 	};
 	key <T174>               {
 		repeat= No,
-		symbols[Group1]= [                              x,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),              SetGroup(group=3) ]
+		symbols[1]= [                              x,                       NoSymbol ],
+		actions[1]= [                     NoAction(),              SetGroup(group=3) ]
 	};
 	key <T177>               {
 		repeat= No,
-		symbols[Group1]= [ {                              x,                              y },                       NoSymbol ],
-		actions[Group1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                              x,                              y },                       NoSymbol ],
+		actions[1]= [                     NoAction(), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T180>               {
 		repeat= No,
-		symbols[Group1]= [                              y, {                              X,                              Y } ],
-		actions[Group1]= [              SetGroup(group=3), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [                              y, {                              X,                              Y } ],
+		actions[1]= [              SetGroup(group=3), {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T183>               {
 		repeat= No,
-		symbols[Group1]= [                              y,                              X ],
-		actions[Group1]= [        SetMods(modifiers=Mod5),              SetGroup(group=3) ]
+		symbols[1]= [                              y,                              X ],
+		actions[1]= [        SetMods(modifiers=Mod5),              SetGroup(group=3) ]
 	};
 	key <T186>               {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
 	};
 	key <T189>               {	[        { A, B },               a ] };
 	key <T192>               {
 		repeat= No,
-		symbols[Group1]= [ {                              x,                              y },                              X ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
+		symbols[1]= [ {                              x,                              y },                              X ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) },              SetGroup(group=3) ]
 	};
 	key <T204>               {
 		repeat= No,
-		symbols[Group1]= [ {                              A,                              A } ],
-		actions[Group1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
+		symbols[1]= [ {                              A,                              A } ],
+		actions[1]= [ {              SetGroup(group=3),        SetMods(modifiers=Mod5) } ]
 	};
 	key <T207>               {
 		repeat= No,
-		symbols[Group1]= [                              Y ],
-		actions[Group1]= [              SetGroup(group=3) ]
+		symbols[1]= [                              Y ],
+		actions[1]= [              SetGroup(group=3) ]
 	};
 };
 

--- a/test/data/keymaps/no_void_action
+++ b/test/data/keymaps/no_void_action
@@ -24,18 +24,18 @@ xkb_compatibility {
 xkb_symbols {
 	key <1>                  {
 		repeat= No,
-		symbols[Group1]= [                              x ],
-		actions[Group1]= [                     NoAction() ]
+		symbols[1]= [                              x ],
+		actions[1]= [                     NoAction() ]
 	};
 	key <2>                  {
 		repeat= No,
-		symbols[Group1]= [                              y ],
-		actions[Group1]= [                     NoAction() ]
+		symbols[1]= [                              y ],
+		actions[1]= [                     NoAction() ]
 	};
 	key <3>                  {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [ LockControls(controls=none,affect=neither) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [ LockControls(controls=none,affect=neither) ]
 	};
 };
 

--- a/test/data/keymaps/optional-components-basic.xkb
+++ b/test/data/keymaps/optional-components-basic.xkb
@@ -22,7 +22,7 @@ xkb_compatibility {
 xkb_symbols {
 	key <>                   {
 		type= "default",
-		symbols[Group1]= [               a ]
+		symbols[1]= [               a ]
 	};
 };
 

--- a/test/data/keymaps/stringcomp.data
+++ b/test/data/keymaps/stringcomp.data
@@ -1073,667 +1073,667 @@ xkb_compatibility "complete_caps(caps_lock)_4_misc(assign_shift_left_action)_4_l
 };
 
 xkb_symbols "pc_us_ru_2_ca(multix)_3_de(neo)_4_inet(evdev)" {
-	name[Group1]="English (US)";
-	name[Group2]="Russian";
-	name[Group3]="Canadian Multilingual";
-	name[Group4]="German (Neo 2)";
+	name[1]="English (US)";
+	name[2]="Russian";
+	name[3]="Canadian Multilingual";
+	name[4]="German (Neo 2)";
 
 	key <ESC>                {	[          Escape ] };
 	key <AE01>               {
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [               1,          exclam ],
-		symbols[Group2]= [               1,          exclam ],
-		symbols[Group3]= [               1,          exclam,       plusminus,        NoSymbol,     onesuperior,      exclamdown,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               1,          degree,     onesuperior,    onesubscript,     ordfeminine,        NoSymbol,         notsign,        NoSymbol ]
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [               1,          exclam ],
+		symbols[2]= [               1,          exclam ],
+		symbols[3]= [               1,          exclam,       plusminus,        NoSymbol,     onesuperior,      exclamdown,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               1,          degree,     onesuperior,    onesubscript,     ordfeminine,        NoSymbol,         notsign,        NoSymbol ]
 	};
 	key <AE02>               {
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [               2,              at ],
-		symbols[Group2]= [               2,        quotedbl ],
-		symbols[Group3]= [               2,              at,              at,        NoSymbol,     twosuperior,        NoSymbol,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               2,         section,     twosuperior,    twosubscript,       masculine,        NoSymbol,       logicalor,        NoSymbol ]
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [               2,              at ],
+		symbols[2]= [               2,        quotedbl ],
+		symbols[3]= [               2,              at,              at,        NoSymbol,     twosuperior,        NoSymbol,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               2,         section,     twosuperior,    twosubscript,       masculine,        NoSymbol,       logicalor,        NoSymbol ]
 	};
 	key <AE03>               {
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [               3,      numbersign ],
-		symbols[Group2]= [               3,      numerosign ],
-		symbols[Group3]= [               3,      numbersign,        sterling,        NoSymbol,   threesuperior,        sterling,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               3,           U2113,   threesuperior,  threesubscript,      numerosign,        NoSymbol,      logicaland,        NoSymbol ]
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [               3,      numbersign ],
+		symbols[2]= [               3,      numerosign ],
+		symbols[3]= [               3,      numbersign,        sterling,        NoSymbol,   threesuperior,        sterling,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               3,           U2113,   threesuperior,  threesubscript,      numerosign,        NoSymbol,      logicaland,        NoSymbol ]
 	};
 	key <AE04>               {
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [               4,          dollar ],
-		symbols[Group2]= [               4,       semicolon ],
-		symbols[Group3]= [               4,          dollar,            cent,        NoSymbol,      onequarter,        currency,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               4,  guillemotright,           U203A,    femalesymbol,        NoSymbol,        NoSymbol,           U22A5,        NoSymbol ]
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [               4,          dollar ],
+		symbols[2]= [               4,       semicolon ],
+		symbols[3]= [               4,          dollar,            cent,        NoSymbol,      onequarter,        currency,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               4,  guillemotright,           U203A,    femalesymbol,        NoSymbol,        NoSymbol,           U22A5,        NoSymbol ]
 	};
 	key <AE05>               {
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [               5,         percent ],
-		symbols[Group2]= [               5,         percent ],
-		symbols[Group3]= [               5,         percent,        currency,        NoSymbol,         onehalf,    threeeighths,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               5,   guillemotleft,           U2039,      malesymbol,  periodcentered,        NoSymbol,           U2221,        NoSymbol ]
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [               5,         percent ],
+		symbols[2]= [               5,         percent ],
+		symbols[3]= [               5,         percent,        currency,        NoSymbol,         onehalf,    threeeighths,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               5,   guillemotleft,           U2039,      malesymbol,  periodcentered,        NoSymbol,           U2221,        NoSymbol ]
 	};
 	key <AE06>               {
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [ { H, E, L, L, O },     asciicircum ],
-		symbols[Group2]= [               6,           colon ],
-		symbols[Group3]= [               6,        question,         notsign,        NoSymbol,   threequarters,     fiveeighths,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               6,          dollar,            cent,           U26A5,        sterling,        NoSymbol,           U2225,        NoSymbol ]
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [ { H, E, L, L, O },     asciicircum ],
+		symbols[2]= [               6,           colon ],
+		symbols[3]= [               6,        question,         notsign,        NoSymbol,   threequarters,     fiveeighths,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               6,          dollar,            cent,           U26A5,        sterling,        NoSymbol,           U2225,        NoSymbol ]
 	};
 	key <AE07>               {
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [ { Y, E, S, space, T, H, I, S, space, I, S, space, D, O, G },       ampersand ],
-		symbols[Group2]= [               7,        question ],
-		symbols[Group3]= [               7,       ampersand,       braceleft,        NoSymbol,        NoSymbol,    seveneighths,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               7,        EuroSign,             yen,           U03F0,        currency,        NoSymbol,      rightarrow,        NoSymbol ]
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [ { Y, E, S, space, T, H, I, S, space, I, S, space, D, O, G },       ampersand ],
+		symbols[2]= [               7,        question ],
+		symbols[3]= [               7,       ampersand,       braceleft,        NoSymbol,        NoSymbol,    seveneighths,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               7,        EuroSign,             yen,           U03F0,        currency,        NoSymbol,      rightarrow,        NoSymbol ]
 	};
 	key <AE08>               {
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [               8,        asterisk ],
-		symbols[Group2]= [               8,        asterisk ],
-		symbols[Group3]= [               8,        asterisk,      braceright,        NoSymbol,        NoSymbol,       trademark,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               8, doublelowquotemark, singlelowquotemark,           U27E8,             Tab,    ISO_Left_Tab,           U221E,        NoSymbol ]
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [               8,        asterisk ],
+		symbols[2]= [               8,        asterisk ],
+		symbols[3]= [               8,        asterisk,      braceright,        NoSymbol,        NoSymbol,       trademark,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               8, doublelowquotemark, singlelowquotemark,           U27E8,             Tab,    ISO_Left_Tab,           U221E,        NoSymbol ]
 	};
 	key <AE09>               {
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [               9,       parenleft ],
-		symbols[Group2]= [               9,       parenleft ],
-		symbols[Group3]= [               9,       parenleft,     bracketleft,        NoSymbol,        NoSymbol,       plusminus,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               9, leftdoublequotemark, leftsinglequotemark,           U27E9,       KP_Divide,       KP_Divide,       variation,        NoSymbol ]
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [               9,       parenleft ],
+		symbols[2]= [               9,       parenleft ],
+		symbols[3]= [               9,       parenleft,     bracketleft,        NoSymbol,        NoSymbol,       plusminus,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               9, leftdoublequotemark, leftsinglequotemark,           U27E9,       KP_Divide,       KP_Divide,       variation,        NoSymbol ]
 	};
 	key <AE10>               {
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [               0,      parenright ],
-		symbols[Group2]= [               0,      parenright ],
-		symbols[Group3]= [               0,      parenright,    bracketright,        NoSymbol,        NoSymbol,        NoSymbol,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               0, rightdoublequotemark, rightsinglequotemark,   zerosubscript,     KP_Multiply,     KP_Multiply,        emptyset,        NoSymbol ]
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [               0,      parenright ],
+		symbols[2]= [               0,      parenright ],
+		symbols[3]= [               0,      parenright,    bracketright,        NoSymbol,        NoSymbol,        NoSymbol,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               0, rightdoublequotemark, rightsinglequotemark,   zerosubscript,     KP_Multiply,     KP_Multiply,        emptyset,        NoSymbol ]
 	};
 	key <AE11>               {
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [           minus,      underscore ],
-		symbols[Group2]= [           minus,      underscore ],
-		symbols[Group3]= [           minus,      underscore,         onehalf,        NoSymbol,        NoSymbol,    questiondown,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [           minus,          emdash,        NoSymbol,           U2011,     KP_Subtract,     KP_Subtract,          hyphen,        NoSymbol ]
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [           minus,      underscore ],
+		symbols[2]= [           minus,      underscore ],
+		symbols[3]= [           minus,      underscore,         onehalf,        NoSymbol,        NoSymbol,    questiondown,        NoSymbol,        NoSymbol ],
+		symbols[4]= [           minus,          emdash,        NoSymbol,           U2011,     KP_Subtract,     KP_Subtract,          hyphen,        NoSymbol ]
 	};
 	key <AE12>               {
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [           equal,            plus ],
-		symbols[Group2]= [           equal,            plus ],
-		symbols[Group3]= [           equal,            plus,         notsign,        NoSymbol,    dead_cedilla,     dead_ogonek,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [      dead_grave,    dead_cedilla,  dead_abovering, dead_abovereversedcomma,  dead_diaeresis,        NoSymbol,     dead_macron,        NoSymbol ]
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [           equal,            plus ],
+		symbols[2]= [           equal,            plus ],
+		symbols[3]= [           equal,            plus,         notsign,        NoSymbol,    dead_cedilla,     dead_ogonek,        NoSymbol,        NoSymbol ],
+		symbols[4]= [      dead_grave,    dead_cedilla,  dead_abovering, dead_abovereversedcomma,  dead_diaeresis,        NoSymbol,     dead_macron,        NoSymbol ]
 	};
 	key <BKSP>               {	[       BackSpace,       BackSpace ] };
 	key <TAB>                {
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [             Tab,    ISO_Left_Tab ],
-		symbols[Group2]= [             Tab,    ISO_Left_Tab ],
-		symbols[Group3]= [             Tab,    ISO_Left_Tab ],
-		symbols[Group4]= [             Tab,    ISO_Left_Tab,       Multi_key, ISO_Level5_Lock,        NoSymbol,        NoSymbol,        NoSymbol, ISO_Level5_Lock ]
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [             Tab,    ISO_Left_Tab ],
+		symbols[2]= [             Tab,    ISO_Left_Tab ],
+		symbols[3]= [             Tab,    ISO_Left_Tab ],
+		symbols[4]= [             Tab,    ISO_Left_Tab,       Multi_key, ISO_Level5_Lock,        NoSymbol,        NoSymbol,        NoSymbol, ISO_Level5_Lock ]
 	};
 	key <AD01>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               q,               Q ],
-		symbols[Group2]= [ Cyrillic_shorti, Cyrillic_SHORTI ],
-		symbols[Group3]= [               q,               Q,        NoSymbol,        NoSymbol,        NoSymbol,     Greek_OMEGA,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               x,               X,        ellipsis,        Greek_xi,           Prior,           Prior,        Greek_XI,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               q,               Q ],
+		symbols[2]= [ Cyrillic_shorti, Cyrillic_SHORTI ],
+		symbols[3]= [               q,               Q,        NoSymbol,        NoSymbol,        NoSymbol,     Greek_OMEGA,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               x,               X,        ellipsis,        Greek_xi,           Prior,           Prior,        Greek_XI,        NoSymbol ]
 	};
 	key <AD02>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               w,               W ],
-		symbols[Group2]= [    Cyrillic_tse,    Cyrillic_TSE ],
-		symbols[Group3]= [               w,               W,        NoSymbol,        NoSymbol,         lstroke,         Lstroke,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               v,               V,      underscore,        NoSymbol,       BackSpace,       BackSpace,         radical,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               w,               W ],
+		symbols[2]= [    Cyrillic_tse,    Cyrillic_TSE ],
+		symbols[3]= [               w,               W,        NoSymbol,        NoSymbol,         lstroke,         Lstroke,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               v,               V,      underscore,        NoSymbol,       BackSpace,       BackSpace,         radical,        NoSymbol ]
 	};
 	key <AD03>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               e,               E ],
-		symbols[Group2]= [      Cyrillic_u,      Cyrillic_U ],
-		symbols[Group3]= [               e,               E,        NoSymbol,        NoSymbol,              oe,              OE,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               l,               L,     bracketleft,     Greek_lamda,              Up,              Up,     Greek_LAMDA,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               e,               E ],
+		symbols[2]= [      Cyrillic_u,      Cyrillic_U ],
+		symbols[3]= [               e,               E,        NoSymbol,        NoSymbol,              oe,              OE,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               l,               L,     bracketleft,     Greek_lamda,              Up,              Up,     Greek_LAMDA,        NoSymbol ]
 	};
 	key <AD04>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               r,               R ],
-		symbols[Group2]= [     Cyrillic_ka,     Cyrillic_KA ],
-		symbols[Group3]= [               r,               R,        NoSymbol,        NoSymbol,       paragraph,      registered,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               c,               C,    bracketright,       Greek_chi,          Delete,          Delete,           U2102,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               r,               R ],
+		symbols[2]= [     Cyrillic_ka,     Cyrillic_KA ],
+		symbols[3]= [               r,               R,        NoSymbol,        NoSymbol,       paragraph,      registered,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               c,               C,    bracketright,       Greek_chi,          Delete,          Delete,           U2102,        NoSymbol ]
 	};
 	key <AD05>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               t,               T ],
-		symbols[Group2]= [     Cyrillic_ie,     Cyrillic_IE ],
-		symbols[Group3]= [               t,               T,        NoSymbol,        NoSymbol,          tslash,          Tslash,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               w,               W,     asciicircum,     Greek_omega,            Next,            Next,     Greek_OMEGA,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               t,               T ],
+		symbols[2]= [     Cyrillic_ie,     Cyrillic_IE ],
+		symbols[3]= [               t,               T,        NoSymbol,        NoSymbol,          tslash,          Tslash,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               w,               W,     asciicircum,     Greek_omega,            Next,            Next,     Greek_OMEGA,        NoSymbol ]
 	};
 	key <AD06>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               y,               Y ],
-		symbols[Group2]= [     Cyrillic_en,     Cyrillic_EN ],
-		symbols[Group3]= [               y,               Y,        NoSymbol,        NoSymbol,       leftarrow,             yen,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               k,               K,          exclam,     Greek_kappa,      exclamdown,        NoSymbol,        multiply,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               y,               Y ],
+		symbols[2]= [     Cyrillic_en,     Cyrillic_EN ],
+		symbols[3]= [               y,               Y,        NoSymbol,        NoSymbol,       leftarrow,             yen,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               k,               K,          exclam,     Greek_kappa,      exclamdown,        NoSymbol,        multiply,        NoSymbol ]
 	};
 	key <AD07>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               u,               U ],
-		symbols[Group2]= [    Cyrillic_ghe,    Cyrillic_GHE ],
-		symbols[Group3]= [               u,               U,        NoSymbol,        NoSymbol,       downarrow,         uparrow,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               h,               H,            less,       Greek_psi,            KP_7,            KP_7,       Greek_PSI,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               u,               U ],
+		symbols[2]= [    Cyrillic_ghe,    Cyrillic_GHE ],
+		symbols[3]= [               u,               U,        NoSymbol,        NoSymbol,       downarrow,         uparrow,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               h,               H,            less,       Greek_psi,            KP_7,            KP_7,       Greek_PSI,        NoSymbol ]
 	};
 	key <AD08>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               i,               I ],
-		symbols[Group2]= [    Cyrillic_sha,    Cyrillic_SHA ],
-		symbols[Group3]= [               i,               I,        NoSymbol,        NoSymbol,      rightarrow,        idotless,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               g,               G,         greater,     Greek_gamma,            KP_8,            KP_8,     Greek_GAMMA,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               i,               I ],
+		symbols[2]= [    Cyrillic_sha,    Cyrillic_SHA ],
+		symbols[3]= [               i,               I,        NoSymbol,        NoSymbol,      rightarrow,        idotless,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               g,               G,         greater,     Greek_gamma,            KP_8,            KP_8,     Greek_GAMMA,        NoSymbol ]
 	};
 	key <AD09>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               o,               O ],
-		symbols[Group2]= [  Cyrillic_shcha,  Cyrillic_SHCHA ],
-		symbols[Group3]= [               o,               O,         section,        NoSymbol,          oslash,          Oslash,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               f,               F,           equal,       Greek_phi,            KP_9,            KP_9,       Greek_PHI,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               o,               O ],
+		symbols[2]= [  Cyrillic_shcha,  Cyrillic_SHCHA ],
+		symbols[3]= [               o,               O,         section,        NoSymbol,          oslash,          Oslash,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               f,               F,           equal,       Greek_phi,            KP_9,            KP_9,       Greek_PHI,        NoSymbol ]
 	};
 	key <AD10>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               p,               P ],
-		symbols[Group2]= [     Cyrillic_ze,     Cyrillic_ZE ],
-		symbols[Group3]= [               p,               P,       paragraph,        NoSymbol,           thorn,           THORN,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               q,               Q,       ampersand,           U03D5,          KP_Add,          KP_Add,           U211A,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               p,               P ],
+		symbols[2]= [     Cyrillic_ze,     Cyrillic_ZE ],
+		symbols[3]= [               p,               P,       paragraph,        NoSymbol,           thorn,           THORN,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               q,               Q,       ampersand,           U03D5,          KP_Add,          KP_Add,           U211A,        NoSymbol ]
 	};
 	key <AD11>               {
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [     bracketleft,       braceleft ],
-		symbols[Group2]= [     Cyrillic_ha,     Cyrillic_HA ],
-		symbols[Group3]= [ dead_circumflex,  dead_diaeresis,      dead_grave,        NoSymbol,        NoSymbol,  dead_abovering,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [          ssharp,           U1E9E,           U017F, Greek_finalsmallsigma,           U2212,        NoSymbol,             jot,        NoSymbol ]
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [     bracketleft,       braceleft ],
+		symbols[2]= [     Cyrillic_ha,     Cyrillic_HA ],
+		symbols[3]= [ dead_circumflex,  dead_diaeresis,      dead_grave,        NoSymbol,        NoSymbol,  dead_abovering,        NoSymbol,        NoSymbol ],
+		symbols[4]= [          ssharp,           U1E9E,           U017F, Greek_finalsmallsigma,           U2212,        NoSymbol,             jot,        NoSymbol ]
 	};
 	key <AD12>               {
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [    bracketright,      braceright ],
-		symbols[Group2]= [ Cyrillic_hardsign, Cyrillic_HARDSIGN ],
-		symbols[Group3]= [        ccedilla,        Ccedilla,      asciitilde,        NoSymbol,      dead_tilde,     dead_macron,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [      dead_acute,      dead_tilde,     dead_stroke, dead_abovecomma, dead_doubleacute,        NoSymbol,      dead_breve,        NoSymbol ]
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [    bracketright,      braceright ],
+		symbols[2]= [ Cyrillic_hardsign, Cyrillic_HARDSIGN ],
+		symbols[3]= [        ccedilla,        Ccedilla,      asciitilde,        NoSymbol,      dead_tilde,     dead_macron,        NoSymbol,        NoSymbol ],
+		symbols[4]= [      dead_acute,      dead_tilde,     dead_stroke, dead_abovecomma, dead_doubleacute,        NoSymbol,      dead_breve,        NoSymbol ]
 	};
 	key <RTRN>               {	[          Return ] };
 	key <LCTL>               {	[       Control_L ] };
 	key <AC01>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               a,               A ],
-		symbols[Group2]= [     Cyrillic_ef,     Cyrillic_EF ],
-		symbols[Group3]= [               a,               A,        NoSymbol,        NoSymbol,              ae,              AE,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               u,               U,       backslash,        NoSymbol,            Home,            Home,      includedin,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               a,               A ],
+		symbols[2]= [     Cyrillic_ef,     Cyrillic_EF ],
+		symbols[3]= [               a,               A,        NoSymbol,        NoSymbol,              ae,              AE,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               u,               U,       backslash,        NoSymbol,            Home,            Home,      includedin,        NoSymbol ]
 	};
 	key <AC02>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               s,               S ],
-		symbols[Group2]= [   Cyrillic_yeru,   Cyrillic_YERU ],
-		symbols[Group3]= [               s,               S,        NoSymbol,        NoSymbol,          ssharp,         section,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               i,               I,           slash,      Greek_iota,            Left,            Left,        integral,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               s,               S ],
+		symbols[2]= [   Cyrillic_yeru,   Cyrillic_YERU ],
+		symbols[3]= [               s,               S,        NoSymbol,        NoSymbol,          ssharp,         section,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               i,               I,           slash,      Greek_iota,            Left,            Left,        integral,        NoSymbol ]
 	};
 	key <AC03>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               d,               D ],
-		symbols[Group2]= [     Cyrillic_ve,     Cyrillic_VE ],
-		symbols[Group3]= [               d,               D,        NoSymbol,        NoSymbol,             eth,             ETH,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               a,               A,       braceleft,     Greek_alpha,            Down,            Down,           U2200,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               d,               D ],
+		symbols[2]= [     Cyrillic_ve,     Cyrillic_VE ],
+		symbols[3]= [               d,               D,        NoSymbol,        NoSymbol,             eth,             ETH,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               a,               A,       braceleft,     Greek_alpha,            Down,            Down,           U2200,        NoSymbol ]
 	};
 	key <AC04>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               f,               F ],
-		symbols[Group2]= [      Cyrillic_a,      Cyrillic_A ],
-		symbols[Group3]= [               f,               F,        NoSymbol,        NoSymbol,        NoSymbol,     ordfeminine,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               e,               E,      braceright,   Greek_epsilon,           Right,           Right,           U2203,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               f,               F ],
+		symbols[2]= [      Cyrillic_a,      Cyrillic_A ],
+		symbols[3]= [               f,               F,        NoSymbol,        NoSymbol,        NoSymbol,     ordfeminine,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               e,               E,      braceright,   Greek_epsilon,           Right,           Right,           U2203,        NoSymbol ]
 	};
 	key <AC05>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               g,               G ],
-		symbols[Group2]= [     Cyrillic_pe,     Cyrillic_PE ],
-		symbols[Group3]= [               g,               G,        NoSymbol,        NoSymbol,             eng,             ENG,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               o,               O,        asterisk,   Greek_omicron,             End,             End,       elementof,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               g,               G ],
+		symbols[2]= [     Cyrillic_pe,     Cyrillic_PE ],
+		symbols[3]= [               g,               G,        NoSymbol,        NoSymbol,             eng,             ENG,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               o,               O,        asterisk,   Greek_omicron,             End,             End,       elementof,        NoSymbol ]
 	};
 	key <AC06>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               h,               H ],
-		symbols[Group2]= [     Cyrillic_er,     Cyrillic_ER ],
-		symbols[Group3]= [               h,               H,        NoSymbol,        NoSymbol,         hstroke,         Hstroke,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               s,               S,        question,     Greek_sigma,    questiondown,        NoSymbol,     Greek_SIGMA,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               h,               H ],
+		symbols[2]= [     Cyrillic_er,     Cyrillic_ER ],
+		symbols[3]= [               h,               H,        NoSymbol,        NoSymbol,         hstroke,         Hstroke,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               s,               S,        question,     Greek_sigma,    questiondown,        NoSymbol,     Greek_SIGMA,        NoSymbol ]
 	};
 	key <AC07>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               j,               J ],
-		symbols[Group2]= [      Cyrillic_o,      Cyrillic_O ],
-		symbols[Group3]= [               j,               J,        NoSymbol,        NoSymbol,           U0133,           U0132,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               n,               N,       parenleft,        Greek_nu,            KP_4,            KP_4,           U2115,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               j,               J ],
+		symbols[2]= [      Cyrillic_o,      Cyrillic_O ],
+		symbols[3]= [               j,               J,        NoSymbol,        NoSymbol,           U0133,           U0132,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               n,               N,       parenleft,        Greek_nu,            KP_4,            KP_4,           U2115,        NoSymbol ]
 	};
 	key <AC08>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               k,               K ],
-		symbols[Group2]= [     Cyrillic_el,     Cyrillic_EL ],
-		symbols[Group3]= [               k,               K,        NoSymbol,        NoSymbol,             kra,        NoSymbol,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               r,               R,      parenright,       Greek_rho,            KP_5,            KP_5,           U211D,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               k,               K ],
+		symbols[2]= [     Cyrillic_el,     Cyrillic_EL ],
+		symbols[3]= [               k,               K,        NoSymbol,        NoSymbol,             kra,        NoSymbol,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               r,               R,      parenright,       Greek_rho,            KP_5,            KP_5,           U211D,        NoSymbol ]
 	};
 	key <AC09>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               l,               L ],
-		symbols[Group2]= [     Cyrillic_de,     Cyrillic_DE ],
-		symbols[Group3]= [               l,               L,        NoSymbol,        NoSymbol,           U0140,           U013F,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               t,               T,           minus,       Greek_tau,            KP_6,            KP_6, partialderivative,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               l,               L ],
+		symbols[2]= [     Cyrillic_de,     Cyrillic_DE ],
+		symbols[3]= [               l,               L,        NoSymbol,        NoSymbol,           U0140,           U013F,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               t,               T,           minus,       Greek_tau,            KP_6,            KP_6, partialderivative,        NoSymbol ]
 	};
 	key <AC10>               {
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [       semicolon,           colon ],
-		symbols[Group2]= [    Cyrillic_zhe,    Cyrillic_ZHE ],
-		symbols[Group3]= [       semicolon,           colon,          degree,        NoSymbol,      dead_acute, dead_doubleacute,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               d,               D,           colon,     Greek_delta,    KP_Separator,           comma,     Greek_DELTA,        NoSymbol ]
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [       semicolon,           colon ],
+		symbols[2]= [    Cyrillic_zhe,    Cyrillic_ZHE ],
+		symbols[3]= [       semicolon,           colon,          degree,        NoSymbol,      dead_acute, dead_doubleacute,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               d,               D,           colon,     Greek_delta,    KP_Separator,           comma,     Greek_DELTA,        NoSymbol ]
 	};
 	key <AC11>               {
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [      apostrophe,        quotedbl ],
-		symbols[Group2]= [      Cyrillic_e,      Cyrillic_E ],
-		symbols[Group3]= [          egrave,          Egrave,       braceleft,        NoSymbol,        NoSymbol,      dead_caron,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               y,               Y,              at,   Greek_upsilon,          period,      KP_Decimal,           nabla,        NoSymbol ]
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [      apostrophe,        quotedbl ],
+		symbols[2]= [      Cyrillic_e,      Cyrillic_E ],
+		symbols[3]= [          egrave,          Egrave,       braceleft,        NoSymbol,        NoSymbol,      dead_caron,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               y,               Y,              at,   Greek_upsilon,          period,      KP_Decimal,           nabla,        NoSymbol ]
 	};
 	key <TLDE>               {
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [           grave,      asciitilde ],
-		symbols[Group2]= [     Cyrillic_io,     Cyrillic_IO ],
-		symbols[Group3]= [           slash,       backslash,             bar,        NoSymbol,        NoSymbol,          hyphen,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [ dead_circumflex,      dead_caron,           U21BB,           U02DE,   dead_abovedot, Pointer_EnableKeys,   dead_belowdot,        NoSymbol ]
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [           grave,      asciitilde ],
+		symbols[2]= [     Cyrillic_io,     Cyrillic_IO ],
+		symbols[3]= [           slash,       backslash,             bar,        NoSymbol,        NoSymbol,          hyphen,        NoSymbol,        NoSymbol ],
+		symbols[4]= [ dead_circumflex,      dead_caron,           U21BB,           U02DE,   dead_abovedot, Pointer_EnableKeys,   dead_belowdot,        NoSymbol ]
 	};
 	key <LFSH>               {
-		type[Group4]= "TWO_LEVEL",
-		symbols[Group1]= [         Shift_L ],
-		symbols[Group2]= [         Shift_L ],
-		symbols[Group3]= [         Shift_L ],
-		symbols[Group4]= [         Shift_L,       Caps_Lock ]
+		type[4]= "TWO_LEVEL",
+		symbols[1]= [         Shift_L ],
+		symbols[2]= [         Shift_L ],
+		symbols[3]= [         Shift_L ],
+		symbols[4]= [         Shift_L,       Caps_Lock ]
 	};
 	key <BKSL>               {
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "ONE_LEVEL",
-		symbols[Group1]= [       backslash,             bar ],
-		symbols[Group2]= [       backslash,           slash ],
-		symbols[Group3]= [          agrave,          Agrave,      braceright,        NoSymbol,        NoSymbol,      dead_breve,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [ ISO_Level3_Shift ]
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "ONE_LEVEL",
+		symbols[1]= [       backslash,             bar ],
+		symbols[2]= [       backslash,           slash ],
+		symbols[3]= [          agrave,          Agrave,      braceright,        NoSymbol,        NoSymbol,      dead_breve,        NoSymbol,        NoSymbol ],
+		symbols[4]= [ ISO_Level3_Shift ]
 	};
 	key <AB01>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "FOUR_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               z,               Z ],
-		symbols[Group2]= [     Cyrillic_ya,     Cyrillic_YA ],
-		symbols[Group3]= [               z,               Z,   guillemotleft,        NoSymbol ],
-		symbols[Group4]= [      udiaeresis,      Udiaeresis,      numbersign,        NoSymbol,          Escape,          Escape,           union,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "FOUR_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               z,               Z ],
+		symbols[2]= [     Cyrillic_ya,     Cyrillic_YA ],
+		symbols[3]= [               z,               Z,   guillemotleft,        NoSymbol ],
+		symbols[4]= [      udiaeresis,      Udiaeresis,      numbersign,        NoSymbol,          Escape,          Escape,           union,        NoSymbol ]
 	};
 	key <AB02>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "FOUR_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               x,               X ],
-		symbols[Group2]= [    Cyrillic_che,    Cyrillic_CHE ],
-		symbols[Group3]= [               x,               X,  guillemotright,        NoSymbol ],
-		symbols[Group4]= [      odiaeresis,      Odiaeresis,          dollar,           U03F5,             Tab,             Tab,    intersection,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "FOUR_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               x,               X ],
+		symbols[2]= [    Cyrillic_che,    Cyrillic_CHE ],
+		symbols[3]= [               x,               X,  guillemotright,        NoSymbol ],
+		symbols[4]= [      odiaeresis,      Odiaeresis,          dollar,           U03F5,             Tab,             Tab,    intersection,        NoSymbol ]
 	};
 	key <AB03>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               c,               C ],
-		symbols[Group2]= [     Cyrillic_es,     Cyrillic_ES ],
-		symbols[Group3]= [               c,               C,        NoSymbol,        NoSymbol,            cent,       copyright,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [      adiaeresis,      Adiaeresis,             bar,       Greek_eta,          Insert,          Insert,           U2135,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               c,               C ],
+		symbols[2]= [     Cyrillic_es,     Cyrillic_ES ],
+		symbols[3]= [               c,               C,        NoSymbol,        NoSymbol,            cent,       copyright,        NoSymbol,        NoSymbol ],
+		symbols[4]= [      adiaeresis,      Adiaeresis,             bar,       Greek_eta,          Insert,          Insert,           U2135,        NoSymbol ]
 	};
 	key <AB04>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               v,               V ],
-		symbols[Group2]= [     Cyrillic_em,     Cyrillic_EM ],
-		symbols[Group3]= [               v,               V,        NoSymbol,        NoSymbol, leftdoublequotemark, leftsinglequotemark,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               p,               P,      asciitilde,        Greek_pi,          Return,          Return,        Greek_PI,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               v,               V ],
+		symbols[2]= [     Cyrillic_em,     Cyrillic_EM ],
+		symbols[3]= [               v,               V,        NoSymbol,        NoSymbol, leftdoublequotemark, leftsinglequotemark,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               p,               P,      asciitilde,        Greek_pi,          Return,          Return,        Greek_PI,        NoSymbol ]
 	};
 	key <AB05>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               b,               B ],
-		symbols[Group2]= [      Cyrillic_i,      Cyrillic_I ],
-		symbols[Group3]= [               b,               B,        NoSymbol,        NoSymbol, rightdoublequotemark, rightsinglequotemark,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               z,               Z,           grave,      Greek_zeta,            Undo,            Undo,           U2124,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               b,               B ],
+		symbols[2]= [      Cyrillic_i,      Cyrillic_I ],
+		symbols[3]= [               b,               B,        NoSymbol,        NoSymbol, rightdoublequotemark, rightsinglequotemark,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               z,               Z,           grave,      Greek_zeta,            Undo,            Undo,           U2124,        NoSymbol ]
 	};
 	key <AB06>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               n,               N ],
-		symbols[Group2]= [     Cyrillic_te,     Cyrillic_TE ],
-		symbols[Group3]= [               n,               N,        NoSymbol,        NoSymbol,           U0149,           U266A,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               b,               B,            plus,      Greek_beta,           colon,        NoSymbol,           U21D0,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               n,               N ],
+		symbols[2]= [     Cyrillic_te,     Cyrillic_TE ],
+		symbols[3]= [               n,               N,        NoSymbol,        NoSymbol,           U0149,           U266A,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               b,               B,            plus,      Greek_beta,           colon,        NoSymbol,           U21D0,        NoSymbol ]
 	};
 	key <AB07>               {
-		type[Group1]= "ALPHABETIC",
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               m,               M ],
-		symbols[Group2]= [ Cyrillic_softsign, Cyrillic_SOFTSIGN ],
-		symbols[Group3]= [               m,               M,              mu,        NoSymbol,              mu,       masculine,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               m,               M,         percent,        Greek_mu,            KP_1,            KP_1,        ifonlyif,        NoSymbol ]
+		type[1]= "ALPHABETIC",
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [               m,               M ],
+		symbols[2]= [ Cyrillic_softsign, Cyrillic_SOFTSIGN ],
+		symbols[3]= [               m,               M,              mu,        NoSymbol,              mu,       masculine,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               m,               M,         percent,        Greek_mu,            KP_1,            KP_1,        ifonlyif,        NoSymbol ]
 	};
 	key <AB08>               {
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [           comma,            less ],
-		symbols[Group2]= [     Cyrillic_be,     Cyrillic_BE ],
-		symbols[Group3]= [           comma,      apostrophe,            less,        NoSymbol,  Greek_horizbar,        multiply,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [           comma,          endash,        quotedbl,           U03F1,            KP_2,            KP_2,           U21D2,        NoSymbol ]
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [           comma,            less ],
+		symbols[2]= [     Cyrillic_be,     Cyrillic_BE ],
+		symbols[3]= [           comma,      apostrophe,            less,        NoSymbol,  Greek_horizbar,        multiply,        NoSymbol,        NoSymbol ],
+		symbols[4]= [           comma,          endash,        quotedbl,           U03F1,            KP_2,            KP_2,           U21D2,        NoSymbol ]
 	};
 	key <AB09>               {
-		type[Group2]= "ALPHABETIC",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [          period,         greater ],
-		symbols[Group2]= [     Cyrillic_yu,     Cyrillic_YU ],
-		symbols[Group3]= [          period,        quotedbl,         greater,        NoSymbol,  periodcentered,        division,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [          period, enfilledcircbullet,      apostrophe,           U03D1,            KP_3,            KP_3,           U21A6,        NoSymbol ]
+		type[2]= "ALPHABETIC",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [          period,         greater ],
+		symbols[2]= [     Cyrillic_yu,     Cyrillic_YU ],
+		symbols[3]= [          period,        quotedbl,         greater,        NoSymbol,  periodcentered,        division,        NoSymbol,        NoSymbol ],
+		symbols[4]= [          period, enfilledcircbullet,      apostrophe,           U03D1,            KP_3,            KP_3,           U21A6,        NoSymbol ]
 	};
 	key <AB10>               {
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [           slash,        question ],
-		symbols[Group2]= [          period,           comma ],
-		symbols[Group3]= [          eacute,          Eacute,      dead_acute,        NoSymbol,        NoSymbol,   dead_abovedot,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [               j,               J,       semicolon,     Greek_theta,       semicolon,        NoSymbol,     Greek_THETA,        NoSymbol ]
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		symbols[1]= [           slash,        question ],
+		symbols[2]= [          period,           comma ],
+		symbols[3]= [          eacute,          Eacute,      dead_acute,        NoSymbol,        NoSymbol,   dead_abovedot,        NoSymbol,        NoSymbol ],
+		symbols[4]= [               j,               J,       semicolon,     Greek_theta,       semicolon,        NoSymbol,     Greek_THETA,        NoSymbol ]
 	};
 	key <RTSH>               {
-		type[Group4]= "TWO_LEVEL",
-		symbols[Group1]= [         Shift_R ],
-		symbols[Group2]= [         Shift_R ],
-		symbols[Group3]= [         Shift_R ],
-		symbols[Group4]= [         Shift_R,       Caps_Lock ]
+		type[4]= "TWO_LEVEL",
+		symbols[1]= [         Shift_R ],
+		symbols[2]= [         Shift_R ],
+		symbols[3]= [         Shift_R ],
+		symbols[4]= [         Shift_R,       Caps_Lock ]
 	};
 	key <KPMU>               {
-		type[Group1]= "CTRL+ALT",
-		type[Group2]= "CTRL+ALT",
-		type[Group3]= "CTRL+ALT",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [     KP_Multiply,     KP_Multiply,     KP_Multiply,     KP_Multiply,   XF86ClearGrab ],
-		symbols[Group2]= [     KP_Multiply,     KP_Multiply,     KP_Multiply,     KP_Multiply,   XF86ClearGrab ],
-		symbols[Group3]= [     KP_Multiply,     KP_Multiply,     KP_Multiply,     KP_Multiply,   XF86ClearGrab ],
-		symbols[Group4]= [     KP_Multiply,     KP_Multiply,           U2219,           U2299,        multiply,        NoSymbol,           U2297,        NoSymbol ]
+		type[1]= "CTRL+ALT",
+		type[2]= "CTRL+ALT",
+		type[3]= "CTRL+ALT",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [     KP_Multiply,     KP_Multiply,     KP_Multiply,     KP_Multiply,   XF86ClearGrab ],
+		symbols[2]= [     KP_Multiply,     KP_Multiply,     KP_Multiply,     KP_Multiply,   XF86ClearGrab ],
+		symbols[3]= [     KP_Multiply,     KP_Multiply,     KP_Multiply,     KP_Multiply,   XF86ClearGrab ],
+		symbols[4]= [     KP_Multiply,     KP_Multiply,           U2219,           U2299,        multiply,        NoSymbol,           U2297,        NoSymbol ]
 	};
 	key <LALT>               {	[           Alt_L,          Meta_L ] };
 	key <SPCE>               {
-		type[Group3]= "FOUR_LEVEL",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [           space ],
-		symbols[Group2]= [           space ],
-		symbols[Group3]= [           space,           space,    nobreakspace,        NoSymbol ],
-		symbols[Group4]= [           space,           space,           space,    nobreakspace,            KP_0,            KP_0,           U202F,        NoSymbol ]
+		type[3]= "FOUR_LEVEL",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [           space ],
+		symbols[2]= [           space ],
+		symbols[3]= [           space,           space,    nobreakspace,        NoSymbol ],
+		symbols[4]= [           space,           space,           space,    nobreakspace,            KP_0,            KP_0,           U202F,        NoSymbol ]
 	};
 	key <CAPS>               {
 		type= "ONE_LEVEL",
-		symbols[Group1]= [       Caps_Lock ],
-		symbols[Group2]= [       Caps_Lock ],
-		symbols[Group3]= [       Caps_Lock ],
-		symbols[Group4]= [ ISO_Level3_Shift ]
+		symbols[1]= [       Caps_Lock ],
+		symbols[2]= [       Caps_Lock ],
+		symbols[3]= [       Caps_Lock ],
+		symbols[4]= [ ISO_Level3_Shift ]
 	};
 	key <FK01>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [              F1,              F1,              F1,              F1, XF86Switch_VT_1 ]
+		symbols[1]= [              F1,              F1,              F1,              F1, XF86Switch_VT_1 ]
 	};
 	key <FK02>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [              F2,              F2,              F2,              F2, XF86Switch_VT_2 ]
+		symbols[1]= [              F2,              F2,              F2,              F2, XF86Switch_VT_2 ]
 	};
 	key <FK03>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [              F3,              F3,              F3,              F3, XF86Switch_VT_3 ]
+		symbols[1]= [              F3,              F3,              F3,              F3, XF86Switch_VT_3 ]
 	};
 	key <FK04>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [              F4,              F4,              F4,              F4, XF86Switch_VT_4 ]
+		symbols[1]= [              F4,              F4,              F4,              F4, XF86Switch_VT_4 ]
 	};
 	key <FK05>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [              F5,              F5,              F5,              F5, XF86Switch_VT_5 ]
+		symbols[1]= [              F5,              F5,              F5,              F5, XF86Switch_VT_5 ]
 	};
 	key <FK06>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [              F6,              F6,              F6,              F6, XF86Switch_VT_6 ]
+		symbols[1]= [              F6,              F6,              F6,              F6, XF86Switch_VT_6 ]
 	};
 	key <FK07>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [              F7,              F7,              F7,              F7, XF86Switch_VT_7 ]
+		symbols[1]= [              F7,              F7,              F7,              F7, XF86Switch_VT_7 ]
 	};
 	key <FK08>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [              F8,              F8,              F8,              F8, XF86Switch_VT_8 ]
+		symbols[1]= [              F8,              F8,              F8,              F8, XF86Switch_VT_8 ]
 	};
 	key <FK09>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [              F9,              F9,              F9,              F9, XF86Switch_VT_9 ]
+		symbols[1]= [              F9,              F9,              F9,              F9, XF86Switch_VT_9 ]
 	};
 	key <FK10>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [             F10,             F10,             F10,             F10, XF86Switch_VT_10 ]
+		symbols[1]= [             F10,             F10,             F10,             F10, XF86Switch_VT_10 ]
 	};
 	key <NMLK>               {
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [        Num_Lock ],
-		symbols[Group2]= [        Num_Lock ],
-		symbols[Group3]= [        Num_Lock ],
-		symbols[Group4]= [             Tab,    ISO_Left_Tab,           equal,        approxeq,        notequal, Pointer_EnableKeys,       identical,        NoSymbol ]
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [        Num_Lock ],
+		symbols[2]= [        Num_Lock ],
+		symbols[3]= [        Num_Lock ],
+		symbols[4]= [             Tab,    ISO_Left_Tab,           equal,        approxeq,        notequal, Pointer_EnableKeys,       identical,        NoSymbol ]
 	};
 	key <SCLK>               {	[     Scroll_Lock ] };
 	key <KP7>                {
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [         KP_Home,            KP_7 ],
-		symbols[Group2]= [         KP_Home,            KP_7 ],
-		symbols[Group3]= [         KP_Home,            KP_7 ],
-		symbols[Group4]= [            KP_7,           U2714,           U2195,           U226A,         KP_Home,         KP_Home,         upstile,        NoSymbol ]
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [         KP_Home,            KP_7 ],
+		symbols[2]= [         KP_Home,            KP_7 ],
+		symbols[3]= [         KP_Home,            KP_7 ],
+		symbols[4]= [            KP_7,           U2714,           U2195,           U226A,         KP_Home,         KP_Home,         upstile,        NoSymbol ]
 	};
 	key <KP8>                {
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [           KP_Up,            KP_8 ],
-		symbols[Group2]= [           KP_Up,            KP_8 ],
-		symbols[Group3]= [           KP_Up,            KP_8 ],
-		symbols[Group4]= [            KP_8,           U2718,         uparrow,    intersection,           KP_Up,           KP_Up,           U22C2,        NoSymbol ]
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [           KP_Up,            KP_8 ],
+		symbols[2]= [           KP_Up,            KP_8 ],
+		symbols[3]= [           KP_Up,            KP_8 ],
+		symbols[4]= [            KP_8,           U2718,         uparrow,    intersection,           KP_Up,           KP_Up,           U22C2,        NoSymbol ]
 	};
 	key <KP9>                {
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [        KP_Prior,            KP_9 ],
-		symbols[Group2]= [        KP_Prior,            KP_9 ],
-		symbols[Group3]= [        KP_Prior,            KP_9 ],
-		symbols[Group4]= [            KP_9,          dagger,           U20D7,           U226B,        KP_Prior,        KP_Prior,           U2309,        NoSymbol ]
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [        KP_Prior,            KP_9 ],
+		symbols[2]= [        KP_Prior,            KP_9 ],
+		symbols[3]= [        KP_Prior,            KP_9 ],
+		symbols[4]= [            KP_9,          dagger,           U20D7,           U226B,        KP_Prior,        KP_Prior,           U2309,        NoSymbol ]
 	};
 	key <KPSU>               {
-		type[Group1]= "CTRL+ALT",
-		type[Group2]= "CTRL+ALT",
-		type[Group3]= "CTRL+ALT",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [     KP_Subtract,     KP_Subtract,     KP_Subtract,     KP_Subtract,  XF86Prev_VMode ],
-		symbols[Group2]= [     KP_Subtract,     KP_Subtract,     KP_Subtract,     KP_Subtract,  XF86Prev_VMode ],
-		symbols[Group3]= [     KP_Subtract,     KP_Subtract,     KP_Subtract,     KP_Subtract,  XF86Prev_VMode ],
-		symbols[Group4]= [     KP_Subtract,     KP_Subtract,           U2212,           U2296,           U2216,        NoSymbol,           U2238,        NoSymbol ]
+		type[1]= "CTRL+ALT",
+		type[2]= "CTRL+ALT",
+		type[3]= "CTRL+ALT",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [     KP_Subtract,     KP_Subtract,     KP_Subtract,     KP_Subtract,  XF86Prev_VMode ],
+		symbols[2]= [     KP_Subtract,     KP_Subtract,     KP_Subtract,     KP_Subtract,  XF86Prev_VMode ],
+		symbols[3]= [     KP_Subtract,     KP_Subtract,     KP_Subtract,     KP_Subtract,  XF86Prev_VMode ],
+		symbols[4]= [     KP_Subtract,     KP_Subtract,           U2212,           U2296,           U2216,        NoSymbol,           U2238,        NoSymbol ]
 	};
 	key <KP4>                {
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [         KP_Left,            KP_4 ],
-		symbols[Group2]= [         KP_Left,            KP_4 ],
-		symbols[Group3]= [         KP_Left,            KP_4 ],
-		symbols[Group4]= [            KP_4,            club,       leftarrow,      includedin,         KP_Left,         KP_Left,           U2286,        NoSymbol ]
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [         KP_Left,            KP_4 ],
+		symbols[2]= [         KP_Left,            KP_4 ],
+		symbols[3]= [         KP_Left,            KP_4 ],
+		symbols[4]= [            KP_4,            club,       leftarrow,      includedin,         KP_Left,         KP_Left,           U2286,        NoSymbol ]
 	};
 	key <KP5>                {
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [        KP_Begin,            KP_5 ],
-		symbols[Group2]= [        KP_Begin,            KP_5 ],
-		symbols[Group3]= [        KP_Begin,            KP_5 ],
-		symbols[Group4]= [            KP_5,        EuroSign,           colon,           U22B6,        KP_Begin,        KP_Begin,           U22B7,        NoSymbol ]
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [        KP_Begin,            KP_5 ],
+		symbols[2]= [        KP_Begin,            KP_5 ],
+		symbols[3]= [        KP_Begin,            KP_5 ],
+		symbols[4]= [            KP_5,        EuroSign,           colon,           U22B6,        KP_Begin,        KP_Begin,           U22B7,        NoSymbol ]
 	};
 	key <KP6>                {
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [        KP_Right,            KP_6 ],
-		symbols[Group2]= [        KP_Right,            KP_6 ],
-		symbols[Group3]= [        KP_Right,            KP_6 ],
-		symbols[Group4]= [            KP_6,           U2023,      rightarrow,        includes,        KP_Right,        KP_Right,           U2287,        NoSymbol ]
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [        KP_Right,            KP_6 ],
+		symbols[2]= [        KP_Right,            KP_6 ],
+		symbols[3]= [        KP_Right,            KP_6 ],
+		symbols[4]= [            KP_6,           U2023,      rightarrow,        includes,        KP_Right,        KP_Right,           U2287,        NoSymbol ]
 	};
 	key <KPAD>               {
-		type[Group1]= "CTRL+ALT",
-		type[Group2]= "CTRL+ALT",
-		type[Group3]= "CTRL+ALT",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [          KP_Add,          KP_Add,          KP_Add,          KP_Add,  XF86Next_VMode ],
-		symbols[Group2]= [          KP_Add,          KP_Add,          KP_Add,          KP_Add,  XF86Next_VMode ],
-		symbols[Group3]= [          KP_Add,          KP_Add,          KP_Add,          KP_Add,  XF86Next_VMode ],
-		symbols[Group4]= [          KP_Add,          KP_Add,       plusminus,           U2295,           U2213,        NoSymbol,           U2214,        NoSymbol ]
+		type[1]= "CTRL+ALT",
+		type[2]= "CTRL+ALT",
+		type[3]= "CTRL+ALT",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [          KP_Add,          KP_Add,          KP_Add,          KP_Add,  XF86Next_VMode ],
+		symbols[2]= [          KP_Add,          KP_Add,          KP_Add,          KP_Add,  XF86Next_VMode ],
+		symbols[3]= [          KP_Add,          KP_Add,          KP_Add,          KP_Add,  XF86Next_VMode ],
+		symbols[4]= [          KP_Add,          KP_Add,       plusminus,           U2295,           U2213,        NoSymbol,           U2214,        NoSymbol ]
 	};
 	key <KP1>                {
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [          KP_End,            KP_1 ],
-		symbols[Group2]= [          KP_End,            KP_1 ],
-		symbols[Group3]= [          KP_End,            KP_1 ],
-		symbols[Group4]= [            KP_1,         diamond,           U2194,   lessthanequal,          KP_End,          KP_End,       downstile,        NoSymbol ]
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [          KP_End,            KP_1 ],
+		symbols[2]= [          KP_End,            KP_1 ],
+		symbols[3]= [          KP_End,            KP_1 ],
+		symbols[4]= [            KP_1,         diamond,           U2194,   lessthanequal,          KP_End,          KP_End,       downstile,        NoSymbol ]
 	};
 	key <KP2>                {
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [         KP_Down,            KP_2 ],
-		symbols[Group2]= [         KP_Down,            KP_2 ],
-		symbols[Group3]= [         KP_Down,            KP_2 ],
-		symbols[Group4]= [            KP_2,           heart,       downarrow,           union,         KP_Down,         KP_Down,           U22C3,        NoSymbol ]
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [         KP_Down,            KP_2 ],
+		symbols[2]= [         KP_Down,            KP_2 ],
+		symbols[3]= [         KP_Down,            KP_2 ],
+		symbols[4]= [            KP_2,           heart,       downarrow,           union,         KP_Down,         KP_Down,           U22C3,        NoSymbol ]
 	};
 	key <KP3>                {
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [         KP_Next,            KP_3 ],
-		symbols[Group2]= [         KP_Next,            KP_3 ],
-		symbols[Group3]= [         KP_Next,            KP_3 ],
-		symbols[Group4]= [            KP_3,           U2660,           U21CC, greaterthanequal,         KP_Next,         KP_Next,           U230B,        NoSymbol ]
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [         KP_Next,            KP_3 ],
+		symbols[2]= [         KP_Next,            KP_3 ],
+		symbols[3]= [         KP_Next,            KP_3 ],
+		symbols[4]= [            KP_3,           U2660,           U21CC, greaterthanequal,         KP_Next,         KP_Next,           U230B,        NoSymbol ]
 	};
 	key <KP0>                {
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [       KP_Insert,            KP_0 ],
-		symbols[Group2]= [       KP_Insert,            KP_0 ],
-		symbols[Group3]= [       KP_Insert,            KP_0 ],
-		symbols[Group4]= [            KP_0,           U2423,         percent,           U2030,       KP_Insert,       KP_Insert,           U25A1,        NoSymbol ]
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [       KP_Insert,            KP_0 ],
+		symbols[2]= [       KP_Insert,            KP_0 ],
+		symbols[3]= [       KP_Insert,            KP_0 ],
+		symbols[4]= [            KP_0,           U2423,         percent,           U2030,       KP_Insert,       KP_Insert,           U25A1,        NoSymbol ]
 	};
 	key <KPDL>               {
-		type[Group2]= "KEYPAD",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [       KP_Delete,      KP_Decimal ],
-		symbols[Group2]= [       KP_Delete,    KP_Separator ],
-		symbols[Group3]= [       KP_Delete,      KP_Decimal ],
-		symbols[Group4]= [    KP_Separator,          period,           comma,         minutes,       KP_Delete,       KP_Delete,         seconds,        NoSymbol ]
+		type[2]= "KEYPAD",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [       KP_Delete,      KP_Decimal ],
+		symbols[2]= [       KP_Delete,    KP_Separator ],
+		symbols[3]= [       KP_Delete,      KP_Decimal ],
+		symbols[4]= [    KP_Separator,          period,           comma,         minutes,       KP_Delete,       KP_Delete,         seconds,        NoSymbol ]
 	};
 	key <LVL3>               {	[ ISO_Level3_Shift ] };
 	key <LSGT>               {
-		type[Group1]= "FOUR_LEVEL",
-		type[Group3]= "EIGHT_LEVEL_SEMIALPHABETIC",
-		type[Group4]= "ONE_LEVEL",
-		symbols[Group1]= [            less,         greater,             bar,       brokenbar ],
-		symbols[Group2]= [           slash,             bar ],
-		symbols[Group3]= [          ugrave,          Ugrave,          degree,        NoSymbol,        NoSymbol,       brokenbar,        NoSymbol,        NoSymbol ],
-		symbols[Group4]= [ ISO_Level5_Shift ]
+		type[1]= "FOUR_LEVEL",
+		type[3]= "EIGHT_LEVEL_SEMIALPHABETIC",
+		type[4]= "ONE_LEVEL",
+		symbols[1]= [            less,         greater,             bar,       brokenbar ],
+		symbols[2]= [           slash,             bar ],
+		symbols[3]= [          ugrave,          Ugrave,          degree,        NoSymbol,        NoSymbol,       brokenbar,        NoSymbol,        NoSymbol ],
+		symbols[4]= [ ISO_Level5_Shift ]
 	};
 	key <FK11>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [             F11,             F11,             F11,             F11, XF86Switch_VT_11 ]
+		symbols[1]= [             F11,             F11,             F11,             F11, XF86Switch_VT_11 ]
 	};
 	key <FK12>               {
 		type= "CTRL+ALT",
-		symbols[Group1]= [             F12,             F12,             F12,             F12, XF86Switch_VT_12 ]
+		symbols[1]= [             F12,             F12,             F12,             F12, XF86Switch_VT_12 ]
 	};
 	key <AB11>               {
 		repeat= No,
-		symbols[Group1]= [                      Control_L, {                      Control_L,                    Mode_switch } ],
-		actions[Group1]= [     SetMods(modifiers=Control), {     SetMods(modifiers=Control),             SetGroup(group=+1) } ],
-		symbols[Group2]= [ {                      Control_L,                    Mode_switch },                      Control_L ],
-		actions[Group2]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) },     SetMods(modifiers=Control) ]
+		symbols[1]= [                      Control_L, {                      Control_L,                    Mode_switch } ],
+		actions[1]= [     SetMods(modifiers=Control), {     SetMods(modifiers=Control),             SetGroup(group=+1) } ],
+		symbols[2]= [ {                      Control_L,                    Mode_switch },                      Control_L ],
+		actions[2]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) },     SetMods(modifiers=Control) ]
 	};
 	key <KATA>               {	[        Katakana ] };
 	key <HIRA>               {	[        Hiragana ] };
@@ -1741,41 +1741,41 @@ xkb_symbols "pc_us_ru_2_ca(multix)_3_de(neo)_4_inet(evdev)" {
 	key <HKTG>               {	[ Hiragana_Katakana ] };
 	key <MUHE>               {	[        Muhenkan ] };
 	key <KPEN>               {
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [        KP_Enter ],
-		symbols[Group2]= [        KP_Enter ],
-		symbols[Group3]= [        KP_Enter ],
-		symbols[Group4]= [        KP_Enter,        KP_Enter,        KP_Enter,        KP_Enter,        KP_Enter,        KP_Enter,        KP_Enter,        NoSymbol ]
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [        KP_Enter ],
+		symbols[2]= [        KP_Enter ],
+		symbols[3]= [        KP_Enter ],
+		symbols[4]= [        KP_Enter,        KP_Enter,        KP_Enter,        KP_Enter,        KP_Enter,        KP_Enter,        KP_Enter,        NoSymbol ]
 	};
 	key <RCTL>               {
 		type= "ONE_LEVEL",
-		symbols[Group1]= [       Control_R ],
-		symbols[Group2]= [       Control_R ],
-		symbols[Group3]= [ ISO_Level5_Shift ]
+		symbols[1]= [       Control_R ],
+		symbols[2]= [       Control_R ],
+		symbols[3]= [ ISO_Level5_Shift ]
 	};
 	key <KPDV>               {
-		type[Group1]= "CTRL+ALT",
-		type[Group2]= "CTRL+ALT",
-		type[Group3]= "CTRL+ALT",
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [       KP_Divide,       KP_Divide,       KP_Divide,       KP_Divide,      XF86Ungrab ],
-		symbols[Group2]= [       KP_Divide,       KP_Divide,       KP_Divide,       KP_Divide,      XF86Ungrab ],
-		symbols[Group3]= [       KP_Divide,       KP_Divide,       KP_Divide,       KP_Divide,      XF86Ungrab ],
-		symbols[Group4]= [       KP_Divide,       KP_Divide,        division,           U2300,           U2215,        NoSymbol,           U2223,        NoSymbol ]
+		type[1]= "CTRL+ALT",
+		type[2]= "CTRL+ALT",
+		type[3]= "CTRL+ALT",
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [       KP_Divide,       KP_Divide,       KP_Divide,       KP_Divide,      XF86Ungrab ],
+		symbols[2]= [       KP_Divide,       KP_Divide,       KP_Divide,       KP_Divide,      XF86Ungrab ],
+		symbols[3]= [       KP_Divide,       KP_Divide,       KP_Divide,       KP_Divide,      XF86Ungrab ],
+		symbols[4]= [       KP_Divide,       KP_Divide,        division,           U2300,           U2215,        NoSymbol,           U2223,        NoSymbol ]
 	};
 	key <PRSC>               {
 		type= "PC_ALT_LEVEL2",
-		symbols[Group1]= [           Print,         Sys_Req ]
+		symbols[1]= [           Print,         Sys_Req ]
 	};
 	key <RALT>               {
-		type[Group1]= "TWO_LEVEL",
-		type[Group2]= "TWO_LEVEL",
-		type[Group3]= "ONE_LEVEL",
-		type[Group4]= "ONE_LEVEL",
-		symbols[Group1]= [           Alt_R,          Meta_R ],
-		symbols[Group2]= [           Alt_R,          Meta_R ],
-		symbols[Group3]= [ ISO_Level3_Shift ],
-		symbols[Group4]= [ ISO_Level5_Shift ]
+		type[1]= "TWO_LEVEL",
+		type[2]= "TWO_LEVEL",
+		type[3]= "ONE_LEVEL",
+		type[4]= "ONE_LEVEL",
+		symbols[1]= [           Alt_R,          Meta_R ],
+		symbols[2]= [           Alt_R,          Meta_R ],
+		symbols[3]= [ ISO_Level3_Shift ],
+		symbols[4]= [ ISO_Level5_Shift ]
 	};
 	key <LNFD>               {	[        Linefeed ] };
 	key <HOME>               {	[            Home ] };
@@ -1793,16 +1793,16 @@ xkb_symbols "pc_us_ru_2_ca(multix)_3_de(neo)_4_inet(evdev)" {
 	key <VOL+>               {	[ XF86AudioRaiseVolume ] };
 	key <POWR>               {	[    XF86PowerOff ] };
 	key <KPEQ>               {
-		type[Group4]= "EIGHT_LEVEL",
-		symbols[Group1]= [        KP_Equal ],
-		symbols[Group2]= [        KP_Equal ],
-		symbols[Group3]= [        KP_Equal ],
-		symbols[Group4]= [        KP_Equal,        NoSymbol,        NoSymbol,        NoSymbol,        NoSymbol,        NoSymbol,        NoSymbol,        NoSymbol ]
+		type[4]= "EIGHT_LEVEL",
+		symbols[1]= [        KP_Equal ],
+		symbols[2]= [        KP_Equal ],
+		symbols[3]= [        KP_Equal ],
+		symbols[4]= [        KP_Equal,        NoSymbol,        NoSymbol,        NoSymbol,        NoSymbol,        NoSymbol,        NoSymbol,        NoSymbol ]
 	};
 	key <I126>               {	[       plusminus ] };
 	key <PAUS>               {
 		type= "PC_CONTROL_LEVEL2",
-		symbols[Group1]= [           Pause,           Break ]
+		symbols[1]= [           Pause,           Break ]
 	};
 	key <I128>               {	[     XF86LaunchA ] };
 	key <I129>               {	[      KP_Decimal,      KP_Decimal ] };

--- a/test/data/keymaps/symbols-multi-actions.xkb
+++ b/test/data/keymaps/symbols-multi-actions.xkb
@@ -175,68 +175,68 @@ xkb_compatibility "basic" {
 xkb_symbols {
 	key <01>                 {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [     SetMods(modifiers=Control) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [     SetMods(modifiers=Control) ]
 	};
 	key <02>                 {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [     SetMods(modifiers=Control),             SetGroup(group=+1) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [     SetMods(modifiers=Control),             SetGroup(group=+1) ]
 	};
 	key <04>                 {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),             SetGroup(group=+1) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),             SetGroup(group=+1) ]
 	};
 	key <05>                 {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [     SetMods(modifiers=Control) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [     SetMods(modifiers=Control) ]
 	};
 	key <07>                 {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [     SetMods(modifiers=Control) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [     SetMods(modifiers=Control) ]
 	};
 	key <08>                 {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [     SetMods(modifiers=Control),             SetGroup(group=+1) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [     SetMods(modifiers=Control),             SetGroup(group=+1) ]
 	};
 	key <09>                 {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) } ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) } ]
 	};
 	key <10>                 {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1), Private(type=0x11,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) } ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1), Private(type=0x11,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) } ]
 	};
 	key <11>                 {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [     SetMods(modifiers=Control), {             SetGroup(group=+1), Private(type=0x11,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [     SetMods(modifiers=Control), {             SetGroup(group=+1), Private(type=0x11,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) } ]
 	};
 	key <12>                 {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, Private(type=0x11,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, Private(type=0x11,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) ]
 	};
 	key <13>                 {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, { Private(type=0x11,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00), Private(type=0x11,data[0]=0x62,data[1]=0x61,data[2]=0x72,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) } ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, { Private(type=0x11,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00), Private(type=0x11,data[0]=0x62,data[1]=0x61,data[2]=0x72,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) } ]
 	};
 	key <14>                 {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, Private(type=0x11,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00), { Private(type=0x11,data[0]=0x62,data[1]=0x61,data[2]=0x72,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00),     SetMods(modifiers=Control) },                     NoAction() ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, Private(type=0x11,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00), { Private(type=0x11,data[0]=0x62,data[1]=0x61,data[2]=0x72,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00),     SetMods(modifiers=Control) },                     NoAction() ]
 	};
 	key <15>                 {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, { Private(type=0x11,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00), Private(type=0x11,data[0]=0x62,data[1]=0x61,data[2]=0x72,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) },     SetMods(modifiers=Control),                     NoAction() ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
+		actions[1]= [ {     SetMods(modifiers=Control),             SetGroup(group=+1) }, { Private(type=0x11,data[0]=0x66,data[1]=0x6f,data[2]=0x6f,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00), Private(type=0x11,data[0]=0x62,data[1]=0x61,data[2]=0x72,data[3]=0x00,data[4]=0x00,data[5]=0x00,data[6]=0x00) },     SetMods(modifiers=Control),                     NoAction() ]
 	};
 };
 

--- a/test/data/keymaps/symbols-multi-keysyms-empty.xkb
+++ b/test/data/keymaps/symbols-multi-keysyms-empty.xkb
@@ -163,31 +163,31 @@ xkb_compatibility {
 xkb_symbols {
 	key <12>                 {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [       SetMods(modifiers=Shift) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [       SetMods(modifiers=Shift) ]
 	};
 	key <13>                 {
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol ],
-		actions[Group1]= [       SetMods(modifiers=Shift) ]
+		symbols[1]= [                       NoSymbol ],
+		actions[1]= [       SetMods(modifiers=Shift) ]
 	};
 	key <14>                 {
 		type= "TWO_LEVEL",
-		symbols[Group1]= [        NoSymbol,        NoSymbol ]
+		symbols[1]= [        NoSymbol,        NoSymbol ]
 	};
 	key <15>                 {
 		type= "TWO_LEVEL",
-		symbols[Group1]= [        NoSymbol,        NoSymbol ]
+		symbols[1]= [        NoSymbol,        NoSymbol ]
 	};
 	key <16>                 {	[               a,               A ] };
 	key <17>                 {	[               a,               A ] };
 	key <18>                 {
 		type= "FOUR_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               a,               A,        NoSymbol,        NoSymbol ]
+		symbols[1]= [               a,               A,        NoSymbol,        NoSymbol ]
 	};
 	key <19>                 {
 		type= "FOUR_LEVEL_SEMIALPHABETIC",
-		symbols[Group1]= [               a,               A,        NoSymbol,        NoSymbol ]
+		symbols[1]= [               a,               A,        NoSymbol,        NoSymbol ]
 	};
 	key <20>                 {	[               a,               A,              ae,        NoSymbol ] };
 	key <21>                 {	[               a,               A,              ae,        NoSymbol ] };
@@ -195,37 +195,37 @@ xkb_symbols {
 	key <23>                 {	[               a,               A,              ae,              AE ] };
 	key <32>                 {
 		repeat= No,
-		symbols[Group1]= [                              a ],
-		actions[Group1]= [                     NoAction() ]
+		symbols[1]= [                              a ],
+		actions[1]= [                     NoAction() ]
 	};
 	key <33>                 {
 		repeat= No,
-		symbols[Group1]= [                              a ],
-		actions[Group1]= [                     NoAction() ]
+		symbols[1]= [                              a ],
+		actions[1]= [                     NoAction() ]
 	};
 	key <34>                 {
 		type= "TWO_LEVEL",
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),                     NoAction() ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),                     NoAction() ]
 	};
 	key <35>                 {
 		type= "TWO_LEVEL",
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),                     NoAction() ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),                     NoAction() ]
 	};
 	key <38>                 {
 		type= "FOUR_LEVEL_SEMIALPHABETIC",
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),                     NoAction(),                     NoAction(),                     NoAction() ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),                     NoAction(),                     NoAction(),                     NoAction() ]
 	};
 	key <39>                 {
 		type= "FOUR_LEVEL_SEMIALPHABETIC",
 		repeat= No,
-		symbols[Group1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
-		actions[Group1]= [                     NoAction(),                     NoAction(),                     NoAction(),                     NoAction() ]
+		symbols[1]= [                       NoSymbol,                       NoSymbol,                       NoSymbol,                       NoSymbol ],
+		actions[1]= [                     NoAction(),                     NoAction(),                     NoAction(),                     NoAction() ]
 	};
 };
 


### PR DESCRIPTION
The upcoming raise of the maximum groups count will require to use numeric group indexes instead of the syntax `GroupN` if groups > 8.

Let’s not bother with handling two cases (group count ≤ 8 or > 8) and always serialize group indexes as numeric values.