### PR TITLE
keymap: Add parameter `latchOnPress` for `LatchMods()`

### DIFF
--- a/changes/api/+latchOnPress.feature.md
+++ b/changes/api/+latchOnPress.feature.md
@@ -1,0 +1,11 @@
+Added the new parameter `latchOnPress` for the key action `LatchMods()`.
+
+Some keyboard layouts use `ISO_Level3_Latch` or `ISO_Level5_Latch` to define
+“built-in” dead keys. `latchOnPress` enables to behave as usual dead keys, i.e.
+to latch on press and to deactivate as soon as another (non-modifier) key is
+pressed.
+
+As it is incompatible with X11, this feature is available only using the keymap
+text format v2.
+
+[XKB protocol key actions]: https://www.x.org/releases/current/doc/kbproto/xkbproto.html#Key_Actions

--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -294,8 +294,25 @@ Unused in [xkeyboard-config] layouts.
 </tr>
 <tr>
 <th>`LatchModifiers()`</th>
-<td>✅ Full support</td>
-<td colspan="2">✅ Full support</td>
+<td>
+<details>
+<summary>⚠️ Partial support</summary>
+- `latchOnPress` parameter is not supported. Use `::XKB_KEYMAP_FORMAT_TEXT_V2`.
+</details>
+</td>
+<td>
+<details>
+<summary>⚠️ Partial support</summary>
+- `latchOnPress` parameter is not supported. Use `::XKB_KEYMAP_FORMAT_TEXT_V2`.
+</details>
+</td>
+<td>
+<details>
+<summary>✅ Full support</summary>
+- `latchOnPress` parameter (since 1.11). See @ref latch-mods-action "its documentation"
+  for further details.
+</details>
+</td>
 </tr>
 <tr>
 <th>`LockModifiers()`</th>

--- a/doc/keymap-text-format-v1-v2.md
+++ b/doc/keymap-text-format-v1-v2.md
@@ -3163,6 +3163,17 @@ Modifies the <em>[latched]</em> modifiers
 <td>`false`</td>
 <td>See its use [hereinafter](@ref latch-modifier-action-effects)</td>
 </tr>
+<tr>
+<th>`latchOnPress`</th>
+<td></td>
+<td>boolean</td>
+<td>`false`</td>
+<td>
+Control whether [latched] modifiers are latched on key press or release (default).
+See [hereinafter](@ref latch-modifier-action-effects) for further details.
+
+@note Available since 1.11, only with `::XKB_KEYMAP_FORMAT_TEXT_V2`.
+</tr>
 </tbody>
 </table>
 
@@ -3273,26 +3284,25 @@ These actions perform different tasks on key press and on key release:
     <tr>
         <th>`LatchMods` @anchor set-modifier-action-effects</th>
         <td>
-          <ul>
-            <li>Adds modifiers to <em>[latched]</em> modifiers.</li>
-          </ul>
+        - If `latchOnPress` is true, then:
+          - If `clearLocks` is true and target modifiers were locked,
+            then unlock them and clear the action.
+          - Otherwise add modifiers to the <em>[latched]</em> modifiers.
+        - Otherwise adds modifiers to <em>[depressed]</em> modifiers.
         </td>
         <td>
-          <ul>
-            <li>
-              Removes modifiers from <em>[latched]</em> modifiers.
-            </li>
-            <li>
-              If <code>clearLocks=yes</code> and no other key
-              has been pressed since this key press, then the
-              modifiers will be removed as well from the
-              <em>[locked]</em> modifiers.
-            </li>
-            <li>
-              If <code>latchToLock=yes</code> then the modifiers
-              are added to the <em>[locked]</em> modifiers.
-            </li>
-          </ul>
+        - If `latchOnPress` is false, then:
+          - Removes modifiers from <em>[depressed]</em> modifiers.
+        - If no keys were operated simultaneously with the latching modifier key:
+          - If `clearLocks` is true and target modifiers were locked,
+            then unlock then stop here and clear the action.
+          <!-- TODO: pending latch? -->
+          - Otherwise add modifiers to <em>[latched]</em> modifiers.
+          - If `latchToLock` is true and if the target modifiers are latched,
+            then unlatch them and <em>[lock][locked]</em> them.
+          - Latch target modifiers that were not used by `clearLocks` and
+            `latchToLock`.
+        - Otherwise unlatch the target modifiers and clear the action.
         </td>
     </tr>
     <tr>

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -113,6 +113,7 @@ enum xkb_action_flags {
     ACTION_SAME_SCREEN = (1 << 9),
     ACTION_LOCK_ON_RELEASE = (1 << 10),
     ACTION_UNLOCK_ON_PRESS = (1 << 11),
+    ACTION_LATCH_ON_PRESS = (1 << 12),
 };
 
 enum xkb_action_controls {

--- a/src/xkbcomp/action.h
+++ b/src/xkbcomp/action.h
@@ -29,6 +29,7 @@ SetDefaultActionField(struct xkb_context *ctx, enum xkb_keymap_format format,
                       ActionsInfo *info, struct xkb_mod_set *mods,
                       const char *elem, const char *field, ExprDef *array_ndx,
                       ExprDef *value, enum merge_mode merge);
+
 static inline bool
 isModsUnLockOnPressSupported(enum xkb_keymap_format format)
 {
@@ -38,6 +39,13 @@ isModsUnLockOnPressSupported(enum xkb_keymap_format format)
 
 static inline bool
 isGroupLockOnReleaseSupported(enum xkb_keymap_format format)
+{
+    /* Lax bound */
+    return format >= XKB_KEYMAP_FORMAT_TEXT_V2;
+}
+
+static inline bool
+isModsLatchOnPressSupported(enum xkb_keymap_format format)
 {
     /* Lax bound */
     return format >= XKB_KEYMAP_FORMAT_TEXT_V2;

--- a/src/xkbcomp/keymap-dump.c
+++ b/src/xkbcomp/keymap-dump.c
@@ -431,11 +431,20 @@ write_action(struct xkb_keymap *keymap, enum xkb_keymap_format format,
                     "in keymap format %d\n", format);
             unlockOnPress = false;
         }
-        write_buf(buf, "%s%s(modifiers=%s%s%s%s%s)%s", prefix, type, args,
+        bool latchOnPress = action->type == ACTION_TYPE_MOD_LATCH &&
+                            (action->group.flags & ACTION_LATCH_ON_PRESS);
+        if (latchOnPress && !isModsLatchOnPressSupported(format)) {
+            log_err(keymap->ctx, XKB_ERROR_INCOMPATIBLE_KEYMAP_TEXT_FORMAT,
+                    "Cannot use \"LatchMods(latchOnPress=true)\" "
+                    "in keymap format %d\n", format);
+            latchOnPress = false;
+        }
+        write_buf(buf, "%s%s(modifiers=%s%s%s%s%s%s)%s", prefix, type, args,
                   (action->type != ACTION_TYPE_MOD_LOCK && (action->mods.flags & ACTION_LOCK_CLEAR)) ? ",clearLocks" : "",
                   (action->type != ACTION_TYPE_MOD_LOCK && (action->mods.flags & ACTION_LATCH_TO_LOCK)) ? ",latchToLock" : "",
                   (action->type == ACTION_TYPE_MOD_LOCK) ? affect_lock_text(action->mods.flags, false) : "",
                   (unlockOnPress) ? ",unlockOnPress" : "",
+                  (latchOnPress) ? ",latchOnPress" : "",
                   suffix);
         break;
 

--- a/test/data/compat/level3-v2
+++ b/test/data/compat/level3-v2
@@ -1,0 +1,39 @@
+partial xkb_compatibility "latchOnPress" {
+
+    virtual_modifiers  LevelThree;
+
+    interpret.repeat= False;
+    setMods.clearLocks= True;
+    latchMods.clearLocks= True;
+    latchMods.latchToLock= True;
+
+    interpret ISO_Level3_Latch+Any {
+	useModMapMods= level1;
+	virtualModifier= LevelThree;
+	action= LatchMods(modifiers=LevelThree, latchOnPress);
+    };
+
+    interpret ISO_Level3_Latch {
+	action= LatchMods(modifiers=LevelThree, latchOnPress);
+    };
+};
+
+partial xkb_compatibility "latchOnRelease" {
+
+    virtual_modifiers  LevelThree;
+
+    interpret.repeat= False;
+    setMods.clearLocks= True;
+    latchMods.clearLocks= True;
+    latchMods.latchToLock= True;
+
+    interpret ISO_Level3_Latch+Any {
+	useModMapMods= level1;
+	virtualModifier= LevelThree;
+	action= LatchMods(modifiers=LevelThree, latchOnPress=false);
+    };
+
+    interpret ISO_Level3_Latch {
+	action= LatchMods(modifiers=LevelThree, latchOnPress=false);
+    };
+};

--- a/test/data/rules/evdev
+++ b/test/data/rules/evdev
@@ -1027,6 +1027,7 @@
   lv3:switch		=	+level3(switch)
   lv3:ralt_switch	=	+level3(ralt_switch)
   lv3:ralt_switch_multikey	=	+level3(ralt_switch_multikey)
+  lv3:ralt_latch	=	+level3(ralt_latch)
   lv3:ralt_alt		=	+level3(ralt_alt)
   lv3:lalt_switch	=	+level3(lalt_switch)
   lv3:alt_switch	=	+level3(alt_switch)
@@ -1176,6 +1177,8 @@
   grab:break_actions    =       +xfree86(grab_break)
   grp:lockOnRelease	=	+iso9995-v2(lockOnRelease)
   grp:lockOnPress	=	+iso9995-v2(lockOnPress)
+  lv3:latchOnPress	=	+level3-v2(latchOnPress)
+  lv3:latchOnRelease	=	+level3-v2(latchOnRelease)
 
 
 ! option	=	types

--- a/test/data/rules/evdev-modern
+++ b/test/data/rules/evdev-modern
@@ -559,6 +559,7 @@
   lv3:switch				=	+level3(switch)
   lv3:ralt_switch			=	+level3(ralt_switch)
   lv3:ralt_switch_multikey		=	+level3(ralt_switch_multikey)
+  lv3:ralt_latch			=	+level3(ralt_latch)
   lv3:ralt_alt				=	+level3(ralt_alt)
   lv3:lalt_switch			=	+level3(lalt_switch)
   lv3:alt_switch			=	+level3(alt_switch)
@@ -706,6 +707,8 @@
   grab:break_actions	=	+xfree86(grab_break)
   grp:lockOnRelease	=	+iso9995-v2(lockOnRelease)
   grp:lockOnPress	=	+iso9995-v2(lockOnPress)
+  lv3:latchOnPress	=	+level3-v2(latchOnPress)
+  lv3:latchOnRelease	=	+level3-v2(latchOnRelease)
 
 
 ! option			=	types

--- a/test/data/symbols/level3
+++ b/test/data/symbols/level3
@@ -12,6 +12,15 @@ xkb_symbols "ralt_switch" {
   include "level3(modifier_mapping)"
 };
 
+default partial modifier_keys
+xkb_symbols "ralt_latch" {
+  key <RALT> {
+    type[Group1]="ONE_LEVEL",
+    symbols[Group1] = [ ISO_Level3_Latch ]
+  };
+  include "level3(modifier_mapping)"
+};
+
 // Ensure a mapping to a real modifier for LevelThree.
 partial modifier_keys
 xkb_symbols "modifier_mapping" {


### PR DESCRIPTION
Some keyboard layouts use `ISO_Level3_Latch` or `ISO_Level5_Latch` to define “built-in” dead keys:
- they do not rely on the installation of custom Compose file;
- they do not clash with other layouts.

However, layout projects usually want the exact same behavior on all OS, but the XKB latch behavior (often misunderstood) also acts as a *set* modifier, which is not expected.

The usual behavior of a dead key on Linux, macOS and Windows is:
- latch on press;
- deactivate as soon as another (non-modifier) key is pressed.

Added the parameter `latchOnPress` to `LatchMods()` to enable the aforementioned behavior.

As it is incompatible with X11, this feature is available only using the keymap text format v2.

[XKB protocol key actions]: https://www.x.org/releases/current/doc/kbproto/xkbproto.html#Key_Actions

Close #777