### PR TITLE
include: Fix infinite loop

### DIFF
--- a/src/xkbcomp/include.h
+++ b/src/xkbcomp/include.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ast.h"
+#include "utils.h"
 
 /* Reasonable threshold, with plenty of margin for keymaps in the wild */
 #define INCLUDE_MAX_DEPTH 15
@@ -19,9 +20,15 @@
 static const char MERGE_MODE_PREFIXES[] =
     { MERGE_OVERRIDE_PREFIX, MERGE_AUGMENT_PREFIX, MERGE_REPLACE_PREFIX, 0 };
 
+
 bool
 ParseIncludeMap(char **str_inout, char **file_rtrn, char **map_rtrn,
                 char *nextop_rtrn, char **extra_data);
+
+ssize_t
+expand_path(struct xkb_context *ctx, const char* parent_file_name,
+            const char *name, size_t name_len, enum xkb_file_type type,
+            char *buf, size_t buf_size);
 
 FILE *
 FindFileInXkbPath(struct xkb_context *ctx, const char* parent_file_name,
@@ -32,5 +39,5 @@ bool
 ExceedsIncludeMaxDepth(struct xkb_context *ctx, unsigned int include_depth);
 
 XkbFile *
-ProcessIncludeFile(struct xkb_context *ctx, IncludeStmt *stmt,
+ProcessIncludeFile(struct xkb_context *ctx, const IncludeStmt *stmt,
                    enum xkb_file_type file_type);

--- a/test/data/symbols/level3
+++ b/test/data/symbols/level3
@@ -12,7 +12,7 @@ xkb_symbols "ralt_switch" {
   include "level3(modifier_mapping)"
 };
 
-default partial modifier_keys
+partial modifier_keys
 xkb_symbols "ralt_latch" {
   key <RALT> {
     type[Group1]="ONE_LEVEL",


### PR DESCRIPTION
Fixed including an absolute path with no default map triggering an infinite loop.

Fixes #817