### PR TITLE
keymap: Add option `unlockOnPress` for `SetMods()` and `LatchMods()`

### DIFF
--- a/changes/api/780.feature.md
+++ b/changes/api/780.feature.md
@@ -1,0 +1,12 @@
+Added the new parameter `unlockOnPress` for the key action `SetMods()`.
+
+It enables e.g. to deactivate `CapsLock` *on press* rather than on release,
+as in other platforms such as Windows.
+
+It fixes a [18-year old issue](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/issues/74)
+inherited from the X11 ecosystem, by extending the [XKB protocol key actions].
+
+As it is incompatible with X11, this feature is available only using the keymap
+text format v2.
+
+[XKB protocol key actions]: https://www.x.org/releases/current/doc/kbproto/xkbproto.html#Key_Actions

--- a/changes/api/780.feature.md
+++ b/changes/api/780.feature.md
@@ -1,4 +1,5 @@
-Added the new parameter `unlockOnPress` for the key action `SetMods()`.
+Added the new parameter `unlockOnPress` for the key actions `SetMods()` and
+`LatchMods()`.
 
 It enables e.g. to deactivate `CapsLock` *on press* rather than on release,
 as in other platforms such as Windows.

--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -351,18 +351,22 @@ Unused in [xkeyboard-config] layouts.
 <details>
 <summary>⚠️ Partial support</summary>
 - `latchOnPress` parameter is not supported.
+- `unLockOnPress` parameter is not supported.
 </details>
 </td>
 <td>
 <details>
 <summary>⚠️ Partial support</summary>
 - `latchOnPress` parameter is not supported. Use `::XKB_KEYMAP_FORMAT_TEXT_V2`.
+- `unLockOnPress` parameter is not supported. Use `::XKB_KEYMAP_FORMAT_TEXT_V2`.
 </details>
 </td>
 <td>
 <details>
 <summary>✅ Full support</summary>
 - `latchOnPress` parameter (since 1.11). See @ref latch-mods-action "its documentation"
+  for further details.
+- `unLockOnPress` parameter (since 1.11). See @ref latch-mods-action "its documentation"
   for further details.
 </details>
 </td>

--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -325,15 +325,32 @@ Unused in [xkeyboard-config] layouts.
 <tr>
 <th rowspan="3">Modifiers</th>
 <th>`SetModifiers()`</th>
-<td>✅ Full support</td>
-<td colspan="2">✅ Full support</td>
+<td>
+<details>
+<summary>⚠️ Partial support</summary>
+- `unlockOnPress` parameter is not supported.
+</details>
+</td>
+<td>
+<details>
+<summary>⚠️ Partial support</summary>
+- `unlockOnPress` parameter is not supported. Use `::XKB_KEYMAP_FORMAT_TEXT_V2`.
+</details>
+</td>
+<td>
+<details>
+<summary>✅ Full support</summary>
+- `unlockOnPress` parameter (since 1.11). See @ref set-mods-action "its documentation"
+  for further details.
+</details>
+</td>
 </tr>
 <tr>
 <th>`LatchModifiers()`</th>
 <td>
 <details>
 <summary>⚠️ Partial support</summary>
-- `latchOnPress` parameter is not supported. Use `::XKB_KEYMAP_FORMAT_TEXT_V2`.
+- `latchOnPress` parameter is not supported.
 </details>
 </td>
 <td>
@@ -355,7 +372,7 @@ Unused in [xkeyboard-config] layouts.
 <td>
 <details>
 <summary>⚠️ Partial support</summary>
-- `unlockOnPress` parameter is not supported. Use `::XKB_KEYMAP_FORMAT_TEXT_V2`.
+- `unlockOnPress` parameter is not supported.
 </details>
 </td>
 <td>

--- a/doc/keymap-text-format-v1-v2.md
+++ b/doc/keymap-text-format-v1-v2.md
@@ -3205,6 +3205,18 @@ The list of modifiers to modify, separated by `+`, or the special value
 <td>`false`</td>
 <td>See its use [hereinafter](@ref set-modifier-action-effects)</td>
 </tr>
+<tr>
+<th>`unlockOnPress`</th>
+<td></td>
+<td>boolean</td>
+<td>`false`</td>
+<td>
+Control whether [locked] modifiers are unlocked on key press or release (default).
+See [hereinafter](@ref set-modifier-action-effects) for further details.
+
+@note Available since 1.11, only with `::XKB_KEYMAP_FORMAT_TEXT_V2`.
+</td>
+</tr>
 </tbody>
 </table>
 </dd>
@@ -3341,26 +3353,17 @@ These actions perform different tasks on key press and on key release:
     <tr>
       <th>`SetMods` @anchor latch-modifier-action-effects</th>
       <td>
-        <ul>
-          <li>
-            Adds modifiers to <em>[depressed]</em> modifiers
-          </li>
-        </ul>
+      - If `clearLocks` and `unlockOnPress` are true, unlock the target
+        modifiers.
+      - Adds modifiers to <em>[depressed]</em> modifiers that were not unlocked.
       </td>
       <td>
-        <ul>
-          <li>
-            Removes modifiers from <em>[depressed]</em> modifiers,
-            provided that no other key which affects the same
-            modifiers is logically down.
-          </li>
-          <li>
-            If <code>clearLocks=yes</code> and no other key
-            were operated simultaneously with this key,
-            then the modifiers will be removed as well from
-            the <em>[locked]</em> modifiers.
-          </li>
-        </ul>
+      - Removes modifiers added on press from <em>[depressed]</em> modifiers,
+        provided that no other key which affects the same modifiers is logically
+        down.
+      - If `clearLocks` is true, `unlockOnPress` is false and no other key were
+        operated simultaneously with this key, then the modifiers will be
+        removed as well from the <em>[locked]</em> modifiers.
       </td>
     </tr>
     <tr>

--- a/doc/keymap-text-format-v1-v2.md
+++ b/doc/keymap-text-format-v1-v2.md
@@ -3268,6 +3268,20 @@ See [hereinafter](@ref latch-modifier-action-effects) for further details.
 
 @note Available since 1.11, only with `::XKB_KEYMAP_FORMAT_TEXT_V2`.
 </tr>
+<tr>
+<th>`unlockOnPress`</th>
+<td></td>
+<td>boolean</td>
+<td>`false`</td>
+<td>
+Control whether [locked] modifiers are unlocked on key press or release (default).
+See [hereinafter](@ref latch-modifier-action-effects) for further details.
+
+@note It is *implied* if both `latchOnPress=true` and `clearLocks=true`.
+
+@note Available since 1.11, only with `::XKB_KEYMAP_FORMAT_TEXT_V2`.
+</td>
+</tr>
 </tbody>
 </table>
 
@@ -3369,18 +3383,19 @@ These actions perform different tasks on key press and on key release:
     <tr>
         <th>`LatchMods` @anchor set-modifier-action-effects</th>
         <td>
-        - If `latchOnPress` is true, then:
-          - If `clearLocks` is true and target modifiers were locked,
-            then unlock them and clear the action.
-          - Otherwise add modifiers to the <em>[latched]</em> modifiers.
+        - If `unLockOnPress` and `clearLocks` are true and target modifiers were
+          locked, then unlocks them and clear the action.
+        - Otherwise if `latchOnPress` is true, then adds modifiers to the
+          <em>[latched]</em> modifiers.
         - Otherwise adds modifiers to <em>[depressed]</em> modifiers.
         </td>
         <td>
         - If `latchOnPress` is false, then:
           - Removes modifiers from <em>[depressed]</em> modifiers.
         - If no keys were operated simultaneously with the latching modifier key:
-          - If `clearLocks` is true and target modifiers were locked,
-            then unlock then stop here and clear the action.
+          - If `clearLocks` is true and `unLockOnPress` is false and target
+            modifiers were locked, then unlock then stop here and clear the
+            action.
           <!-- TODO: pending latch? -->
           - Otherwise add modifiers to <em>[latched]</em> modifiers.
           - If `latchToLock` is true and if the target modifiers are latched,

--- a/src/xkbcomp/action.c
+++ b/src/xkbcomp/action.c
@@ -295,9 +295,10 @@ HandleSetLatchLockMods(struct xkb_context *ctx, enum xkb_keymap_format format,
     if (field == ACTION_FIELD_MODIFIERS)
         return CheckModifierField(ctx, mods, action->type, array_ndx, value,
                                   &act->flags, &act->mods.mods);
-    if ((type == ACTION_TYPE_MOD_SET || type == ACTION_TYPE_MOD_LOCK) &&
-        field == ACTION_FIELD_UNLOCK_ON_PRESS) {
-        /* TODO: This should be implemented for Latch too. */
+    if (field == ACTION_FIELD_UNLOCK_ON_PRESS) {
+        /* Ensure to update if a new modifier action is introduced. */
+        assert(type == ACTION_TYPE_MOD_SET || type == ACTION_TYPE_MOD_LATCH ||
+               type == ACTION_TYPE_MOD_LOCK);
         if (isModsUnLockOnPressSupported(format)) {
             return CheckBooleanFlag(ctx, action->type, field,
                                     ACTION_UNLOCK_ON_PRESS, array_ndx,

--- a/src/xkbcomp/action.c
+++ b/src/xkbcomp/action.c
@@ -295,6 +295,18 @@ HandleSetLatchLockMods(struct xkb_context *ctx, enum xkb_keymap_format format,
     if (field == ACTION_FIELD_MODIFIERS)
         return CheckModifierField(ctx, mods, action->type, array_ndx, value,
                                   &act->flags, &act->mods.mods);
+    if ((type == ACTION_TYPE_MOD_SET || type == ACTION_TYPE_MOD_LOCK) &&
+        field == ACTION_FIELD_UNLOCK_ON_PRESS) {
+        /* TODO: This should be implemented for Latch too. */
+        if (isModsUnLockOnPressSupported(format)) {
+            return CheckBooleanFlag(ctx, action->type, field,
+                                    ACTION_UNLOCK_ON_PRESS, array_ndx,
+                                    value, &act->flags);
+        } else {
+            return ReportFormatVersionMismatch(ctx, action->type, field,
+                                                format, ">= 2");
+        }
+    }
     if ((type == ACTION_TYPE_MOD_SET || type == ACTION_TYPE_MOD_LATCH) &&
         field == ACTION_FIELD_CLEAR_LOCKS)
         return CheckBooleanFlag(ctx, action->type, field,
@@ -316,21 +328,9 @@ HandleSetLatchLockMods(struct xkb_context *ctx, enum xkb_keymap_format format,
             }
         }
     }
-    if (type == ACTION_TYPE_MOD_LOCK) {
-        if (field == ACTION_FIELD_AFFECT)
-            return CheckAffectField(ctx, action->type, array_ndx, value,
-                                    &act->flags);
-        if (field == ACTION_FIELD_UNLOCK_ON_PRESS) {
-            if (isModsUnLockOnPressSupported(format)) {
-                return CheckBooleanFlag(ctx, action->type, field,
-                                        ACTION_UNLOCK_ON_PRESS, array_ndx,
-                                        value, &act->flags);
-            } else {
-                return ReportFormatVersionMismatch(ctx, action->type, field,
-                                                   format, ">= 2");
-            }
-        }
-    }
+    if (type == ACTION_TYPE_MOD_LOCK && field == ACTION_FIELD_AFFECT)
+        return CheckAffectField(ctx, action->type, array_ndx, value,
+                                &act->flags);
 
     return ReportIllegal(ctx, action->type, field);
 }

--- a/src/xkbcomp/keymap-dump.c
+++ b/src/xkbcomp/keymap-dump.c
@@ -444,9 +444,7 @@ write_action(struct xkb_keymap *keymap, enum xkb_keymap_format format,
         else
             args = ModMaskText(keymap->ctx, MOD_BOTH, &keymap->mods,
                                action->mods.mods.mods);
-        bool unlockOnPress = (action->type == ACTION_TYPE_MOD_SET ||
-                              action->type == ACTION_TYPE_MOD_LOCK) &&
-                             (action->mods.flags & ACTION_UNLOCK_ON_PRESS);
+        bool unlockOnPress = (action->mods.flags & ACTION_UNLOCK_ON_PRESS);
         if (unlockOnPress && !isModsUnLockOnPressSupported(format)) {
             log_err(keymap->ctx, XKB_ERROR_INCOMPATIBLE_KEYMAP_TEXT_FORMAT,
                     "Cannot use \"%s(unlockOnPress=true)\" in keymap format %d\n",

--- a/src/xkbcomp/keymap-dump.c
+++ b/src/xkbcomp/keymap-dump.c
@@ -444,12 +444,13 @@ write_action(struct xkb_keymap *keymap, enum xkb_keymap_format format,
         else
             args = ModMaskText(keymap->ctx, MOD_BOTH, &keymap->mods,
                                action->mods.mods.mods);
-        bool unlockOnPress = action->type == ACTION_TYPE_MOD_LOCK &&
+        bool unlockOnPress = (action->type == ACTION_TYPE_MOD_SET ||
+                              action->type == ACTION_TYPE_MOD_LOCK) &&
                              (action->mods.flags & ACTION_UNLOCK_ON_PRESS);
         if (unlockOnPress && !isModsUnLockOnPressSupported(format)) {
             log_err(keymap->ctx, XKB_ERROR_INCOMPATIBLE_KEYMAP_TEXT_FORMAT,
-                    "Cannot use \"LockMods(unlockOnPress=true)\" "
-                    "in keymap format %d\n", format);
+                    "Cannot use \"%s(unlockOnPress=true)\" in keymap format %d\n",
+                    ActionTypeText(action->type), format);
             unlockOnPress = false;
         }
         bool latchOnPress = action->type == ACTION_TYPE_MOD_LATCH &&

--- a/test/data/rules/evdev
+++ b/test/data/rules/evdev
@@ -1128,6 +1128,7 @@
   kpdl:kposs            =	+kpdl(kposs)
   kpdl:semi             =	+kpdl(semi)
   shift:breaks_caps     =	+shift(breaks_caps)
+  shift:breaks_caps-v2  =	+shift-v2(breaks_caps)
   esperanto:qwerty      =	+epo(qwerty)
   esperanto:dvorak      =	+epo(dvorak)
   esperanto:colemak     =	+epo(colemak)

--- a/test/data/rules/evdev-modern
+++ b/test/data/rules/evdev-modern
@@ -660,6 +660,7 @@
   kpdl:kposs            		=	+kpdl(kposs)
   kpdl:semi             		=	+kpdl(semi)
   shift:breaks_caps     		=	+shift(breaks_caps)
+  shift:breaks_caps-v2			=	+shift-v2(breaks_caps)
   esperanto:qwerty      		=	+epo(qwerty)
   esperanto:dvorak      		=	+epo(dvorak)
   esperanto:colemak     		=	+epo(colemak)

--- a/test/data/symbols/shift
+++ b/test/data/symbols/shift
@@ -3,14 +3,16 @@ partial modifier_keys
 xkb_symbols "breaks_caps" {
     key <LFSH> {
 	type = "ALPHABETIC",
-    	actions [Group1] = [
+	[Shift_L, Shift_L],
+    	[
 	    SetMods(modifiers=Shift),
 	    SetMods(modifiers=Shift+Lock,clearLocks)
 	]
     };
     key <RTSH> {
 	type = "ALPHABETIC",
-	actions [Group1] = [
+	[Shift_R, Shift_R],
+	[
 	    SetMods(modifiers=Shift),
 	    SetMods(modifiers=Shift+Lock,clearLocks)
 	]

--- a/test/data/symbols/shift-v2
+++ b/test/data/symbols/shift-v2
@@ -1,0 +1,18 @@
+xkb_symbols "breaks_caps" {
+    key <LFSH> {
+	type = "ALPHABETIC",
+	[Shift_L, Shift_L],
+    	[
+	    SetMods(modifiers=Shift),
+	    SetMods(modifiers=Shift+Lock,clearLocks,unlockOnPress)
+	]
+    };
+    key <RTSH> {
+	type = "ALPHABETIC",
+	[Shift_R, Shift_R],
+	[
+	    SetMods(modifiers=Shift),
+	    SetMods(modifiers=Shift+Lock,clearLocks,unlockOnPress)
+	]
+    };
+};

--- a/test/keyseq.c
+++ b/test/keyseq.c
@@ -553,6 +553,44 @@ test_group_latch(struct xkb_context *ctx)
 }
 
 static void
+test_mod_set(struct xkb_context *ctx)
+{
+    struct xkb_keymap *keymap;
+
+    /* Shift break caps: unlockOnPress=false */
+    keymap = test_compile_rules(ctx, XKB_KEYMAP_FORMAT_TEXT_V2,
+                                "evdev", "pc105", "us", "",
+                                "shift:breaks_caps");
+    assert(test_key_seq(keymap,
+        KEY_CAPSLOCK,  BOTH, XKB_KEY_Caps_Lock, NEXT,
+        KEY_A,         BOTH, XKB_KEY_A,         NEXT,
+        KEY_LEFTSHIFT, DOWN, XKB_KEY_Shift_L,   NEXT,
+        KEY_A,         BOTH, XKB_KEY_a,         NEXT,
+        KEY_LEFTSHIFT, UP,   XKB_KEY_Shift_L,   NEXT,
+        /* Caps still locked: key was operated before Shift release */
+        KEY_A,         BOTH, XKB_KEY_A,         FINISH
+    ));
+    assert(keymap);
+
+    xkb_keymap_unref(keymap);
+
+    /* Shift break caps: unlockOnPress=true (XKB extension) */
+    keymap = test_compile_rules(ctx, XKB_KEYMAP_FORMAT_TEXT_V2,
+                                "evdev", "pc105", "us", "",
+                                "shift:breaks_caps-v2");
+    assert(keymap);
+    assert(test_key_seq(keymap,
+        KEY_CAPSLOCK,  BOTH, XKB_KEY_Caps_Lock, NEXT,
+        KEY_A,         BOTH, XKB_KEY_A,         NEXT,
+        KEY_LEFTSHIFT, DOWN, XKB_KEY_Shift_L,   NEXT,
+        KEY_A,         BOTH, XKB_KEY_A,         NEXT,
+        KEY_LEFTSHIFT, UP,   XKB_KEY_Shift_L,   NEXT,
+        KEY_A,         BOTH, XKB_KEY_a,         FINISH
+    ));
+    xkb_keymap_unref(keymap);
+}
+
+static void
 test_mod_lock(struct xkb_context *ctx)
 {
     struct xkb_keymap *keymap;
@@ -1822,6 +1860,7 @@ main(void)
     test_simultaneous_modifier_clear(ctx);
     test_group_lock(ctx);
     test_group_latch(ctx);
+    test_mod_set(ctx);
     test_mod_lock(ctx);
     test_mod_latch(ctx);
     test_explicit_actions(ctx);


### PR DESCRIPTION
It enables e.g. to deactivate `CapsLock` *on press* rather than on release, as in other platforms such as Windows.

It fixes a [18-year old issue] inherited from the X11 ecosystem, by extending the [XKB protocol key actions].

As it is incompatible with X11, this feature is available only using the keymap text format v2.

[18-year old issue]: https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/issues/74
[XKB protocol key actions]: https://www.x.org/releases/current/doc/kbproto/xkbproto.html#Key_Actions

Fixes #780