### PR TITLE
doc: Fix headers markup

### DIFF
--- a/include/xkbcommon/xkbcommon-compose.h
+++ b/include/xkbcommon/xkbcommon-compose.h
@@ -30,7 +30,7 @@ extern "C" {
  * @parblock
  *
  * Compose and dead-keys are a common feature of many keyboard input
- * systems.  They extend the range of the keysysm that can be produced
+ * systems.  They extend the range of the keysyms that can be produced
  * directly from a keyboard by using a sequence of key strokes, instead
  * of just one.
  *
@@ -40,22 +40,22 @@ extern "C" {
  *     <Multi_key> <A> <T>      : "@"   at     # COMMERCIAL AT
  *
  * When the user presses a key which produces the `<dead_acute>` keysym,
- * nothing initially happens (thus the key is dubbed a "dead-key").  But
- * when the user enters `<a>`, "á" is "composed", in place of "a".  If
+ * nothing initially happens (thus the key is dubbed a *dead-key*).  But
+ * when the user enters `<a>`, “á” is *composed*, in place of “a”.  If
  * instead the user had entered a keysym which does not follow
  * `<dead_acute>` in any compose sequence, the sequence is said to be
- * "cancelled".
+ * *cancelled*.
  *
  * Compose files define many such sequences.  For a description of the
- * common file format for Compose files, see the Compose(5) man page.
+ * common file format for Compose files, see the `Compose(5)` man page.
  *
- * A successfuly-composed sequence has two results: a keysym and a UTF-8
+ * A successfully-composed sequence has two results: a keysym and a UTF-8
  * string.  At least one of the two is defined for each sequence.  If only
- * a keysym is given, the keysym's string representation is used for the
+ * a keysym is given, the keysym’s string representation is used for the
  * result string (using xkb_keysym_to_utf8()).
  *
  * This library provides low-level support for Compose file parsing and
- * processing.  Higher-level APIs (such as libX11's `Xutf8LookupString`(3))
+ * processing.  Higher-level APIs (such as libX11’s `Xutf8LookupString(3)`)
  * may be built upon it, or it can be used directly.
  *
  * @endparblock
@@ -136,37 +136,39 @@ enum xkb_compose_format {
  * - Compose files are written for a locale, and the locale is used when
  *   searching for the appropriate file to use.
  * - Compose files may reference the locale internally, with directives
- *   such as \%L.
+ *   such as `%%L`.
  *
- * As such, functions like xkb_compose_table_new_from_locale() require
- * a `locale` parameter.  This will usually be the current locale (see
- * locale(7) for more details).  You may also want to allow the user to
+ * As such, functions like `xkb_compose_table::xkb_compose_table_new_from_locale()`
+ * require a `locale` parameter.  This will usually be the current locale (see
+ * `locale(7)` for more details).  You may also want to allow the user to
  * explicitly configure it, so he can use the Compose file of a given
  * locale, but not use that locale for other things.
  *
  * You may query the current locale as follows:
- * @code
- *     const char *locale;
- *     locale = setlocale(LC_CTYPE, NULL);
- * @endcode
+ *
+ * ```c
+ * const char *locale;
+ * locale = setlocale(LC_CTYPE, NULL);
+ * ```
  *
  * This will only give useful results if the program had previously set
  * the current locale using setlocale(3), with `LC_CTYPE` or `LC_ALL`
- * and a non-NULL argument.
+ * and a non-`NULL` argument.
  *
  * If you prefer not to use the locale system of the C runtime library,
- * you may nevertheless obtain the user's locale directly using
- * environment variables, as described in locale(7).  For example,
- * @code
- *     const char *locale;
- *     locale = getenv("LC_ALL");
- *     if (!locale || !*locale)
- *         locale = getenv("LC_CTYPE");
- *     if (!locale || !*locale)
- *         locale = getenv("LANG");
- *     if (!locale || !*locale)
- *         locale = "C";
- * @endcode
+ * you may nevertheless obtain the user’s locale directly using
+ * environment variables, as described in `locale(7)`.  For example,
+ *
+ * ```c
+ * const char *locale;
+ * locale = getenv("LC_ALL");
+ * if (!locale || !*locale)
+ *     locale = getenv("LC_CTYPE");
+ * if (!locale || !*locale)
+ *     locale = getenv("LANG");
+ * if (!locale || !*locale)
+ *     locale = "C";
+ * ```
  *
  * Note that some locales supported by the C standard library may not
  * have a Compose file assigned.
@@ -190,7 +192,7 @@ enum xkb_compose_format {
  *    implementations, such as libX11, might not find a Compose file in
  *    this path.
  * 3. `HOME` - see Compose(5).
- * 4. `XLOCALEDIR` - if set, used as the base directory for the system's
+ * 4. `XLOCALEDIR` - if set, used as the base directory for the system’s
  *    X locale files, e.g. `/usr/share/X11/locale`, instead of the
  *    preconfigured directory.
  *
@@ -199,13 +201,13 @@ enum xkb_compose_format {
  * @param locale
  *     The current locale.  See @ref compose-locale.
  *     \n
- *     The value is copied, so it is safe to pass the result of getenv(3)
+ *     The value is copied, so it is safe to pass the result of `getenv(3)`
  *     (or similar) without fear of it being invalidated by a subsequent
- *     setenv(3) (or similar).
+ *     `setenv(3)` (or similar).
  * @param flags
  *     Optional flags for the compose table, or 0.
  *
- * @returns A compose table for the given locale, or NULL if the
+ * @returns A compose table for the given locale, or `NULL` if the
  * compilation failed or a Compose file was not found.
  *
  * @memberof xkb_compose_table
@@ -229,7 +231,7 @@ xkb_compose_table_new_from_locale(struct xkb_context *context,
  * @param flags
  *     Optional flags for the compose table, or 0.
  *
- * @returns A compose table compiled from the given file, or NULL if
+ * @returns A compose table compiled from the given file, or `NULL` if
  * the compilation failed.
  *
  * @memberof xkb_compose_table
@@ -270,7 +272,7 @@ xkb_compose_table_ref(struct xkb_compose_table *table);
 /**
  * Release a reference on a compose table, and possibly free it.
  *
- * @param table The object.  If it is NULL, this function does nothing.
+ * @param table The object.  If it is `NULL`, this function does nothing.
  *
  * @memberof xkb_compose_table
  */
@@ -337,7 +339,7 @@ xkb_compose_table_entry_keysym(struct xkb_compose_table_entry *entry);
 /**
  * Get the right-hand result string of a Compose table entry.
  *
- * The string is UTF-8 encoded and NULL-terminated.
+ * The string is UTF-8 encoded and `NULL`-terminated.
  *
  * For example, given the following entry:
  *
@@ -428,7 +430,7 @@ enum xkb_compose_state_flags {
  * @param flags
  *     Optional flags for the compose state, or 0.
  *
- * @returns A new compose state, or NULL on failure.
+ * @returns A new compose state, or `NULL` on failure.
  *
  * @memberof xkb_compose_state
  */
@@ -449,7 +451,7 @@ xkb_compose_state_ref(struct xkb_compose_state *state);
 /**
  * Release a reference on a compose state object, and possibly free it.
  *
- * @param state The object.  If NULL, do nothing.
+ * @param state The object.  If `NULL`, do nothing.
  *
  * @memberof xkb_compose_state
  */
@@ -496,7 +498,7 @@ enum xkb_compose_feed_result {
  *
  * This function can advance into a compose sequence, cancel a sequence,
  * start a new sequence, or do nothing in particular.  The resulting
- * status may be observed with xkb_compose_state_get_status().
+ * status may be observed with `xkb_compose_state_get_status()`.
  *
  * Some keysyms, such as keysyms for modifier keys, are ignored - they
  * have no effect on the status or otherwise.
@@ -520,16 +522,16 @@ enum xkb_compose_feed_result {
                 possible sequences.
    @endverbatim
  *
- * The current Compose formats do not support multiple-keysyms.
- * Therefore, if you are using a function such as xkb_state_key_get_syms()
- * and it returns more than one keysym, consider feeding XKB_KEY_NoSymbol
+ * The current Compose formats do not support multiple-keysyms. Therefore, if
+ * you are using a function such as `xkb_state::xkb_state_key_get_syms()`
+ * and it returns more than one keysym, consider feeding `XKB_KEY_NoSymbol`
  * instead.
  *
  * @param state
  *     The compose state object.
  * @param keysym
  *     A keysym, usually obtained after a key-press event, with a
- *     function such as xkb_state_key_get_one_sym().
+ *     function such as `xkb_state::xkb_state_key_get_one_sym()`.
  *
  * @returns Whether the keysym was ignored.  This is useful, for example,
  * if you want to keep a record of the sequence matched thus far.
@@ -543,7 +545,7 @@ xkb_compose_state_feed(struct xkb_compose_state *state,
 /**
  * Reset the Compose sequence state machine.
  *
- * The status is set to XKB_COMPOSE_NOTHING, and the current sequence
+ * The status is set to `::XKB_COMPOSE_NOTHING`, and the current sequence
  * is discarded.
  *
  * @memberof xkb_compose_state
@@ -564,7 +566,7 @@ xkb_compose_state_get_status(struct xkb_compose_state *state);
  * Get the result Unicode/UTF-8 string for a composed sequence.
  *
  * See @ref compose-overview for more details.  This function is only
- * useful when the status is XKB_COMPOSE_COMPOSED.
+ * useful when the status is `::XKB_COMPOSE_COMPOSED`.
  *
  * @param[in] state
  *     The compose state.
@@ -574,17 +576,17 @@ xkb_compose_state_get_status(struct xkb_compose_state *state);
  *     Size of the buffer.
  *
  * @warning If the buffer passed is too small, the string is truncated
- * (though still NUL-terminated).
+ * (though still `NULL`-terminated).
  *
  * @returns
- *   The number of bytes required for the string, excluding the NUL byte.
+ *   The number of bytes required for the string, excluding the `NULL` byte.
  *   If the sequence is not complete, or does not have a viable result
  *   string, returns 0, and sets `buffer` to the empty string (if possible).
  * @returns
  *   You may check if truncation has occurred by comparing the return value
- *   with the size of `buffer`, similarly to the `snprintf`(3) function.
- *   You may safely pass NULL and 0 to `buffer` and `size` to find the
- *   required size (without the NUL-byte).
+ *   with the size of `buffer`, similarly to the `snprintf(3)` function.
+ *   You may safely pass `NULL` and 0 to `buffer` and `size` to find the
+ *   required size (without the `NULL`-byte).
  *
  * @memberof xkb_compose_state
  **/
@@ -596,10 +598,10 @@ xkb_compose_state_get_utf8(struct xkb_compose_state *state,
  * Get the result keysym for a composed sequence.
  *
  * See @ref compose-overview for more details.  This function is only
- * useful when the status is XKB_COMPOSE_COMPOSED.
+ * useful when the status is `::XKB_COMPOSE_COMPOSED`.
  *
  * @returns The result keysym.  If the sequence is not complete, or does
- * not specify a result keysym, returns XKB_KEY_NoSymbol.
+ * not specify a result keysym, returns `XKB_KEY_NoSymbol`.
  *
  * @memberof xkb_compose_state
  **/

--- a/include/xkbcommon/xkbcommon-x11.h
+++ b/include/xkbcommon/xkbcommon-x11.h
@@ -33,30 +33,30 @@ extern "C" {
  * The xkbcommon-x11 module provides a means for creating an xkb_keymap
  * corresponding to the currently active keymap on the X server.  To do
  * so, it queries the XKB X11 extension using the xcb-xkb library.  It
- * can be used as a replacement for Xlib's keyboard handling.
+ * can be used as a replacement for Xlib’s keyboard handling.
  *
  * Following is an example workflow using xkbcommon-x11.  A complete
- * example may be found in the tools/interactive-x11.c file in the
+ * example may be found in the `tools/interactive-x11.c` file in the
  * xkbcommon source repository.  On startup:
  *
- * 1. Connect to the X server using xcb_connect().
+ * 1. Connect to the X server using `xcb_connect()`.
  * 2. Setup the XKB X11 extension.  You can do this either by using the
- *    xcb_xkb_use_extension() request directly, or by using the
- *    xkb_x11_setup_xkb_extension() helper function.
+ *    `xcb_xkb_use_extension()` request directly, or by using the
+ *    `xkb_x11_setup_xkb_extension()` helper function.
  *
  * The XKB extension supports using separate keymaps and states for
  * different keyboard devices.  The devices are identified by an integer
  * device ID and are managed by another X11 extension, XInput. The
- * original X11 protocol only had one keyboard device, called the "core
- * keyboard", which is still supported as a "virtual device".
+ * original X11 protocol only had one keyboard device, called the *core
+ * keyboard*, which is still supported as a *virtual device*.
  *
  * 3. We will use the core keyboard as an example.  To get its device ID,
- *    use either the xcb_xkb_get_device_info() request directly, or the
- *    xkb_x11_get_core_keyboard_device_id() helper function.
+ *    use either the `xcb_xkb_get_device_info()` request directly, or the
+ *    `xkb_x11_get_core_keyboard_device_id()` helper function.
  * 4. Create an initial xkb_keymap for this device, using the
- *    xkb_x11_keymap_new_from_device() function.
+ *    `xkb_x11_keymap_new_from_device()` function.
  * 5. Create an initial xkb_state for this device, using the
- *    xkb_x11_state_new_from_device() function.
+ *    `xkb_x11_state_new_from_device()` function.
  *
  * @note At this point, you may consider setting various XKB controls and
  * XKB per-client flags.  For example, enabling detectable autorepeat: \n
@@ -67,25 +67,25 @@ extern "C" {
  * setxkbmap or xmodmap was used):
  *
  * 6. Select to listen to at least the following XKB events:
- *    NewKeyboardNotify, MapNotify, StateNotify; using the
- *    xcb_xkb_select_events_aux() request.
- * 7. When NewKeyboardNotify or MapNotify are received, recreate the
- *    xkb_keymap and xkb_state as described above.
- * 8. When StateNotify is received, update the xkb_state accordingly
- *    using the xkb_state_update_mask() function.
+ *    `NewKeyboardNotify`, `MapNotify`, `StateNotify`; using the
+ *    `xcb_xkb_select_events_aux()` request.
+ * 7. When `NewKeyboardNotify` or `MapNotify` are received, recreate the
+ *    `xkb_keymap` and `xkb_state` as described above.
+ * 8. When `StateNotify` is received, update the `xkb_state` accordingly
+ *    using the `xkb_state::xkb_state_update_mask()` function.
  *
- * @note It is also possible to use the KeyPress/KeyRelease @p state
+ * @note It is also possible to use the `KeyPress`/`KeyRelease` @p state
  * field to find the effective modifier and layout state, instead of
- * using XkbStateNotify: \n
+ * using `XkbStateNotify`: \n
  * https://www.x.org/releases/current/doc/kbproto/xkbproto.html#Computing_A_State_Field_from_an_XKB_State
- * \n However, XkbStateNotify is more accurate.
+ * \n However, `XkbStateNotify` is more accurate.
  *
- * @note There is no need to call xkb_state_update_key(); the state is
+ * @note There is no need to call `xkb_state_update_key()`; the state is
  * already synchronized.
  *
  * Finally, when a key event is received, you can use ordinary xkbcommon
- * functions, like xkb_state_key_get_one_sym() and xkb_state_key_get_utf8(),
- * as you normally would.
+ * functions, like `xkb_state::xkb_state_key_get_one_sym()` and
+ * `xkb_state::xkb_state_key_get_utf8()`, as you normally would.
  *
  * @endparblock
  */
@@ -101,7 +101,7 @@ extern "C" {
  */
 #define XKB_X11_MIN_MINOR_XKB_VERSION 0
 
-/** Flags for the xkb_x11_setup_xkb_extension() function. */
+/** Flags for the `xkb_x11_setup_xkb_extension()` function. */
 enum xkb_x11_setup_xkb_extension_flags {
     /** Do not apply any flags. */
     XKB_X11_SETUP_XKB_EXTENSION_NO_FLAGS = 0
@@ -126,8 +126,8 @@ enum xkb_x11_setup_xkb_extension_flags {
  *     See @p minor_xkb_version.
  * @param minor_xkb_version
  *     The XKB extension version to request.  To operate correctly, you
- *     must have (major_xkb_version, minor_xkb_version) >=
- *     (XKB_X11_MIN_MAJOR_XKB_VERSION, XKB_X11_MIN_MINOR_XKB_VERSION),
+ *     must have (@p major_xkb_version, @p minor_xkb_version) >=
+ *     (`XKB_X11_MIN_MAJOR_XKB_VERSION`, `XKB_X11_MIN_MINOR_XKB_VERSION`),
  *     though this is not enforced.
  * @param flags
  *     Optional flags, or 0.
@@ -135,13 +135,13 @@ enum xkb_x11_setup_xkb_extension_flags {
  *     See @p minor_xkb_version_out.
  * @param[out] minor_xkb_version_out
  *     Backfilled with the compatible XKB extension version numbers picked
- *     by the server.  Can be NULL.
+ *     by the server.  Can be `NULL`.
  * @param[out] base_event_out
  *     Backfilled with the XKB base (also known as first) event code, needed
- *     to distinguish XKB events.  Can be NULL.
+ *     to distinguish XKB events.  Can be `NULL`.
  * @param[out] base_error_out
  *     Backfilled with the XKB base (also known as first) error code, needed
- *     to distinguish XKB errors.  Can be NULL.
+ *     to distinguish XKB errors.  Can be `NULL`.
  *
  * @returns 1 on success, or 0 on failure.
  */
@@ -160,7 +160,7 @@ xkb_x11_setup_xkb_extension(xcb_connection_t *connection,
  *
  * @param connection An XCB connection to the X server.
  *
- * @returns A device ID which may be used with other xkb_x11_* functions,
+ * @returns A device ID which may be used with other `xkb_x11_*` functions,
  *          or -1 on failure.
  */
 XKB_EXPORT int32_t
@@ -184,7 +184,7 @@ xkb_x11_get_core_keyboard_device_id(xcb_connection_t *connection);
  * @param flags
  *     Optional flags for the keymap, or 0.
  *
- * @returns A keymap retrieved from the X server, or NULL on failure.
+ * @returns A keymap retrieved from the X server, or `NULL` on failure.
  *
  * @memberof xkb_keymap
  */
@@ -197,7 +197,7 @@ xkb_x11_keymap_new_from_device(struct xkb_context *context,
 /**
  * Create a new keyboard state object from an X11 keyboard device.
  *
- * This function is the same as xkb_state_new(), only pre-initialized
+ * This function is the same as `xkb_state_new()`, only pre-initialized
  * with the state of the device at the time this function is called.
  *
  * @param keymap
@@ -208,7 +208,7 @@ xkb_x11_keymap_new_from_device(struct xkb_context *context,
  *     An XInput 1 device ID (in the range 0-255) with input class KEY.
  *     Passing values outside of this range is an error.
  *
- * @returns A new keyboard state object, or NULL on failure.
+ * @returns A new keyboard state object, or `NULL` on failure.
  *
  * @memberof xkb_state
  */

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -92,13 +92,13 @@ struct xkb_state;
  * assign only 8 bits for keycodes.  This limits the number of different
  * keys that can be used simultaneously in a single keymap to 256
  * (disregarding other limitations).  This library does not share this limit;
- * keycodes beyond 255 ('extended keycodes') are not treated specially.
+ * keycodes beyond 255 (*extended* keycodes) are not treated specially.
  * Keymaps and applications which are compatible with X11 should not use
  * these keycodes.
  *
  * The values of specific keycodes are determined by the keymap and the
  * underlying input system.  For example, with an X11-compatible keymap
- * and Linux evdev scan codes (see linux/input.h), a fixed offset is used:
+ * and Linux evdev scan codes (see `linux/input.h`), a fixed offset is used:
  *
  * The keymap defines a canonical name for each key, plus possible aliases.
  * Historically, the XKB protocol restricts these names to at most 4 (ASCII)
@@ -148,14 +148,14 @@ typedef uint32_t xkb_keycode_t;
  * [encoding]: https://www.x.org/releases/current/doc/xproto/x11protocol.html#keysym_encoding
  *
  * @ingroup keysyms
- * @sa XKB_KEYSYM_MAX
+ * @sa `::XKB_KEYSYM_MAX`
  */
 typedef uint32_t xkb_keysym_t;
 
 /**
  * Index of a keyboard layout.
  *
- * The layout index is a state component which detemines which <em>keyboard
+ * The layout index is a state component which determines which <em>keyboard
  * layout</em> is active.  These may be different alphabets, different key
  * arrangements, etc.
  *
@@ -166,18 +166,19 @@ typedef uint32_t xkb_keysym_t;
  * Therefore, it is not safe to use the name as a unique identifier for a
  * layout.  Layout names are case-sensitive.
  *
- * Layout names are specified in the layout's definition, for example
- * "English (US)".  These are different from the (conventionally) short names
- * which are used to locate the layout, for example "us" or "us(intl)".  These
+ * Layout names are specified in the layout’s definition, for example
+ * “English (US)”.  These are different from the (conventionally) short names
+ * which are used to locate the layout, for example `us` or `us(intl)`.  These
  * names are not present in a compiled keymap.
  *
  * If the user selects layouts from a list generated from the XKB registry
  * (using libxkbregistry or directly), and this metadata is needed later on, it
  * is recommended to store it along with the keymap.
  *
- * Layouts are also called "groups" by XKB.
+ * Layouts are also called *groups* by XKB.
  *
- * @sa xkb_keymap_num_layouts() xkb_keymap_num_layouts_for_key()
+ * @sa xkb_keymap::xkb_keymap_num_layouts()
+ * @sa xkb_keymap::xkb_keymap_num_layouts_for_key()
  */
 typedef uint32_t xkb_layout_index_t;
 /** A mask of layout indices. */
@@ -191,7 +192,7 @@ typedef uint32_t xkb_layout_mask_t;
  * to use is chosen according to the current keyboard state; for example,
  * if no keys are pressed, the first level may be used; if the Left Shift
  * key is pressed, the second; if Num Lock is pressed, the third; and
- * many such combinations are possible (see xkb_mod_index_t).
+ * many such combinations are possible (see `xkb_mod_index_t`).
  *
  * Level indices are consecutive.  The first level has index 0.
  */
@@ -208,14 +209,14 @@ typedef uint32_t xkb_level_index_t;
  * Different keymaps do this differently).
  *
  * When retrieving the keysyms for a key, the active modifier set is
- * consulted; this detemines the correct shift level to use within the
- * currently active layout (see xkb_level_index_t).
+ * consulted; this determines the correct shift level to use within the
+ * currently active layout (see `xkb_level_index_t`).
  *
  * Modifier indices are consecutive.  The first modifier has index 0.
  *
  * Each modifier must have a name, and the names are unique.  Therefore, it
  * is safe to use the name as a unique identifier for a modifier.  The names
- * of some common modifiers are provided in the xkbcommon/xkbcommon-names.h
+ * of some common modifiers are provided in the `xkbcommon/xkbcommon-names.h`
  * header file.  Modifier names are case-sensitive.
  *
  * @sa xkb_keymap_num_mods()
@@ -235,30 +236,38 @@ typedef uint32_t xkb_mod_mask_t;
  *
  * Each LED must have a name, and the names are unique. Therefore,
  * it is safe to use the name as a unique identifier for a LED.  The names
- * of some common LEDs are provided in the xkbcommon/xkbcommon-names.h
+ * of some common LEDs are provided in the `xkbcommon/xkbcommon-names.h`
  * header file.  LED names are case-sensitive.
  *
  * @warning A given keymap may specify an exact index for a given LED.
  * Therefore, LED indexing is not necessarily sequential, as opposed to
  * modifiers and layouts.  This means that when iterating over the LEDs
- * in a keymap using e.g. xkb_keymap_num_leds(), some indices might be
- * invalid.  Given such an index, functions like xkb_keymap_led_get_name()
- * will return NULL, and xkb_state_led_index_is_active() will return -1.
+ * in a keymap using e.g. xkb_keymap::xkb_keymap_num_leds(), some indices might
+ * be invalid.
+ * Given such an index, functions like xkb_keymap::xkb_keymap_led_get_name()
+ * will return `NULL`, and `xkb_state::xkb_state_led_index_is_active()` will
+ * return -1.
  *
- * LEDs are also called "indicators" by XKB.
+ * LEDs are also called *indicators* by XKB.
  *
- * @sa xkb_keymap_num_leds()
+ * @sa `xkb_keymap::xkb_keymap_num_leds()`
  */
 typedef uint32_t xkb_led_index_t;
 /** A mask of LED indices. */
 typedef uint32_t xkb_led_mask_t;
 
+/** Invalid keycode */
 #define XKB_KEYCODE_INVALID (0xffffffff)
+/** Invalid layout index */
 #define XKB_LAYOUT_INVALID  (0xffffffff)
+/** Invalid level index */
 #define XKB_LEVEL_INVALID   (0xffffffff)
+/** Invalid modifier index */
 #define XKB_MOD_INVALID     (0xffffffff)
+/** Invalid LED index */
 #define XKB_LED_INVALID     (0xffffffff)
 
+/** Maximum legal keycode */
 #define XKB_KEYCODE_MAX     (0xffffffff - 1)
 
 /**
@@ -439,7 +448,7 @@ struct xkb_rule_names {
      * modify or augment the respective layout in various ways.
      *
      * Generally, should either be empty or have the same number of values
-     * as the number of layouts. You may use empty values as in "intl,,neo".
+     * as the number of layouts. You may use empty values as in `intl,,neo`.
      *
      * If `NULL` or the empty string `""`, and a default value is also used
      * for the layout, a default value is used.  Otherwise no variant is
@@ -498,7 +507,7 @@ struct xkb_component_names {
  * Resolve [RMLVO] names to [KcCGST] components.
  *
  * This function is used primarily for *debugging*. See
- * xkb_keymap::xkb_keymap_new_from_names2() for creating keymaps from
+ * `xkb_keymap::xkb_keymap_new_from_names2()` for creating keymaps from
  * [RMLVO] names.
  *
  * @param[in]  context    The context in which to resolve the names.
@@ -545,24 +554,31 @@ xkb_components_names_from_rules(struct xkb_context *context,
 /**
  * @page keysym-transformations Keysym Transformations
  *
- * Keysym translation is subject to several "keysym transformations",
+ * Keysym translation is subject to several *keysym transformations*,
  * as described in the XKB specification.  These are:
  *
- * - Capitalization transformation.  If the Caps Lock modifier is
- *   active and was not consumed by the translation process, keysyms
- *   are transformed to their upper-case form (if applicable).
- *   Similarly, the UTF-8/UTF-32 string produced is capitalized.
+ * <dl>
+ * <dt>Capitalization transformation</dt>
+ * <dd>
+ * If the Caps Lock modifier is
+ * active and was not consumed by the translation process, keysyms
+ * are transformed to their upper-case form (if applicable).
+ * Similarly, the UTF-8/UTF-32 string produced is capitalized.
  *
- *   This is described in:
- *   https://www.x.org/releases/current/doc/kbproto/xkbproto.html#Interpreting_the_Lock_Modifier
+ * This is described in:
+ * https://www.x.org/releases/current/doc/kbproto/xkbproto.html#Interpreting_the_Lock_Modifier
+ * </dd>
+ * <dt>Control transformation</dt>
+ * <dd>
+ * If the Control modifier is active and
+ * was not consumed by the translation process, the string produced
+ * is transformed to its matching ASCII control character (if
+ * applicable).  Keysyms are not affected.
  *
- * - Control transformation.  If the Control modifier is active and
- *   was not consumed by the translation process, the string produced
- *   is transformed to its matching ASCII control character (if
- *   applicable).  Keysyms are not affected.
- *
- *   This is described in:
- *   https://www.x.org/releases/current/doc/kbproto/xkbproto.html#Interpreting_the_Control_Modifier
+ * This is described in:
+ * https://www.x.org/releases/current/doc/kbproto/xkbproto.html#Interpreting_the_Control_Modifier
+ * </dd>
+ * </dl>
  *
  * Each relevant function discusses which transformations it performs.
  *
@@ -581,15 +597,15 @@ xkb_components_names_from_rules(struct xkb_context *context,
  * @param[in]  size   Size of the buffer.
  *
  * @warning If the buffer passed is too small, the string is truncated
- * (though still NUL-terminated); a size of at least 64 bytes is recommended.
+ * (though still `NULL`-terminated); a size of at least 64 bytes is recommended.
  *
- * @returns The number of bytes in the name, excluding the NUL byte. If
+ * @returns The number of bytes in the name, excluding the `NULL` byte. If
  * the keysym is invalid, returns -1.
  *
  * You may check if truncation has occurred by comparing the return value
- * with the length of buffer, similarly to the snprintf(3) function.
+ * with the length of buffer, similarly to the `snprintf(3)` function.
  *
- * @sa xkb_keysym_t
+ * @sa `xkb_keysym_t`
  */
 XKB_EXPORT int
 xkb_keysym_get_name(xkb_keysym_t keysym, char *buffer, size_t size);
@@ -605,12 +621,12 @@ enum xkb_keysym_flags {
 /**
  * Get a keysym from its name.
  *
- * @param name The name of a keysym. See remarks in xkb_keysym_get_name();
+ * @param name The name of a keysym. See remarks in `xkb_keysym_get_name()`;
  * this function will accept any name returned by that function.
  * @param flags A set of flags controlling how the search is done. If
- * invalid flags are passed, this will fail with XKB_KEY_NoSymbol.
+ * invalid flags are passed, this will fail with `XKB_KEY_NoSymbol`.
  *
- * If you use the XKB_KEYSYM_CASE_INSENSITIVE flag and two keysym names
+ * If you use the `::XKB_KEYSYM_CASE_INSENSITIVE`` flag and two keysym names
  * differ only by case, then the lower-case keysym name is returned.  For
  * instance, for KEY_a and KEY_A, this function would return KEY_a for the
  * case-insensitive search.  If this functionality is needed, it is
@@ -621,7 +637,7 @@ enum xkb_keysym_flags {
  * Case folding is done according to the C locale; the current locale is not
  * consulted.
  *
- * @returns The keysym. If the name is invalid, returns XKB_KEY_NoSymbol.
+ * @returns The keysym. If the name is invalid, returns `XKB_KEY_NoSymbol`.
  *
  * @sa xkb_keysym_t
  * @since 1.9.0: Enable support for C0 and C1 control characters in the Unicode
@@ -642,9 +658,9 @@ xkb_keysym_from_name(const char *name, enum xkb_keysym_flags flags);
  * representation, returns 0.  If the buffer is too small, returns -1.
  *
  * This function does not perform any @ref keysym-transformations.
- * Therefore, prefer to use xkb_state_key_get_utf8() if possible.
+ * Therefore, prefer to use `xkb_state::xkb_state_key_get_utf8()` if possible.
  *
- * @sa xkb_state_key_get_utf8()
+ * @sa `xkb_state::xkb_state_key_get_utf8()`
  */
 XKB_EXPORT int
 xkb_keysym_to_utf8(xkb_keysym_t keysym, char *buffer, size_t size);
@@ -659,7 +675,7 @@ xkb_keysym_to_utf8(xkb_keysym_t keysym, char *buffer, size_t size);
  * This function does not perform any @ref keysym-transformations.
  * Therefore, prefer to use xkb_state_key_get_utf32() if possible.
  *
- * @sa xkb_state_key_get_utf32()
+ * @sa `xkb_state::xkb_state_key_get_utf32()`
  */
 XKB_EXPORT uint32_t
 xkb_keysym_to_utf32(xkb_keysym_t keysym);
@@ -675,10 +691,10 @@ xkb_keysym_to_utf32(xkb_keysym_t keysym);
  * the keysym with the lowest value.
  *
  * Unicode codepoints which do not have a special (legacy) keysym
- * encoding use a direct encoding scheme. These keysyms don't usually
- * have an associated keysym constant (XKB_KEY_*).
+ * encoding use a direct encoding scheme. These keysyms don’t usually
+ * have an associated keysym constant (`XKB_KEY_*`).
  *
- * @sa xkb_keysym_to_utf32()
+ * @sa `xkb_keysym_to_utf32()`
  * @since 1.0.0
  * @since 1.9.0: Enable support for all noncharacters.
  */
@@ -744,10 +760,10 @@ xkb_keysym_to_lower(xkb_keysym_t ks);
  * The user may set some environment variables which affect the library:
  *
  * - `XKB_CONFIG_ROOT`, `XKB_CONFIG_EXTRA_PATH`, `XDG_CONFIG_DIR`, `HOME` - see @ref include-path.
- * - `XKB_LOG_LEVEL` - see xkb_context_set_log_level().
- * - `XKB_LOG_VERBOSITY` - see xkb_context_set_log_verbosity().
+ * - `XKB_LOG_LEVEL` - see `xkb_context::xkb_context_set_log_level()`.
+ * - `XKB_LOG_VERBOSITY` - see `xkb_context::xkb_context_set_log_verbosity()`.
  * - `XKB_DEFAULT_RULES`, `XKB_DEFAULT_MODEL`, `XKB_DEFAULT_LAYOUT`,
- *   `XKB_DEFAULT_VARIANT`, `XKB_DEFAULT_OPTIONS` - see xkb_rule_names.
+ *   `XKB_DEFAULT_VARIANT`, `XKB_DEFAULT_OPTIONS` - see `xkb_rule_names`.
  */
 
 /** Flags for context creation. */
@@ -757,7 +773,7 @@ enum xkb_context_flags {
     /** Create this context with an empty include path. */
     XKB_CONTEXT_NO_DEFAULT_INCLUDES = (1 << 0),
     /**
-     * Don't take RMLVO names from the environment.
+     * Don’t take RMLVO names from the environment.
      *
      * @since 0.3.0
      */
@@ -776,7 +792,7 @@ enum xkb_context_flags {
  *
  * @param flags Optional flags for the context, or 0.
  *
- * @returns A new context, or NULL on failure.
+ * @returns A new context, or `NULL` on failure.
  *
  * @memberof xkb_context
  */
@@ -796,7 +812,7 @@ xkb_context_ref(struct xkb_context *context);
 /**
  * Release a reference on a context, and possibly free it.
  *
- * @param context The context.  If it is NULL, this function does nothing.
+ * @param context The context.  If it is `NULL`, this function does nothing.
  *
  * @memberof xkb_context
  */
@@ -806,8 +822,8 @@ xkb_context_unref(struct xkb_context *context);
 /**
  * Store custom user data in the context.
  *
- * This may be useful in conjunction with xkb_context_set_log_fn() or other
- * callbacks.
+ * This may be useful in conjunction with `xkb_context::xkb_context_set_log_fn()`
+ * or other callbacks.
  *
  * @memberof xkb_context
  */
@@ -817,8 +833,8 @@ xkb_context_set_user_data(struct xkb_context *context, void *user_data);
 /**
  * Retrieves stored user data from the context.
  *
- * @returns The stored user data.  If the user data wasn't set, or the
- * passed in context is NULL, returns NULL.
+ * @returns The stored user data.  If the user data wasn’t set, or the
+ * passed in context is `NULL`, returns `NULL`.
  *
  * This may be useful to access private user data from callbacks like a
  * custom logging function.
@@ -852,7 +868,7 @@ xkb_context_get_user_data(struct xkb_context *context);
  */
 
 /**
- * Append a new entry to the context's include path.
+ * Append a new entry to the context’s include path.
  *
  * @returns 1 on success, or 0 if the include path could not be added or is
  * inaccessible.
@@ -863,7 +879,7 @@ XKB_EXPORT int
 xkb_context_include_path_append(struct xkb_context *context, const char *path);
 
 /**
- * Append the default include paths to the context's include path.
+ * Append the default include paths to the context’s include path.
  *
  * @returns 1 on success, or 0 if the primary include path could not be added.
  *
@@ -873,9 +889,9 @@ XKB_EXPORT int
 xkb_context_include_path_append_default(struct xkb_context *context);
 
 /**
- * Reset the context's include path to the default.
+ * Reset the context’s include path to the default.
  *
- * Removes all entries from the context's include path, and inserts the
+ * Removes all entries from the context’s include path, and inserts the
  * default paths.
  *
  * @returns 1 on success, or 0 if the primary include path could not be added.
@@ -886,7 +902,7 @@ XKB_EXPORT int
 xkb_context_include_path_reset_defaults(struct xkb_context *context);
 
 /**
- * Remove all entries from the context's include path.
+ * Remove all entries from the context’s include path.
  *
  * @memberof xkb_context
  */
@@ -894,7 +910,7 @@ XKB_EXPORT void
 xkb_context_include_path_clear(struct xkb_context *context);
 
 /**
- * Get the number of paths in the context's include path.
+ * Get the number of paths in the context’s include path.
  *
  * @memberof xkb_context
  */
@@ -902,7 +918,7 @@ XKB_EXPORT unsigned int
 xkb_context_num_include_paths(struct xkb_context *context);
 
 /**
- * Get a specific include path from the context's include path.
+ * Get a specific include path from the context’s include path.
  *
  * @returns The include path at the specified index.  If the index is
  * invalid, returns NULL.
@@ -937,8 +953,8 @@ enum xkb_log_level {
  * @param level   The logging level to use.  Only messages from this level
  * and below will be logged.
  *
- * The default level is XKB_LOG_LEVEL_ERROR.  The environment variable
- * XKB_LOG_LEVEL, if set in the time the context was created, overrides the
+ * The default level is `::XKB_LOG_LEVEL_ERROR`.  The environment variable
+ * `XKB_LOG_LEVEL`, if set in the time the context was created, overrides the
  * default value.  It may be specified as a level number or name.
  *
  * @memberof xkb_context
@@ -962,7 +978,7 @@ xkb_context_get_log_level(struct xkb_context *context);
  * ordinary users of the library.  The verbosity may be increased if more
  * information is desired (e.g. when developing a new keymap).
  *
- * The default verbosity is 0.  The environment variable XKB_LOG_VERBOSITY,
+ * The default verbosity is 0.  The environment variable `XKB_LOG_VERBOSITY`,
  * if set in the time the context was created, overrides the default value.
  *
  * @param context   The context in which to use the set verbosity.
@@ -970,7 +986,7 @@ xkb_context_get_log_level(struct xkb_context *context);
  * 1 to 10, higher values being more verbose.  0 would result in no verbose
  * messages being logged.
  *
- * Most verbose messages are of level XKB_LOG_LEVEL_WARNING or lower.
+ * Most verbose messages are of level `::XKB_LOG_LEVEL_WARNING` or lower.
  *
  * @memberof xkb_context
  */
@@ -990,18 +1006,18 @@ xkb_context_get_log_verbosity(struct xkb_context *context);
  *
  * @param context The context in which to use the set logging function.
  * @param log_fn  The function that will be called for logging messages.
- * Passing NULL restores the default function, which logs to stderr.
+ * Passing `NULL` restores the default function, which logs to stderr.
  *
  * By default, log messages from this library are printed to stderr.  This
  * function allows you to replace the default behavior with a custom
  * handler.  The handler is only called with messages which match the
  * current logging level and verbosity settings for the context.
  * level is the logging level of the message.  @a format and @a args are
- * the same as in the vprintf(3) function.
+ * the same as in the `vprintf(3)` function.
  *
- * You may use xkb_context_set_user_data() on the context, and then call
- * xkb_context_get_user_data() from within the logging function to provide
- * it with additional private context.
+ * You may use `xkb_context::xkb_context_set_user_data()` on the context, and
+ * then call `xkb_context::xkb_context_get_user_data()` from within the logging
+ * function to provide it with additional private context.
  *
  * @memberof xkb_context
  */
@@ -1067,7 +1083,7 @@ enum xkb_keymap_format {
  * @param format  The text format of the keymap file to compile.
  * @param flags   Optional flags for the keymap, or 0.
  *
- * @returns A keymap compiled according to the [RMLVO] names, or NULL if
+ * @returns A keymap compiled according to the [RMLVO] names, or `NULL` if
  * the compilation failed.
  *
  * @since 1.11.0
@@ -1111,11 +1127,11 @@ xkb_keymap_new_from_names(struct xkb_context *context,
  * [RMLVO] \(Rules + Model + Layouts + Variants + Options) names.
  *
  * @param context The context in which to create the keymap.
- * @param names   The RMLVO names to use.  See xkb_rule_names.
+ * @param names   The [RMLVO] names to use.  See xkb_rule_names.
  * @param format  The text format of the keymap file to compile.
  * @param flags   Optional flags for the keymap, or 0.
  *
- * @returns A keymap compiled according to the RMLVO names, or NULL if
+ * @returns A keymap compiled according to the [RMLVO] names, or `NULL` if
  * the compilation failed.
  *
  * @sa `xkb_rule_names`
@@ -1139,12 +1155,12 @@ xkb_keymap_new_from_names2(struct xkb_context *context,
  * @param format  The text format of the keymap file to compile.
  * @param flags   Optional flags for the keymap, or 0.
  *
- * @returns A keymap compiled from the given XKB keymap file, or NULL if
+ * @returns A keymap compiled from the given XKB keymap file, or `NULL` if
  * the compilation failed.
  *
  * The file must contain a complete keymap.  For example, in the
- * XKB_KEYMAP_FORMAT_TEXT_V1 format, this means the file must contain one
- * top level '%xkb_keymap' section, which in turn contains other required
+ * `::XKB_KEYMAP_FORMAT_TEXT_V1` format, this means the file must contain one
+ * top level `%xkb_keymap` section, which in turn contains other required
  * sections.
  *
  * @memberof xkb_keymap
@@ -1157,10 +1173,10 @@ xkb_keymap_new_from_file(struct xkb_context *context, FILE *file,
 /**
  * Create a keymap from a keymap string.
  *
- * This is just like xkb_keymap_new_from_file(), but instead of a file, gets
+ * This is just like `xkb_keymap_new_from_file()`, but instead of a file, gets
  * the keymap as one enormous string.
  *
- * @see xkb_keymap_new_from_file()
+ * @see `xkb_keymap_new_from_file()`
  * @memberof xkb_keymap
  */
 XKB_EXPORT struct xkb_keymap *
@@ -1171,10 +1187,10 @@ xkb_keymap_new_from_string(struct xkb_context *context, const char *string,
 /**
  * Create a keymap from a memory buffer.
  *
- * This is just like xkb_keymap_new_from_string(), but takes a length argument
+ * This is just like `xkb_keymap_new_from_string()`, but takes a length argument
  * so the input string does not have to be zero-terminated.
  *
- * @see xkb_keymap_new_from_string()
+ * @see `xkb_keymap_new_from_string()`
  * @memberof xkb_keymap
  * @since 0.3.0
  */
@@ -1196,7 +1212,7 @@ xkb_keymap_ref(struct xkb_keymap *keymap);
 /**
  * Release a reference on a keymap, and possibly free it.
  *
- * @param keymap The keymap.  If it is NULL, this function does nothing.
+ * @param keymap The keymap.  If it is `NULL`, this function does nothing.
  *
  * @memberof xkb_keymap
  */
@@ -1205,7 +1221,7 @@ xkb_keymap_unref(struct xkb_keymap *keymap);
 
 /**
  * Get the keymap as a string in the format from which it was created.
- * @sa xkb_keymap_get_as_string()
+ * @sa `xkb_keymap::xkb_keymap_get_as_string()`
  **/
 #define XKB_KEYMAP_USE_ORIGINAL_FORMAT ((enum xkb_keymap_format) -1)
 
@@ -1214,13 +1230,13 @@ xkb_keymap_unref(struct xkb_keymap *keymap);
  *
  * @param keymap The keymap to get as a string.
  * @param format The keymap format to use for the string.  You can pass
- * in the special value XKB_KEYMAP_USE_ORIGINAL_FORMAT to use the format
+ * in the special value `::XKB_KEYMAP_USE_ORIGINAL_FORMAT` to use the format
  * from which the keymap was originally created.
  *
- * @returns The keymap as a NUL-terminated string, or NULL if unsuccessful.
+ * @returns The keymap as a `NULL`-terminated string, or `NULL` if unsuccessful.
  *
- * The returned string may be fed back into xkb_keymap_new_from_string() to get
- * the exact same keymap (possibly in another process, etc.).
+ * The returned string may be fed back into `xkb_keymap_new_from_string()` to
+ * get the exact same keymap (possibly in another process, etc.).
  *
  * The returned string is dynamically allocated and should be freed by the
  * caller.
@@ -1261,7 +1277,7 @@ XKB_EXPORT xkb_keycode_t
 xkb_keymap_max_keycode(struct xkb_keymap *keymap);
 
 /**
- * The iterator used by xkb_keymap_key_for_each().
+ * The iterator used by `xkb_keymap_key_for_each()`.
  *
  * @sa xkb_keymap_key_for_each
  * @memberof xkb_keymap
@@ -1276,7 +1292,9 @@ typedef void
  * keymap is sparse, this function may be called fewer than
  * (max_keycode - min_keycode + 1) times.
  *
- * @sa xkb_keymap_min_keycode() xkb_keymap_max_keycode() xkb_keycode_t
+ * @sa xkb_keymap_min_keycode()
+ * @sa xkb_keymap_max_keycode()
+ * @sa xkb_keycode_t
  * @memberof xkb_keymap
  * @since 0.3.1
  */
@@ -1288,10 +1306,10 @@ xkb_keymap_key_for_each(struct xkb_keymap *keymap, xkb_keymap_key_iter_t iter,
  * Find the name of the key with the given keycode.
  *
  * This function always returns the canonical name of the key (see
- * description in xkb_keycode_t).
+ * description in `xkb_keycode_t`).
  *
  * @returns The key name. If no key with this keycode exists,
- * returns NULL.
+ * returns `NULL`.
  *
  * @sa xkb_keycode_t
  * @memberof xkb_keymap
@@ -1306,7 +1324,7 @@ xkb_keymap_key_get_name(struct xkb_keymap *keymap, xkb_keycode_t key);
  * The name can be either a canonical name or an alias.
  *
  * @returns The keycode. If no key with this name exists,
- * returns XKB_KEYCODE_INVALID.
+ * returns `::XKB_KEYCODE_INVALID`.
  *
  * @sa xkb_keycode_t
  * @memberof xkb_keymap
@@ -1327,7 +1345,7 @@ xkb_keymap_num_mods(struct xkb_keymap *keymap);
 /**
  * Get the name of a modifier by index.
  *
- * @returns The name.  If the index is invalid, returns NULL.
+ * @returns The name.  If the index is invalid, returns `NULL`.
  *
  * @sa xkb_mod_index_t
  * @memberof xkb_keymap
@@ -1339,7 +1357,7 @@ xkb_keymap_mod_get_name(struct xkb_keymap *keymap, xkb_mod_index_t idx);
  * Get the index of a modifier by name.
  *
  * @returns The index.  If no modifier with this name exists, returns
- * XKB_MOD_INVALID.
+ * `::XKB_MOD_INVALID`.
  *
  * @sa xkb_mod_index_t
  * @memberof xkb_keymap
@@ -1367,7 +1385,9 @@ xkb_keymap_mod_get_mask(struct xkb_keymap *keymap, const char *name);
 /**
  * Get the number of layouts in the keymap.
  *
- * @sa xkb_layout_index_t xkb_rule_names xkb_keymap_num_layouts_for_key()
+ * @sa `xkb_layout_index_t`
+ * @sa `xkb_rule_names`
+ * @sa `xkb_keymap_num_layouts_for_key()`
  * @memberof xkb_keymap
  */
 XKB_EXPORT xkb_layout_index_t
@@ -1377,7 +1397,7 @@ xkb_keymap_num_layouts(struct xkb_keymap *keymap);
  * Get the name of a layout by index.
  *
  * @returns The name.  If the index is invalid, or the layout does not have
- * a name, returns NULL.
+ * a name, returns `NULL`.
  *
  * @sa xkb_layout_index_t
  *     For notes on layout names.
@@ -1390,11 +1410,10 @@ xkb_keymap_layout_get_name(struct xkb_keymap *keymap, xkb_layout_index_t idx);
  * Get the index of a layout by name.
  *
  * @returns The index.  If no layout exists with this name, returns
- * XKB_LAYOUT_INVALID.  If more than one layout in the keymap has this name,
+ * `::XKB_LAYOUT_INVALID`.  If more than one layout in the keymap has this name,
  * returns the lowest index among them.
  *
- * @sa xkb_layout_index_t
- *     For notes on layout names.
+ * @sa `xkb_layout_index_t` for notes on layout names.
  * @memberof xkb_keymap
  */
 XKB_EXPORT xkb_layout_index_t
@@ -1403,10 +1422,10 @@ xkb_keymap_layout_get_index(struct xkb_keymap *keymap, const char *name);
 /**
  * Get the number of LEDs in the keymap.
  *
- * @warning The range [ 0...xkb_keymap_num_leds() ) includes all of the LEDs
+ * @warning The range [ 0...`xkb_keymap_num_leds()` ) includes all of the LEDs
  * in the keymap, but may also contain inactive LEDs.  When iterating over
  * this range, you need the handle this case when calling functions such as
- * xkb_keymap_led_get_name() or xkb_state_led_index_is_active().
+ * `xkb_keymap_led_get_name()` or `xkb_state::xkb_state_led_index_is_active()`.
  *
  * @sa xkb_led_index_t
  * @memberof xkb_keymap
@@ -1417,7 +1436,7 @@ xkb_keymap_num_leds(struct xkb_keymap *keymap);
 /**
  * Get the name of a LED by index.
  *
- * @returns The name.  If the index is invalid, returns NULL.
+ * @returns The name.  If the index is invalid, returns `NULL`.
  *
  * @memberof xkb_keymap
  */
@@ -1428,7 +1447,7 @@ xkb_keymap_led_get_name(struct xkb_keymap *keymap, xkb_led_index_t idx);
  * Get the index of a LED by name.
  *
  * @returns The index.  If no LED with this name exists, returns
- * XKB_LED_INVALID.
+ * `::XKB_LED_INVALID`.
  *
  * @memberof xkb_keymap
  */
@@ -1438,7 +1457,7 @@ xkb_keymap_led_get_index(struct xkb_keymap *keymap, const char *name);
 /**
  * Get the number of layouts for a specific key.
  *
- * This number can be different from xkb_keymap_num_layouts(), but is always
+ * This number can be different from `xkb_keymap_num_layouts()`, but is always
  * smaller.  It is the appropriate value to use when iterating over the
  * layouts of a key.
  *
@@ -1452,8 +1471,9 @@ xkb_keymap_num_layouts_for_key(struct xkb_keymap *keymap, xkb_keycode_t key);
  * Get the number of shift levels for a specific key and layout.
  *
  * If @c layout is out of range for this key (that is, larger or equal to
- * the value returned by xkb_keymap_num_layouts_for_key()), it is brought
- * back into range in a manner consistent with xkb_state_key_get_layout().
+ * the value returned by `xkb_keymap_num_layouts_for_key()`), it is brought
+ * back into range in a manner consistent with
+ * `xkb_state::xkb_state_key_get_layout()`.
  *
  * @sa xkb_level_index_t
  * @memberof xkb_keymap
@@ -1486,8 +1506,9 @@ xkb_keymap_num_levels_for_key(struct xkb_keymap *keymap, xkb_keycode_t key,
  * masks_out.
  *
  * If @c layout is out of range for this key (that is, larger or equal to
- * the value returned by xkb_keymap_num_layouts_for_key()), it is brought
- * back into range in a manner consistent with xkb_state_key_get_layout().
+ * the value returned by `xkb_keymap_num_layouts_for_key()`), it is brought
+ * back into range in a manner consistent with
+ * `xkb_state::xkb_state_key_get_layout()`.
  *
  * @returns The number of modifier masks stored in the masks_out array.
  * If the key is not in the keymap or if the specified shift level cannot
@@ -1510,8 +1531,8 @@ xkb_keymap_key_get_mods_for_level(struct xkb_keymap *keymap,
  * Get the keysyms obtained from pressing a key in a given layout and
  * shift level.
  *
- * This function is like xkb_state_key_get_syms(), only the layout and
- * shift level are not derived from the keyboard state but are instead
+ * This function is like `xkb_state::xkb_state_key_get_syms()`, only the layout
+ * and shift level are not derived from the keyboard state but are instead
  * specified explicitly.
  *
  * @param[in] keymap    The keymap.
@@ -1524,14 +1545,15 @@ xkb_keymap_key_get_mods_for_level(struct xkb_keymap *keymap,
  * key in the given layout and shift level.
  *
  * If @c layout is out of range for this key (that is, larger or equal to
- * the value returned by xkb_keymap_num_layouts_for_key()), it is brought
- * back into range in a manner consistent with xkb_state_key_get_layout().
+ * the value returned by `xkb_keymap_num_layouts_for_key()`), it is brought
+ * back into range in a manner consistent with
+ * `xkb_state::xkb_state_key_get_layout()`.
  *
  * @returns The number of keysyms in the syms_out array.  If no keysyms
  * are produced by the key in the given layout and shift level, returns 0
- * and sets syms_out to NULL.
+ * and sets @p syms_out to `NULL`.
  *
- * @sa xkb_state_key_get_syms()
+ * @sa `xkb_state::xkb_state_key_get_syms()`
  * @memberof xkb_keymap
  */
 XKB_EXPORT int
@@ -1546,7 +1568,7 @@ xkb_keymap_key_get_syms_by_level(struct xkb_keymap *keymap,
  *
  * A keymap may specify different repeat behaviors for different keys.
  * Most keys should generally exhibit repeat behavior; for example, holding
- * the 'a' key down in a text editor should normally insert a single 'a'
+ * the `a` key down in a text editor should normally insert a single ‘a’
  * character every few milliseconds, until the key is released.  However,
  * there are keys which should not or do not need to be repeated.  For
  * example, repeating modifier keys such as Left/Right Shift or Caps Lock
@@ -1573,7 +1595,7 @@ xkb_keymap_key_repeats(struct xkb_keymap *keymap, xkb_keycode_t key);
  *
  * @param keymap The keymap which the state will use.
  *
- * @returns A new keyboard state object, or NULL on failure.
+ * @returns A new keyboard state object, or `NULL` on failure.
  *
  * @memberof xkb_state
  */
@@ -1591,9 +1613,9 @@ XKB_EXPORT struct xkb_state *
 xkb_state_ref(struct xkb_state *state);
 
 /**
- * Release a reference on a keybaord state object, and possibly free it.
+ * Release a reference on a keyboard state object, and possibly free it.
  *
- * @param state The state.  If it is NULL, this function does nothing.
+ * @param state The state.  If it is `NULL`, this function does nothing.
  *
  * @memberof xkb_state
  */
@@ -1603,7 +1625,7 @@ xkb_state_unref(struct xkb_state *state);
 /**
  * Get the keymap which a keyboard state object is using.
  *
- * @returns The keymap which was passed to xkb_state_new() when creating
+ * @returns The keymap which was passed to `xkb_state_new()` when creating
  * this state object.
  *
  * This function does not take a new reference on the keymap; you must
@@ -1650,10 +1672,10 @@ enum xkb_key_direction {
 
 /**
  * Modifier and layout types for state objects.  This enum is bitmaskable,
- * e.g. (XKB_STATE_MODS_DEPRESSED | XKB_STATE_MODS_LATCHED) is valid to
+ * e.g. (`::XKB_STATE_MODS_DEPRESSED` | `::XKB_STATE_MODS_LATCHED`) is valid to
  * exclude locked modifiers.
  *
- * In XKB, the DEPRESSED components are also known as 'base'.
+ * In XKB, the `DEPRESSED` components are also known as *base*.
  */
 enum xkb_state_component {
     /** Depressed modifiers, i.e. a key is physically holding them. */
@@ -1692,12 +1714,12 @@ enum xkb_state_component {
  * by *client* applications; see @ref server-client-state for details.
  *
  * A series of calls to this function should be consistent; that is, a call
- * with XKB_KEY_DOWN for a key should be matched by an XKB_KEY_UP; if a key
- * is pressed twice, it should be released twice; etc. Otherwise (e.g. due
- * to missed input events), situations like "stuck modifiers" may occur.
+ * with `::XKB_KEY_DOWN` for a key should be matched by an `::XKB_KEY_UP`; if a
+ * key is pressed twice, it should be released twice; etc. Otherwise (e.g. due
+ * to missed input events), situations like “stuck modifiers” may occur.
  *
  * This function is often used in conjunction with the function
- * xkb_state_key_get_syms() (or xkb_state_key_get_one_sym()), for example,
+ * `xkb_state_key_get_syms()` (or `xkb_state_key_get_one_sym()`), for example,
  * when handling a key event.  In this case, you should prefer to get the
  * keysyms *before* updating the key, such that the keysyms reported for
  * the key event are not affected by the event itself.  This is the
@@ -1708,7 +1730,7 @@ enum xkb_state_component {
  *
  * @memberof xkb_state
  *
- * @sa xkb_state_update_mask()
+ * @sa `xkb_state_update_mask()`
  */
 XKB_EXPORT enum xkb_state_component
 xkb_state_update_key(struct xkb_state *state, xkb_keycode_t key,
@@ -1739,18 +1761,18 @@ xkb_state_update_key(struct xkb_state *state, xkb_keycode_t key,
  * @param affect_latched_mods
  * @param latched_mods
  *     Modifiers to set as latched or unlatched. Only modifiers in
- *     `affect_latched_mods` are considered.
+ *     @p affect_latched_mods are considered.
  * @param affect_latched_layout
  * @param latched_layout
- *     Layout to latch. Only considered if `affect_latched_layout` is true.
+ *     Layout to latch. Only considered if @p affect_latched_layout is true.
  *     Maybe be out of range (including negative) -- see note above.
  * @param affect_locked_mods
  * @param locked_mods
  *     Modifiers to set as locked or unlocked. Only modifiers in
- *     `affect_locked_mods` are considered.
+ *     @p affect_locked_mods are considered.
  * @param affect_locked_layout
  * @param locked_layout
- *     Layout to lock. Only considered if `affect_locked_layout` is true.
+ *     Layout to lock. Only considered if @p affect_locked_layout is true.
  *     Maybe be out of range (including negative) -- see note above.
  *
  * @returns A mask of state components that have changed as a result of
@@ -1776,7 +1798,7 @@ xkb_state_update_latched_locked(struct xkb_state *state,
  *
  * This entry point is intended for *client* applications; see @ref
  * server-client-state for details. *Server* applications should use
- * xkb_state_update_key() instead.
+ * `xkb_state_update_key()` instead.
  *
  * All parameters must always be passed, or the resulting state may be
  * incoherent.
@@ -1790,8 +1812,8 @@ xkb_state_update_latched_locked(struct xkb_state *state,
  *
  * @memberof xkb_state
  *
- * @sa xkb_state_component
- * @sa xkb_state_update_key
+ * @sa `xkb_state_component`
+ * @sa `xkb_state_update_key()`
  */
 XKB_EXPORT enum xkb_state_component
 xkb_state_update_mask(struct xkb_state *state,
@@ -1817,11 +1839,11 @@ xkb_state_update_mask(struct xkb_state *state,
  *
  * As an extension to XKB, this function can return more than one keysym.
  * If you do not want to handle this case, you can use
- * xkb_state_key_get_one_sym() for a simpler interface.
+ * `xkb_state_key_get_one_sym()` for a simpler interface.
  *
  * @returns The number of keysyms in the syms_out array.  If no keysyms
  * are produced by the key in the given keyboard state, returns 0 and sets
- * syms_out to NULL.
+ * syms_out to `NULL`.
  *
  * This function performs Capitalization @ref keysym-transformations.
  *
@@ -1843,15 +1865,15 @@ xkb_state_key_get_syms(struct xkb_state *state, xkb_keycode_t key,
  * @param[in]  size   Size of the buffer.
  *
  * @warning If the buffer passed is too small, the string is truncated
- * (though still NUL-terminated).
+ * (though still `NULL`-terminated).
  *
  * @returns The number of bytes required for the string, excluding the
- * NUL byte.  If there is nothing to write, returns 0.
+ * `NULL` byte.  If there is nothing to write, returns 0.
  *
  * You may check if truncation has occurred by comparing the return value
- * with the size of @p buffer, similarly to the snprintf(3) function.
- * You may safely pass NULL and 0 to @p buffer and @p size to find the
- * required size (without the NUL-byte).
+ * with the size of @p buffer, similarly to the `snprintf(3)` function.
+ * You may safely pass `NULL` and 0 to @p buffer and @p size to find the
+ * required size (without the `NULL`-byte).
  *
  * This function performs Capitalization and Control @ref
  * keysym-transformations.
@@ -1883,13 +1905,13 @@ xkb_state_key_get_utf32(struct xkb_state *state, xkb_keycode_t key);
  * Get the single keysym obtained from pressing a particular key in a
  * given keyboard state.
  *
- * This function is similar to xkb_state_key_get_syms(), but intended
+ * This function is similar to `xkb_state_key_get_syms()`, but intended
  * for users which cannot or do not want to handle the case where
  * multiple keysyms are returned (in which case this function is
  * preferred).
  *
  * @returns The keysym.  If the key does not have exactly one keysym,
- * returns XKB_KEY_NoSymbol
+ * returns `XKB_KEY_NoSymbol`.
  *
  * This function performs Capitalization @ref keysym-transformations.
  *
@@ -1904,7 +1926,7 @@ xkb_state_key_get_one_sym(struct xkb_state *state, xkb_keycode_t key);
  *
  * @returns The layout index for the key in the given keyboard state.  If
  * the given keycode is invalid, or if the key is not included in any
- * layout at all, returns XKB_LAYOUT_INVALID.
+ * layout at all, returns `::XKB_LAYOUT_INVALID`.
  *
  * @invariant If the returned layout is valid, the following always holds:
  * @code
@@ -1929,7 +1951,7 @@ xkb_state_key_get_layout(struct xkb_state *state, xkb_keycode_t key);
  * @code xkb_state_key_get_layout(state, key) @endcode
  *
  * @return The shift level index.  If the key or layout are invalid,
- * returns XKB_LEVEL_INVALID.
+ * returns `::XKB_LEVEL_INVALID`.
  *
  * @invariant If the returned level is valid, the following always holds:
  * @code
@@ -1943,9 +1965,9 @@ xkb_state_key_get_level(struct xkb_state *state, xkb_keycode_t key,
                         xkb_layout_index_t layout);
 
 /**
- * Match flags for xkb_state_mod_indices_are_active() and
- * xkb_state_mod_names_are_active(), specifying the conditions for a
- * successful match.  XKB_STATE_MATCH_NON_EXCLUSIVE is bitmaskable with
+ * Match flags for `xkb_state::xkb_state_mod_indices_are_active()` and
+ * `xkb_state::xkb_state_mod_names_are_active()`, specifying the conditions for a
+ * successful match.  `::XKB_STATE_MATCH_NON_EXCLUSIVE` is bitmaskable with
  * the other modes.
  */
 enum xkb_state_match {
@@ -1959,20 +1981,20 @@ enum xkb_state_match {
 };
 
 /**
- * The counterpart to xkb_state_update_mask for modifiers, to be used on
- * the server side of serialization.
+ * The counterpart to `xkb_state::xkb_state_update_mask()` for modifiers, to be
+ * used on the server side of serialization.
  *
  * This entry point is intended for *server* applications; see @ref
  * server-client-state for details. *Client* applications should use the
- * xkb_state_mod_*_is_active API.
+ * `xkb_state_mod_*_is_active` API.
  *
  * @param state      The keyboard state.
  * @param components A mask of the modifier state components to serialize.
- * State components other than XKB_STATE_MODS_* are ignored.
- * If XKB_STATE_MODS_EFFECTIVE is included, all other state components are
+ * State components other than `XKB_STATE_MODS_*` are ignored.
+ * If `::XKB_STATE_MODS_EFFECTIVE` is included, all other state components are
  * ignored.
  *
- * @returns A xkb_mod_mask_t representing the given components of the
+ * @returns A `xkb_mod_mask_t` representing the given components of the
  * modifier state.
  *
  * @memberof xkb_state
@@ -1982,8 +2004,8 @@ xkb_state_serialize_mods(struct xkb_state *state,
                          enum xkb_state_component components);
 
 /**
- * The counterpart to xkb_state_update_mask for layouts, to be used on
- * the server side of serialization.
+ * The counterpart to `xkb_state::xkb_state_update_mask()` for layouts, to be
+ * used on the server side of serialization.
  *
  * This entry point is intended for *server* applications; see @ref
  * server-client-state for details. *Client* applications should use the
@@ -1991,8 +2013,8 @@ xkb_state_serialize_mods(struct xkb_state *state,
  *
  * @param state      The keyboard state.
  * @param components A mask of the layout state components to serialize.
- * State components other than XKB_STATE_LAYOUT_* are ignored.
- * If XKB_STATE_LAYOUT_EFFECTIVE is included, all other state components are
+ * State components other than `XKB_STATE_LAYOUT_*` are ignored.
+ * If `::XKB_STATE_LAYOUT_EFFECTIVE` is included, all other state components are
  * ignored.
  *
  * @returns A layout index representing the given components of the
@@ -2091,7 +2113,7 @@ xkb_state_mod_index_is_active(struct xkb_state *state, xkb_mod_index_t idx,
  * @param match The manner by which to match the state against the
  * given modifiers.
  * @param ...   The set of of modifier indices to test, terminated by a
- * XKB_MOD_INVALID argument (sentinel).
+ * `::XKB_MOD_INVALID` argument (sentinel).
  *
  * @returns 1 if the modifiers are active, 0 if they are not.  If any of
  * the modifier indices are invalid in the keymap, returns -1.
@@ -2114,11 +2136,11 @@ xkb_state_mod_indices_are_active(struct xkb_state *state,
  * @page consumed-modifiers Consumed Modifiers
  * @parblock
  *
- * Some functions, like xkb_state_key_get_syms(), look at the state of
- * the modifiers in the keymap and derive from it the correct shift level
+ * Some functions, like `xkb_state::xkb_state_key_get_syms()`, look at the state
+ * of the modifiers in the keymap and derive from it the correct shift level
  * to use for the key.  For example, in a US layout, pressing the key
- * labeled \<A\> while the Shift modifier is active, generates the keysym
- * 'A'.  In this case, the Shift modifier is said to be "consumed".
+ * labeled `<A>` while the Shift modifier is active, generates the keysym
+ * `A`.  In this case, the Shift modifier is said to be *consumed*.
  * However, the Num Lock modifier does not affect this translation at all,
  * even if it is active, so it is not consumed by this translation.
  *
@@ -2127,28 +2149,28 @@ xkb_state_mod_indices_are_active(struct xkb_state *state,
  * understand why, consider some requirements from a standard shortcut
  * mechanism, and how they are implemented:
  *
- * 1. The shortcut's modifiers must match exactly to the state.  For
- *    example, it is possible to bind separate actions to \<Alt\>\<Tab\>
- *    and to \<Alt\>\<Shift\>\<Tab\>.  Further, if only \<Alt\>\<Tab\> is
- *    bound to an action, pressing \<Alt\>\<Shift\>\<Tab\> should not
+ * 1. The shortcut’s modifiers must match exactly to the state.  For
+ *    example, it is possible to bind separate actions to `<Alt><Tab>`
+ *    and to `<Alt><Shift><Tab>`.  Further, if only `<Alt><Tab>` is
+ *    bound to an action, pressing `<Alt><Shift><Tab>` should not
  *    trigger the shortcut.
  *    Effectively, this means that the modifiers are compared using the
- *    equality operator (==).
+ *    equality operator (`==`).
  *
  * 2. Only relevant modifiers are considered for the matching.  For example,
  *    Caps Lock and Num Lock should not generally affect the matching, e.g.
- *    when matching \<Alt\>\<Tab\> against the state, it does not matter
- *    whether Num Lock is active or not.  These relevant, or "significant",
+ *    when matching `<Alt><Tab>` against the state, it does not matter
+ *    whether Num Lock is active or not.  These relevant, or *significant*,
  *    modifiers usually include Alt, Control, Shift, Super and similar.
  *    Effectively, this means that non-significant modifiers are masked out,
  *    before doing the comparison as described above.
  *
  * 3. The matching must be independent of the layout/keymap.  For example,
- *    the \<Plus\> (+) symbol is found on the first level on some layouts,
+ *    the `<Plus>` (+) symbol is found on the first level on some layouts,
  *    but requires holding Shift on others.  If you simply bind the action
- *    to the \<Plus\> keysym, it would work for the unshifted kind, but
+ *    to the `<Plus>` keysym, it would work for the unshifted kind, but
  *    not for the others, because the match against Shift would fail.  If
- *    you bind the action to \<Shift\>\<Plus\>, only the shifted kind would
+ *    you bind the action to `<Shift><Plus>`, only the shifted kind would
  *    work.  So what is needed is to recognize that Shift is used up in the
  *    translation of the keysym itself, and therefore should not be included
  *    in the matching.
@@ -2156,15 +2178,16 @@ xkb_state_mod_indices_are_active(struct xkb_state *state,
  *    are masked out as well, before doing the comparison.
  *
  * In summary, this is approximately how the matching would be performed:
- * @code
+ *
+ * ```c
  *   (keysym == shortcut_keysym) &&
  *   ((state_mods & ~consumed_mods & significant_mods) == shortcut_mods)
- * @endcode
+ * ```
  *
  * @c state_mods are the modifiers reported by
- * xkb_state_mod_index_is_active() and similar functions.
+ * `xkb_state::xkb_state_mod_index_is_active()` and similar functions.
  * @c consumed_mods are the modifiers reported by
- * xkb_state_mod_index_is_consumed() and similar functions.
+ * `xkb_state::xkb_state_mod_index_is_consumed()` and similar functions.
  * @c significant_mods are decided upon by the application/toolkit/user;
  * it is up to them to decide whether these are configurable or hard-coded.
  *
@@ -2178,7 +2201,7 @@ xkb_state_mod_indices_are_active(struct xkb_state *state,
  * consumed and which are not, each applicable for different systems or
  * situations. The mode selects the method to use.
  *
- * Keep in mind that in all methods, the keymap may decide to "preserve"
+ * Keep in mind that in all methods, the keymap may decide to *preserve*
  * a modifier, meaning it is not reported as consumed even if it would
  * have otherwise.
  */
@@ -2231,7 +2254,7 @@ xkb_state_key_get_consumed_mods2(struct xkb_state *state, xkb_keycode_t key,
                                  enum xkb_consumed_mode mode);
 
 /**
- * Same as xkb_state_key_get_consumed_mods2() with mode XKB_CONSUMED_MODE_XKB.
+ * Same as `xkb_state_key_get_consumed_mods2()` with mode `::XKB_CONSUMED_MODE_XKB`.
  *
  * @memberof xkb_state
  * @since 0.4.1
@@ -2270,7 +2293,7 @@ xkb_state_mod_index_is_consumed2(struct xkb_state *state,
                                  enum xkb_consumed_mode mode);
 
 /**
- * Same as xkb_state_mod_index_is_consumed2() with mode XKB_CONSUMED_MOD_XKB.
+ * Same as `xkb_state_mod_index_is_consumed2()` with mode `::XKB_CONSUMED_MOD_XKB`.
  *
  * @warning For [virtual modifiers], this function may *overmatch* in case
  * there are virtual modifiers with overlapping mappings to [real modifiers].
@@ -2289,10 +2312,10 @@ xkb_state_mod_index_is_consumed(struct xkb_state *state, xkb_keycode_t key,
 /**
  * Remove consumed modifiers from a modifier mask for a key.
  *
- * @deprecated Use xkb_state_key_get_consumed_mods2() instead.
+ * @deprecated Use `xkb_state_key_get_consumed_mods2()` instead.
  *
  * Takes the given modifier mask, and removes all modifiers which are
- * consumed for that particular key (as in xkb_state_mod_index_is_consumed()).
+ * consumed for that particular key (as in `xkb_state_mod_index_is_consumed()`).
  *
  * @returns a mask of [real modifiers] modifiers.
  *

--- a/include/xkbcommon/xkbregistry.h
+++ b/include/xkbcommon/xkbregistry.h
@@ -67,10 +67,10 @@ struct rxkb_model;
  * @struct rxkb_layout
  *
  * Opaque struct representing an XKB layout, including an optional variant.
- * Where the variant is NULL, the layout is the base layout.
+ * Where the variant is `NULL`, the layout is the base layout.
  *
- * For example, "us" is the base layout, "us(intl)" is the "intl" variant of the
- * layout "us".
+ * For example, `us` is the base layout, `us(intl)` is the `intl` variant of the
+ * layout `us`.
  */
 struct rxkb_layout;
 
@@ -95,7 +95,7 @@ struct rxkb_option;
  *
  * @struct rxkb_iso639_code
  *
- * Opaque struct representing an ISO 639-3 code (e.g. "eng", "fra"). There
+ * Opaque struct representing an ISO 639-3 code (e.g. `eng`, `fra`). There
  * is no guarantee that two identical ISO codes share the same struct. You
  * must not rely on the pointer value of this struct.
  *
@@ -107,7 +107,7 @@ struct rxkb_iso639_code;
  *
  * @struct rxkb_iso3166_code
  *
- * Opaque struct representing an ISO 3166 Alpha 2 code (e.g. "US", "FR").
+ * Opaque struct representing an ISO 3166 Alpha 2 code (e.g. `US`, `FR`).
  * There is no guarantee that two identical ISO codes share the same struct.
  * You must not rely on the pointer value of this struct.
  *
@@ -138,8 +138,8 @@ enum rxkb_context_flags {
     RXKB_CONTEXT_NO_FLAGS = 0,
     /**
      * Skip the default include paths. This requires the caller to call
-     * rxkb_context_include_path_append() or
-     * rxkb_context_include_path_append_default().
+     * `rxkb_context_include_path_append()` or
+     * `rxkb_context_include_path_append_default()`.
      */
     RXKB_CONTEXT_NO_DEFAULT_INCLUDES = (1 << 0),
     /**
@@ -148,12 +148,12 @@ enum rxkb_context_flags {
      * For historical reasons, xkeyboard-config ships those exotic rules in a
      * separate file (e.g. `evdev.extras.xml`). Where the exotic rules are
      * requested, libxkbregistry will look for and load `$ruleset.extras.xml`
-     * in the include paths, see rxkb_context_include_path_append() for details
-     * on the lookup behavior.
+     * in the include paths, see `rxkb_context_include_path_append()` for
+     * details on the lookup behavior.
      */
     RXKB_CONTEXT_LOAD_EXOTIC_RULES = (1 << 1),
     /**
-     * Disable the use of secure_getenv for this context, so that privileged
+     * Disable the use of `secure_getenv()` for this context, so that privileged
      * processes can use environment variables. Client uses at their own risk.
      *
      * @since 1.5.0
@@ -164,14 +164,14 @@ enum rxkb_context_flags {
 /**
  * Create a new xkb registry context.
  *
- * The context has an initial refcount of 1. Use rxkb_context_unref() to release
- * memory associated with this context.
+ * The context has an initial refcount of 1. Use `rxkb_context_unref()` to
+ * release memory associated with this context.
  *
  * Creating a context does not parse the files yet, use
- * rxkb_context_parse().
+ * `rxkb_context_parse()`.
  *
  * @param flags Flags affecting context behavior
- * @return A new xkb registry context or NULL on failure
+ * @return A new xkb registry context or `NULL` on failure
  */
 RXKB_EXPORT struct rxkb_context *
 rxkb_context_new(enum rxkb_context_flags flags);
@@ -192,8 +192,8 @@ enum rxkb_log_level {
  * @param level   The logging level to use.  Only messages from this level
  * and below will be logged.
  *
- * The default level is RXKB_LOG_LEVEL_ERROR.  The environment variable
- * RXKB_LOG_LEVEL, if set at the time the context was created, overrides the
+ * The default level is `::RXKB_LOG_LEVEL_ERROR`.  The environment variable
+ * `RXKB_LOG_LEVEL`, if set at the time the context was created, overrides the
  * default value.  It may be specified as a level number or name.
  */
 RXKB_EXPORT void
@@ -211,17 +211,17 @@ rxkb_context_get_log_level(struct rxkb_context *ctx);
  *
  * @param ctx     The context in which to use the set logging function.
  * @param log_fn  The function that will be called for logging messages.
- * Passing NULL restores the default function, which logs to stderr.
+ * Passing `NULL` restores the default function, which logs to `stderr`.
  *
  * By default, log messages from this library are printed to stderr.  This
  * function allows you to replace the default behavior with a custom
  * handler.  The handler is only called with messages which match the
  * current logging level and verbosity settings for the context.
  * level is the logging level of the message.  @a format and @a args are
- * the same as in the vprintf(3) function.
+ * the same as in the `vprintf(3)` function.
  *
- * You may use rxkb_context_set_user_data() on the context, and then call
- * rxkb_context_get_user_data() from within the logging function to provide
+ * You may use `rxkb_context_set_user_data()` on the context, and then call
+ * `rxkb_context_get_user_data()` from within the logging function to provide
  * it with additional private context.
  */
 RXKB_EXPORT void
@@ -241,22 +241,22 @@ rxkb_context_set_log_fn(struct rxkb_context *ctx,
  *
  * If this function returns false, libxkbregistry failed to parse the xml files.
  * This is usually caused by invalid files on the host and should be debugged by
- * the host's administrator using external tools. Callers should reduce the
+ * the host’s administrator using external tools. Callers should reduce the
  * include paths to known good paths and/or fall back to a default RMLVO set.
  *
  * If this function returns false, the context should be be considered dead and
- * must be released with rxkb_context_unref().
+ * must be released with `rxkb_context_unref()`.
  *
  * @param ctx The xkb registry context
- * @param ruleset The ruleset to parse, e.g. "evdev"
- * @return true on success or false on failure
+ * @param ruleset The ruleset to parse, e.g. `evdev`
+ * @return `true` on success or `false` on failure
  */
 RXKB_EXPORT bool
 rxkb_context_parse(struct rxkb_context *ctx, const char *ruleset);
 
 /**
  * Parse the default ruleset as configured at build time. See
- * rxkb_context_parse() for details.
+ * `rxkb_context_parse()` for details.
  */
 RXKB_EXPORT bool
 rxkb_context_parse_default_ruleset(struct rxkb_context *ctx);
@@ -275,7 +275,7 @@ rxkb_context_ref(struct rxkb_context *ctx);
  * object hits zero, associated resources will be freed.
  *
  * @param ctx The xkb registry context
- * @return always NULL
+ * @return always `NULL`
  */
 RXKB_EXPORT struct rxkb_context*
 rxkb_context_unref(struct rxkb_context *ctx);
@@ -283,7 +283,7 @@ rxkb_context_unref(struct rxkb_context *ctx);
 /**
  * Assign user-specific data. libxkbregistry will not look at or modify the
  * data, it will merely return the same pointer in
- * rxkb_context_get_user_data().
+ * `rxkb_context_get_user_data()`.
  *
  * @param ctx The xkb registry context
  * @param user_data User-specific data pointer
@@ -292,7 +292,7 @@ RXKB_EXPORT void
 rxkb_context_set_user_data(struct rxkb_context *ctx, void *user_data);
 
 /**
- * Return the pointer passed into rxkb_context_get_user_data().
+ * Return the pointer passed into `rxkb_context_get_user_data()`.
  *
  * @param ctx The xkb registry context
  * @return User-specific data pointer
@@ -301,7 +301,7 @@ RXKB_EXPORT void *
 rxkb_context_get_user_data(struct rxkb_context *ctx);
 
 /**
- * Append a new entry to the context's include path.
+ * Append a new entry to the context’s include path.
  *
  * The include path handling is optimized for the most common use-case: a set of
  * system files that provide a complete set of MLVO and some
@@ -310,31 +310,31 @@ rxkb_context_get_user_data(struct rxkb_context *ctx);
  * The include paths should be given so that the least complete path is
  * specified first and the most complete path is appended last. For example:
  *
- * @code
- *    ctx = rxkb_context_new(RXKB_CONTEXT_NO_DEFAULT_INCLUDES);
- *    rxkb_context_include_path_append(ctx, "/home/user/.config/xkb");
- *    rxkb_context_include_path_append(ctx, "/usr/share/X11/xkb");
- *    rxkb_context_parse(ctx, "evdev");
- * @endcode
+ * ```c
+ * ctx = rxkb_context_new(RXKB_CONTEXT_NO_DEFAULT_INCLUDES);
+ * rxkb_context_include_path_append(ctx, `/home/user/.config/xkb`);
+ * rxkb_context_include_path_append(ctx, `/usr/share/X11/xkb`);
+ * rxkb_context_parse(ctx, `evdev`);
+ * ```
  *
  * The above example reflects the default behavior unless @ref
  * RXKB_CONTEXT_NO_DEFAULT_INCLUDES is provided.
  *
  * Loading of the files is in **reverse order**, i.e. the last path appended is
  * loaded first - in this case the ``/usr/share/X11/xkb`` path.
- * Any models, layouts, variants and options defined in the "evdev" ruleset
- * are loaded into the context. Then, any RMLVO found in the "evdev" ruleset of
- * the user's path (``/home/user/.config/xkb`` in this example) are **appended**
+ * Any models, layouts, variants and options defined in the `evdev` ruleset
+ * are loaded into the context. Then, any RMLVO found in the `evdev` ruleset of
+ * the user’s path (``/home/user/.config/xkb`` in this example) are **appended**
  * to the existing set.
  *
  * Note that data from previously loaded include paths is never overwritten,
  * only appended to. It is not not possible to change the system-provided data,
  * only to append new models, layouts, variants and options to it.
  *
- * In other words, to define a new variant of the "us" layout called "banana",
+ * In other words, to define a new variant of the `us` layout called `banana`,
  * the following XML is sufficient.
  *
- * @verbatim
+ * ```xml
  * <xkbConfigRegistry version="1.1">
  * <layoutList>
  *   <layout>
@@ -351,30 +351,30 @@ rxkb_context_get_user_data(struct rxkb_context *ctx);
  *    </layout>
  * </layoutList>
  * </xkbConfigRegistry>
- * @endverbatim
+ * ```
  *
- * The list of models, options and all other layouts (including "us" and its
+ * The list of models, options and all other layouts (including `us` and its
  * variants) is taken from the system files. The resulting list of layouts will
- * thus have a "us" keyboard layout with the variant "banana" and all other
- * system-provided variants (dvorak, colemak, intl, etc.)
+ * thus have a `us` keyboard layout with the variant `banana` and all other
+ * system-provided variants (`dvorak`, `colemak`, `intl`, etc.)
  *
- * This function must be called before rxkb_context_parse() or
- * rxkb_context_parse_default_ruleset().
+ * This function must be called before `rxkb_context_parse()` or
+ * `rxkb_context_parse_default_ruleset()`.
  *
- * @returns true on success, or false if the include path could not be added
+ * @returns `true` on success, or `false` if the include path could not be added
  * or is inaccessible.
  */
 RXKB_EXPORT bool
 rxkb_context_include_path_append(struct rxkb_context *ctx, const char *path);
 
 /**
- * Append the default include paths to the context's include path.
- * See rxkb_context_include_path_append() for details about the merge order.
+ * Append the default include paths to the context’s include path.
+ * See `rxkb_context_include_path_append()` for details about the merge order.
  *
- * This function must be called before rxkb_context_parse() or
- * rxkb_context_parse_default_ruleset().
+ * This function must be called before `rxkb_context_parse()` or
+ * `rxkb_context_parse_default_ruleset()`.
  *
- * @returns true on success, or false if the include path could not be added
+ * @returns `true` on success, or `false` if the include path could not be added
  * or is inaccessible.
  */
 RXKB_EXPORT bool
@@ -382,10 +382,10 @@ rxkb_context_include_path_append_default(struct rxkb_context *ctx);
 
 /**
  * Return the first model for this context. Use this to start iterating over
- * the models, followed by calls to rxkb_model_next(). Models are not sorted.
+ * the models, followed by calls to `rxkb_model_next()`. Models are not sorted.
  *
- * The refcount of the returned model is not increased. Use rxkb_model_ref() if
- * you need to keep this struct outside the immediate scope.
+ * The refcount of the returned model is not increased. Use `rxkb_model_ref()`
+ * if you need to keep this struct outside the immediate scope.
  *
  * @return The first model in the model list.
  */
@@ -393,13 +393,13 @@ RXKB_EXPORT struct rxkb_model *
 rxkb_model_first(struct rxkb_context *ctx);
 
 /**
- * Return the next model for this context. Returns NULL when no more models
+ * Return the next model for this context. Returns `NULL` when no more models
  * are available.
  *
- * The refcount of the returned model is not increased. Use rxkb_model_ref() if
- * you need to keep this struct outside the immediate scope.
+ * The refcount of the returned model is not increased. Use `rxkb_model_ref()`
+ * if you need to keep this struct outside the immediate scope.
  *
- * @return the next model or NULL at the end of the list
+ * @return the next model or `NULL` at the end of the list
  */
 RXKB_EXPORT struct rxkb_model *
 rxkb_model_next(struct rxkb_model *m);
@@ -416,7 +416,7 @@ rxkb_model_ref(struct rxkb_model *m);
  * Decrease the refcount of the argument by one. When the refcount hits zero,
  * all memory associated with this struct is freed.
  *
- * @returns always NULL
+ * @returns always `NULL`
  */
 RXKB_EXPORT struct rxkb_model *
 rxkb_model_unref(struct rxkb_model *m);
@@ -430,13 +430,13 @@ rxkb_model_get_name(struct rxkb_model *m);
 
 /**
  * Return a human-readable description of this model. This function may return
- * NULL.
+ * `NULL`.
  */
 RXKB_EXPORT const char *
 rxkb_model_get_description(struct rxkb_model *m);
 
 /**
- * Return the vendor name for this model. This function may return NULL.
+ * Return the vendor name for this model. This function may return `NULL`.
  */
 RXKB_EXPORT const char *
 rxkb_model_get_vendor(struct rxkb_model *m);
@@ -449,10 +449,13 @@ rxkb_model_get_popularity(struct rxkb_model *m);
 
 /**
  * Return the first layout for this context. Use this to start iterating over
- * the layouts, followed by calls to rxkb_layout_next(). Layouts are not sorted.
+ * the layouts, followed by calls to `rxkb_layout_next()`.
  *
- * The refcount of the returned layout is not increased. Use rxkb_layout_ref() if
- * you need to keep this struct outside the immediate scope.
+ * @note Layouts are not sorted.
+ *
+ * The refcount of the returned layout is not increased.
+ * Use `rxkb_layout_ref()` if you need to keep this struct outside the immediate
+ * scope.
  *
  * @return The first layout in the layout list.
  */
@@ -460,13 +463,13 @@ RXKB_EXPORT struct rxkb_layout *
 rxkb_layout_first(struct rxkb_context *ctx);
 
 /**
- * Return the next layout for this context. Returns NULL when no more layouts
+ * Return the next layout for this context. Returns `NULL` when no more layouts
  * are available.
  *
- * The refcount of the returned layout is not increased. Use rxkb_layout_ref()
+ * The refcount of the returned layout is not increased. Use `rxkb_layout_ref()`
  * if you need to keep this struct outside the immediate scope.
  *
- * @return the next layout or NULL at the end of the list
+ * @return the next layout or `NULL` at the end of the list
  */
 RXKB_EXPORT struct rxkb_layout *
 rxkb_layout_next(struct rxkb_layout *l);
@@ -483,7 +486,7 @@ rxkb_layout_ref(struct rxkb_layout *l);
  * Decrease the refcount of the argument by one. When the refcount hits zero,
  * all memory associated with this struct is freed.
  *
- * @returns always NULL
+ * @returns always `NULL`
  */
 RXKB_EXPORT struct rxkb_layout *
 rxkb_layout_unref(struct rxkb_layout *l);
@@ -500,24 +503,24 @@ rxkb_layout_get_name(struct rxkb_layout *l);
  * used with libxkbcommon.
  *
  * A variant does not stand on its own, it always depends on the base layout.
- * e.g. there may be multiple variants called "intl" but there is only one
- * "us(intl)".
+ * e.g. there may be multiple variants called `intl` but there is only one
+ * `us(intl)`.
  *
- * Where the variant is NULL, the layout is the base layout (e.g. "us").
+ * Where the variant is `NULL`, the layout is the base layout (e.g. `us`).
  */
 RXKB_EXPORT const char *
 rxkb_layout_get_variant(struct rxkb_layout *l);
 
 /**
  * Return a short (one-word) description of this layout. This function may
- * return NULL.
+ * return `NULL`.
  */
 RXKB_EXPORT const char *
 rxkb_layout_get_brief(struct rxkb_layout *l);
 
 /**
  * Return a human-readable description of this layout. This function may return
- * NULL.
+ * `NULL`.
  */
 RXKB_EXPORT const char *
 rxkb_layout_get_description(struct rxkb_layout *l);
@@ -530,11 +533,11 @@ rxkb_layout_get_popularity(struct rxkb_layout *l);
 
 /**
  * Return the first option group for this context. Use this to start iterating
- * over the option groups, followed by calls to rxkb_option_group_next().
+ * over the option groups, followed by calls to `rxkb_option_group_next()`.
  * Option groups are not sorted.
  *
  * The refcount of the returned option group is not increased. Use
- * rxkb_option_group_ref() if you need to keep this struct outside the immediate
+ * `rxkb_option_group_ref()` if you need to keep this struct outside the immediate
  * scope.
  *
  * @return The first option group in the option group list.
@@ -543,14 +546,14 @@ RXKB_EXPORT struct rxkb_option_group *
 rxkb_option_group_first(struct rxkb_context *ctx);
 
 /**
- * Return the next option group for this context. Returns NULL when no more
+ * Return the next option group for this context. Returns `NULL` when no more
  * option groups are available.
  *
  * The refcount of the returned option group is not increased. Use
- * rxkb_option_group_ref() if you need to keep this struct outside the immediate
+ * `rxkb_option_group_ref()` if you need to keep this struct outside the immediate
  * scope.
  *
- * @return the next option group or NULL at the end of the list
+ * @return the next option group or `NULL` at the end of the list
  */
 RXKB_EXPORT struct rxkb_option_group *
 rxkb_option_group_next(struct rxkb_option_group *g);
@@ -567,7 +570,7 @@ rxkb_option_group_ref(struct rxkb_option_group *g);
  * Decrease the refcount of the argument by one. When the refcount hits zero,
  * all memory associated with this struct is freed.
  *
- * @returns always NULL
+ * @returns always `NULL`
  */
 RXKB_EXPORT struct rxkb_option_group *
 rxkb_option_group_unref(struct rxkb_option_group *g);
@@ -575,22 +578,22 @@ rxkb_option_group_unref(struct rxkb_option_group *g);
 /**
  * Return the name of this option group. This is **not** the value for O in
  * RMLVO, the name can be used for internal sorting in the caller. This function
- * may return NULL.
+ * may return `NULL`.
  */
 RXKB_EXPORT const char *
 rxkb_option_group_get_name(struct rxkb_option_group *m);
 
 /**
  * Return a human-readable description of this option group. This function may
- * return NULL.
+ * return `NULL`.
  */
 RXKB_EXPORT const char *
 rxkb_option_group_get_description(struct rxkb_option_group *m);
 
 /**
- * @return true if multiple options within this option group can be selected
- *              simultaneously, false if all options within this option group
- *              are mutually exclusive.
+ * @return `true` if multiple options within this option group can be selected
+ *                simultaneously, `false` if all options within this option
+ *                group are mutually exclusive.
  */
 RXKB_EXPORT bool
 rxkb_option_group_allows_multiple(struct rxkb_option_group *g);
@@ -603,10 +606,10 @@ rxkb_option_group_get_popularity(struct rxkb_option_group *g);
 
 /**
  * Return the first option for this option group. Use this to start iterating
- * over the options, followed by calls to rxkb_option_next(). Options are not
+ * over the options, followed by calls to `rxkb_option_next()`. Options are not
  * sorted.
  *
- * The refcount of the returned option is not increased. Use rxkb_option_ref()
+ * The refcount of the returned option is not increased. Use `rxkb_option_ref()`
  * if you need to keep this struct outside the immediate scope.
  *
  * @return The first option in the option list.
@@ -615,13 +618,13 @@ RXKB_EXPORT struct rxkb_option *
 rxkb_option_first(struct rxkb_option_group *group);
 
 /**
- * Return the next option for this option group. Returns NULL when no more
+ * Return the next option for this option group. Returns `NULL` when no more
  * options are available.
  *
- * The refcount of the returned options is not increased. Use rxkb_option_ref()
+ * The refcount of the returned options is not increased. Use `rxkb_option_ref()`
  * if you need to keep this struct outside the immediate scope.
  *
- * @returns The next option or NULL at the end of the list
+ * @returns The next option or `NULL` at the end of the list
  */
 RXKB_EXPORT struct rxkb_option *
 rxkb_option_next(struct rxkb_option *o);
@@ -638,7 +641,7 @@ rxkb_option_ref(struct rxkb_option *o);
  * Decrease the refcount of the argument by one. When the refcount hits zero,
  * all memory associated with this struct is freed.
  *
- * @returns always NULL
+ * @returns always `NULL`
  */
 RXKB_EXPORT struct rxkb_option *
 rxkb_option_unref(struct rxkb_option *o);
@@ -652,14 +655,14 @@ rxkb_option_get_name(struct rxkb_option *o);
 
 /**
  * Return a short (one-word) description of this option. This function may
- * return NULL.
+ * return `NULL`.
  */
 RXKB_EXPORT const char *
 rxkb_option_get_brief(struct rxkb_option *o);
 
 /**
  * Return a human-readable description of this option. This function may return
- * NULL.
+ * `NULL`.
  */
 RXKB_EXPORT const char *
 rxkb_option_get_description(struct rxkb_option *o);
@@ -672,7 +675,7 @@ rxkb_option_get_popularity(struct rxkb_option *o);
 
 /**
  * Return `true` if the given option accepts layout index specifiers to restrict
- * its application to the corresponding layouts, false otherwise.
+ * its application to the corresponding layouts, `false` otherwise.
  *
  * @sa `xkb_rmlvo_builder::xkb_rmlvo_builder_append_layout()`
  * @sa `xkb_rule_names::options`
@@ -692,24 +695,25 @@ rxkb_iso639_code_ref(struct rxkb_iso639_code *iso639);
  * Decrease the refcount of the argument by one. When the refcount hits zero,
  * all memory associated with this struct is freed.
  *
- * @returns always NULL
+ * @returns always `NULL`
  */
 RXKB_EXPORT struct rxkb_iso639_code *
 rxkb_iso639_code_unref(struct rxkb_iso639_code *iso639);
 
 /**
- * Return the ISO 639-3 code for this code (e.g. "eng", "fra").
+ * Return the ISO 639-3 code for this code. E.g. `eng`, `fra`.
  */
 RXKB_EXPORT const char *
 rxkb_iso639_code_get_code(struct rxkb_iso639_code *iso639);
 
 /**
  * Return the first ISO 639 for this layout. Use this to start iterating over
- * the codes, followed by calls to rxkb_iso639_code_next(). Codes are not
+ * the codes, followed by calls to `rxkb_iso639_code_next()`. Codes are not
  * sorted.
  *
- * The refcount of the returned code is not increased. Use rxkb_iso639_code_ref()
- * if you need to keep this struct outside the immediate scope.
+ * The refcount of the returned code is not increased.
+ * Use `rxkb_iso639_code_ref()` if you need to keep this struct outside the
+ * immediate scope.
  *
  * @return The first code in the code list.
  */
@@ -717,14 +721,14 @@ RXKB_EXPORT struct rxkb_iso639_code *
 rxkb_layout_get_iso639_first(struct rxkb_layout *layout);
 
 /**
- * Return the next code in the list. Returns NULL when no more codes
+ * Return the next code in the list. Returns `NULL` when no more codes
  * are available.
  *
- * The refcount of the returned codes is not increased. Use
- * rxkb_iso639_code_ref() if you need to keep this struct outside the immediate
- * scope.
+ * The refcount of the returned codes is not increased.
+ * Use `rxkb_iso639_code_ref()` if you need to keep this struct outside the
+ * immediate scope.
  *
- * @returns The next code or NULL at the end of the list
+ * @returns The next code or `NULL` at the end of the list
  */
 RXKB_EXPORT struct rxkb_iso639_code *
 rxkb_iso639_code_next(struct rxkb_iso639_code *iso639);
@@ -741,24 +745,24 @@ rxkb_iso3166_code_ref(struct rxkb_iso3166_code *iso3166);
  * Decrease the refcount of the argument by one. When the refcount hits zero,
  * all memory associated with this struct is freed.
  *
- * @returns always NULL
+ * @returns always `NULL`
  */
 RXKB_EXPORT struct rxkb_iso3166_code *
 rxkb_iso3166_code_unref(struct rxkb_iso3166_code *iso3166);
 
 /**
- * Return the ISO 3166 Alpha 2 code for this code (e.g. "US", "FR").
+ * Return the ISO 3166 Alpha 2 code for this code (e.g. `US`, `FR`).
  */
 RXKB_EXPORT const char *
 rxkb_iso3166_code_get_code(struct rxkb_iso3166_code *iso3166);
 
 /**
  * Return the first ISO 3166 for this layout. Use this to start iterating over
- * the codes, followed by calls to rxkb_iso3166_code_next(). Codes are not
+ * the codes, followed by calls to `rxkb_iso3166_code_next()`. Codes are not
  * sorted.
  *
  * The refcount of the returned code is not increased. Use
- * rxkb_iso3166_code_ref() if you need to keep this struct outside the immediate
+ * `rxkb_iso3166_code_ref()` if you need to keep this struct outside the immediate
  * scope.
  *
  * @return The first code in the code list.
@@ -767,14 +771,14 @@ RXKB_EXPORT struct rxkb_iso3166_code *
 rxkb_layout_get_iso3166_first(struct rxkb_layout *layout);
 
 /**
- * Return the next code in the list. Returns NULL when no more codes
+ * Return the next code in the list. Returns `NULL` when no more codes
  * are available.
  *
  * The refcount of the returned codes is not increased. Use
- * rxkb_iso3166_code_ref() if you need to keep this struct outside the immediate
+ * `rxkb_iso3166_code_ref()` if you need to keep this struct outside the immediate
  * scope.
  *
- * @returns The next code or NULL at the end of the list
+ * @returns The next code or `NULL` at the end of the list
  */
 RXKB_EXPORT struct rxkb_iso3166_code *
 rxkb_iso3166_code_next(struct rxkb_iso3166_code *iso3166);


### PR DESCRIPTION
- Fixed a lot of broken internal links.
- Improved the markup of code items.
- Fixed a few typos.