### PR TITLE
state: Fix LatchMods mutation to SetMods or LockMods

### DIFF
--- a/changes/api/808.bugfix.md
+++ b/changes/api/808.bugfix.md
@@ -1,0 +1,2 @@
+Fixed incorrect implementation of `latchToLock` for `LatchMods()`, which could
+result in unintended `CapsLock` unlock.

--- a/src/state.c
+++ b/src/state.c
@@ -607,16 +607,19 @@ xkb_filter_mod_latch_func(struct xkb_state *state,
                 actions[k].mods.mods.mask == filter->action.mods.mods.mask) {
                 filter->action = actions[k];
                 if (filter->action.mods.flags & ACTION_LATCH_TO_LOCK) {
+                    /* Mutate the action to LockMods() */
                     filter->action.type = ACTION_TYPE_MOD_LOCK;
                     filter->func = xkb_filter_mod_lock_func;
-                    state->components.locked_mods |= filter->action.mods.mods.mask;
+                    xkb_filter_mod_lock_new(state, filter);
                 }
                 else {
+                    /* Mutate the action to SetMods() */
                     filter->action.type = ACTION_TYPE_MOD_SET;
                     filter->func = xkb_filter_mod_set_func;
-                    state->set_mods |= filter->action.mods.mods.mask;
+                    xkb_filter_mod_set_new(state, filter);
                 }
                 filter->key = key;
+                /* Clear latches */
                 state->components.latched_mods &= ~filter->action.mods.mods.mask;
                 /* XXX beep beep! */
                 return XKB_FILTER_CONSUME;

--- a/test/state.c
+++ b/test/state.c
@@ -1429,6 +1429,33 @@ test_update_latched_locked(struct xkb_keymap *keymap)
             KEY_ENTRY(KEY_A, DOWN, XKB_KEY_A),
             .changes = XKB_STATE_MODS_LATCHED | XKB_STATE_MODS_EFFECTIVE
         },
+        /* Latch-to-lock */
+        RESET_STATE,
+        {
+            /* Set capslock, to ensure that when *mutating* the latch to a lock,
+             * the `priv` field and refcnt fields are set accordingly. */
+            MOD_LOCK_ENTRY(capslock, capslock),
+            .locked_mods=capslock, .mods=capslock,
+            .changes=XKB_STATE_MODS_LOCKED | XKB_STATE_MODS_EFFECTIVE | XKB_STATE_LEDS
+        },
+        {
+            KEY_ENTRY(KEY_102ND, BOTH, XKB_KEY_ISO_Level3_Latch),
+            /* Pending latch */
+            .base_mods = 0, .latched_mods=level3, .locked_mods=capslock, .mods=capslock | level3,
+            .changes = XKB_STATE_MODS_DEPRESSED | XKB_STATE_MODS_LATCHED
+        },
+        {
+            KEY_ENTRY(KEY_102ND, BOTH, XKB_KEY_ISO_Level3_Latch),
+            /* Mutate to a lock */
+            .base_mods = 0, .latched_mods=0, .locked_mods=capslock | level3, .mods=capslock | level3,
+            .changes = XKB_STATE_MODS_DEPRESSED
+        },
+        {
+            KEY_ENTRY(KEY_102ND, BOTH, XKB_KEY_ISO_Level3_Latch),
+            /* Unlock via latch’s ACTION_LOCK_CLEAR */
+            .base_mods = 0, .latched_mods=0, .locked_mods=capslock, .mods=capslock,
+            .changes = XKB_STATE_MODS_DEPRESSED | XKB_STATE_MODS_LOCKED | XKB_STATE_MODS_EFFECTIVE
+        },
         // TODO
 
         /*


### PR DESCRIPTION
Previously we use inlined version of the corresponding filter functions of the `SetMods()` and `LockMods()` actions, but they were incomplete and did not set some fields (`priv`, `refcnt`) properly. Also, it is error-prone: it requires discipline to keep it in sync.

E.g. before this commit, converting to `LockMods()` would always try to unlock `CapsLock` due to the wrong value of the `priv` field.

Fixed by using the corresponding filter functions directly, so that we always mutate the filter properly, as in `xkb_filter_group_latch_func`.

Fixes #808