### PR TITLE
Add Support for `first` and `last` group indexes

### DIFF
--- a/changes/api/798.feature.md
+++ b/changes/api/798.feature.md
@@ -1,0 +1,1 @@
+Add Support for `first` and `last` group indexes.

--- a/src/text.c
+++ b/src/text.c
@@ -95,6 +95,7 @@ const LookupEntry groupMaskNames[] = {
 };
 
 const LookupEntry groupNames[] = {
+    { "First" , 1 },
     { "Group1", 1 },
     { "Group2", 2 },
     { "Group3", 3 },

--- a/src/xkbcomp/action.c
+++ b/src/xkbcomp/action.c
@@ -193,10 +193,10 @@ ReportActionNotArray(struct xkb_context *ctx, enum xkb_action_type action,
 
 static bool
 HandleNoAction(struct xkb_context *ctx, enum xkb_keymap_format format,
+               xkb_layout_index_t num_groups,
                const struct xkb_mod_set *mods,
                union xkb_action *action, enum action_field field,
                const ExprDef *array_ndx, const ExprDef *value)
-
 {
     log_err(ctx, XKB_ERROR_INVALID_ACTION_FIELD,
             "The \"%s\" action takes no argument, but got \"%s\" field; "
@@ -285,6 +285,7 @@ CheckAffectField(struct xkb_context *ctx, enum xkb_action_type action,
 
 static bool
 HandleSetLatchLockMods(struct xkb_context *ctx, enum xkb_keymap_format format,
+                       xkb_layout_index_t num_groups,
                        const struct xkb_mod_set *mods,
                        union xkb_action *action, enum action_field field,
                        const ExprDef *array_ndx, const ExprDef *value)
@@ -338,9 +339,9 @@ HandleSetLatchLockMods(struct xkb_context *ctx, enum xkb_keymap_format format,
 
 static bool
 CheckGroupField(struct xkb_context *ctx, enum xkb_action_type action,
-                xkb_layout_index_t max_groups, const ExprDef *array_ndx,
-                const ExprDef *value, enum xkb_action_flags *flags_inout,
-                int32_t *group_rtrn)
+                xkb_layout_index_t max_groups, xkb_layout_index_t num_groups,
+                const ExprDef *array_ndx, const ExprDef *value,
+                enum xkb_action_flags *flags_inout, int32_t *group_rtrn)
 {
     const ExprDef *spec;
     xkb_layout_index_t idx = 0;
@@ -358,7 +359,7 @@ CheckGroupField(struct xkb_context *ctx, enum xkb_action_type action,
         spec = value;
     }
 
-    if (!ExprResolveGroup(ctx, max_groups, spec, &idx))
+    if (!ExprResolveGroup(ctx, max_groups, num_groups, spec, &idx))
         return ReportMismatch(ctx, XKB_ERROR_UNSUPPORTED_GROUP_INDEX, action,
                               ACTION_FIELD_GROUP, "integer");
 
@@ -377,6 +378,7 @@ CheckGroupField(struct xkb_context *ctx, enum xkb_action_type action,
 
 static bool
 HandleSetLatchLockGroup(struct xkb_context *ctx, enum xkb_keymap_format format,
+                        xkb_layout_index_t num_groups,
                         const struct xkb_mod_set *mods,
                         union xkb_action *action, enum action_field field,
                         const ExprDef *array_ndx, const ExprDef *value)
@@ -386,8 +388,8 @@ HandleSetLatchLockGroup(struct xkb_context *ctx, enum xkb_keymap_format format,
 
     if (field == ACTION_FIELD_GROUP) {
         const xkb_layout_index_t max_groups = format_max_groups(format);
-        return CheckGroupField(ctx, action->type, max_groups, array_ndx, value,
-                               &act->flags, &act->group);
+        return CheckGroupField(ctx, action->type, max_groups, num_groups,
+                               array_ndx, value, &act->flags, &act->group);
     }
     if ((type == ACTION_TYPE_GROUP_SET || type == ACTION_TYPE_GROUP_LATCH) &&
         field == ACTION_FIELD_CLEAR_LOCKS)
@@ -417,6 +419,7 @@ HandleSetLatchLockGroup(struct xkb_context *ctx, enum xkb_keymap_format format,
 
 static bool
 HandleMovePtr(struct xkb_context *ctx, enum xkb_keymap_format format,
+              xkb_layout_index_t num_groups,
               const struct xkb_mod_set *mods,
               union xkb_action *action, enum action_field field,
               const ExprDef *array_ndx, const ExprDef *value)
@@ -467,6 +470,7 @@ HandleMovePtr(struct xkb_context *ctx, enum xkb_keymap_format format,
 
 static bool
 HandlePtrBtn(struct xkb_context *ctx, enum xkb_keymap_format format,
+             xkb_layout_index_t num_groups,
              const struct xkb_mod_set *mods,
              union xkb_action *action, enum action_field field,
              const ExprDef *array_ndx, const ExprDef *value)
@@ -531,6 +535,7 @@ static const LookupEntry ptrDflts[] = {
 
 static bool
 HandleSetPtrDflt(struct xkb_context *ctx, enum xkb_keymap_format format,
+                 xkb_layout_index_t num_groups,
                  const struct xkb_mod_set *mods,
                  union xkb_action *action, enum action_field field,
                  const ExprDef *array_ndx, const ExprDef *value)
@@ -591,6 +596,7 @@ HandleSetPtrDflt(struct xkb_context *ctx, enum xkb_keymap_format format,
 
 static bool
 HandleSwitchScreen(struct xkb_context *ctx, enum xkb_keymap_format format,
+                   xkb_layout_index_t num_groups,
                    const struct xkb_mod_set *mods,
                    union xkb_action *action, enum action_field field,
                    const ExprDef *array_ndx, const ExprDef *value)
@@ -641,6 +647,7 @@ HandleSwitchScreen(struct xkb_context *ctx, enum xkb_keymap_format format,
 
 static bool
 HandleSetLockControls(struct xkb_context *ctx, enum xkb_keymap_format format,
+                      xkb_layout_index_t num_groups,
                       const struct xkb_mod_set *mods,
                       union xkb_action *action, enum action_field field,
                       const ExprDef *array_ndx, const ExprDef *value)
@@ -670,6 +677,7 @@ HandleSetLockControls(struct xkb_context *ctx, enum xkb_keymap_format format,
 
 static bool
 HandleUnsupportedLegacy(struct xkb_context *ctx, enum xkb_keymap_format format,
+                        xkb_layout_index_t num_groups,
                         const struct xkb_mod_set *mods,
                         union xkb_action *action, enum action_field field,
                         const ExprDef *array_ndx, const ExprDef *value)
@@ -681,6 +689,7 @@ HandleUnsupportedLegacy(struct xkb_context *ctx, enum xkb_keymap_format format,
 
 static bool
 HandlePrivate(struct xkb_context *ctx, enum xkb_keymap_format format,
+              xkb_layout_index_t num_groups,
               const struct xkb_mod_set *mods,
               union xkb_action *action, enum action_field field,
               const ExprDef *array_ndx, const ExprDef *value)
@@ -787,6 +796,7 @@ HandlePrivate(struct xkb_context *ctx, enum xkb_keymap_format format,
 
 typedef bool (*actionHandler)(struct xkb_context *ctx,
                               enum xkb_keymap_format format,
+                              xkb_layout_index_t num_groups,
                               const struct xkb_mod_set *mods,
                               union xkb_action *action,
                               enum action_field field,
@@ -818,7 +828,8 @@ static const actionHandler handleAction[_ACTION_TYPE_NUM_ENTRIES] = {
 
 bool
 HandleActionDef(struct xkb_context *ctx, enum xkb_keymap_format format,
-                ActionsInfo *info, const struct xkb_mod_set *mods, ExprDef *def,
+                xkb_layout_index_t num_groups, ActionsInfo *info,
+                const struct xkb_mod_set *mods, ExprDef *def,
                 union xkb_action *action)
 {
     if (def->common.type != STMT_EXPR_ACTION_DECL) {
@@ -898,8 +909,8 @@ HandleActionDef(struct xkb_context *ctx, enum xkb_keymap_format format,
             return false;
         }
 
-        if (!handleAction[handler_type](ctx, format, mods, action, fieldNdx,
-                                        arrayRtrn, value))
+        if (!handleAction[handler_type](ctx, format, num_groups, mods, action,
+                                        fieldNdx, arrayRtrn, value))
             return false;
     }
 
@@ -908,8 +919,9 @@ HandleActionDef(struct xkb_context *ctx, enum xkb_keymap_format format,
 
 bool
 SetDefaultActionField(struct xkb_context *ctx, enum xkb_keymap_format format,
-                      ActionsInfo *info, struct xkb_mod_set *mods,
-                      const char *elem, const char *field, ExprDef *array_ndx,
+                      xkb_layout_index_t num_groups, ActionsInfo *info,
+                      struct xkb_mod_set *mods, const char *elem,
+                      const char *field, ExprDef *array_ndx,
                       ExprDef *value, enum merge_mode merge)
 {
     enum xkb_action_type action;
@@ -930,7 +942,8 @@ SetDefaultActionField(struct xkb_context *ctx, enum xkb_keymap_format format,
     union xkb_action from = *into;
 
     /* Parse action */
-    if (!handleAction[action](ctx, format, mods, &from, action_field, array_ndx, value))
+    if (!handleAction[action](ctx, format, num_groups, mods, &from, action_field,
+                              array_ndx, value))
         return false;
 
     /*

--- a/src/xkbcomp/action.h
+++ b/src/xkbcomp/action.h
@@ -6,6 +6,7 @@
 
 #include "ast.h"
 #include "keymap.h"
+#include "xkbcommon/xkbcommon.h"
 
 /*
  * This struct contains the default values which every new action
@@ -21,13 +22,15 @@ InitActionsInfo(ActionsInfo *info);
 
 bool
 HandleActionDef(struct xkb_context *ctx, enum xkb_keymap_format format,
-                ActionsInfo *info, const struct xkb_mod_set *mods, ExprDef *def,
+                xkb_layout_index_t num_groups, ActionsInfo *info,
+                const struct xkb_mod_set *mods, ExprDef *def,
                 union xkb_action *action);
 
 bool
 SetDefaultActionField(struct xkb_context *ctx, enum xkb_keymap_format format,
-                      ActionsInfo *info, struct xkb_mod_set *mods,
-                      const char *elem, const char *field, ExprDef *array_ndx,
+                      xkb_layout_index_t num_groups, ActionsInfo *info,
+                      struct xkb_mod_set *mods, const char *elem,
+                      const char *field, ExprDef *array_ndx,
                       ExprDef *value, enum merge_mode merge);
 
 static inline bool

--- a/src/xkbcomp/compat.c
+++ b/src/xkbcomp/compat.c
@@ -64,6 +64,7 @@ typedef struct {
     struct xkb_mod_set mods;
 
     enum xkb_keymap_format format;
+    xkb_layout_index_t num_groups;
     struct xkb_context *ctx;
 } CompatInfo;
 
@@ -143,11 +144,12 @@ InitLED(LedInfo *info)
 static void
 InitCompatInfo(CompatInfo *info, struct xkb_context *ctx,
                unsigned int include_depth, enum xkb_keymap_format format,
-               const struct xkb_mod_set *mods)
+               xkb_layout_index_t num_groups, const struct xkb_mod_set *mods)
 {
     memset(info, 0, sizeof(*info));
     info->ctx = ctx;
     info->format = format;
+    info->num_groups = num_groups;
     info->include_depth = include_depth;
     InitActionsInfo(&info->default_actions);
     InitVMods(&info->mods, mods, include_depth > 0);
@@ -458,7 +460,7 @@ HandleIncludeCompatMap(CompatInfo *info, IncludeStmt *include)
     }
 
     InitCompatInfo(&included, info->ctx, info->include_depth + 1,
-                   info->format, &info->mods);
+                   info->format, info->num_groups, &info->mods);
     included.name = steal(&include->stmt);
 
     for (IncludeStmt *stmt = include; stmt; stmt = stmt->next_incl) {
@@ -473,7 +475,7 @@ HandleIncludeCompatMap(CompatInfo *info, IncludeStmt *include)
         }
 
         InitCompatInfo(&next_incl, info->ctx, info->include_depth + 1,
-                       info->format, &included.mods);
+                       info->format, info->num_groups, &included.mods);
         next_incl.default_interp = info->default_interp;
         next_incl.default_led = info->default_led;
 
@@ -521,7 +523,7 @@ SetInterpField(CompatInfo *info, SymInterpInfo *si, const char *field,
             for (ExprDef *act = value->actions.actions;
                  act; act = (ExprDef *) act->common.next) {
                 union xkb_action toAct = { 0 };
-                if (!HandleActionDef(info->ctx, info->format,
+                if (!HandleActionDef(info->ctx, info->format, info->num_groups,
                                      &info->default_actions, &info->mods,
                                      act, &toAct)) {
                     darray_free(actions);
@@ -556,7 +558,7 @@ SetInterpField(CompatInfo *info, SymInterpInfo *si, const char *field,
                 darray_steal(actions, &si->interp.a.actions, NULL);
             }
         }
-        else if (HandleActionDef(info->ctx, info->format,
+        else if (HandleActionDef(info->ctx, info->format, info->num_groups,
                                  &info->default_actions, &info->mods,
                                  value, &si->interp.a.action))
             si->interp.num_actions =
@@ -746,7 +748,7 @@ HandleGlobalVar(CompatInfo *info, VarDef *stmt)
         MergeLedMap(info, &info->default_led, &temp, true);
     }
     else if (elem) {
-        ret = SetDefaultActionField(info->ctx, info->format,
+        ret = SetDefaultActionField(info->ctx, info->format, info->num_groups,
                                     &info->default_actions, &info->mods,
                                     elem, field, ndx,
                                     stmt->value, stmt->merge);
@@ -1010,7 +1012,8 @@ CompileCompatMap(XkbFile *file, struct xkb_keymap *keymap)
 {
     CompatInfo info;
 
-    InitCompatInfo(&info, keymap->ctx, 0, keymap->format, &keymap->mods);
+    InitCompatInfo(&info, keymap->ctx, 0, keymap->format, keymap->num_groups,
+                   &keymap->mods);
 
     if (file != NULL)
         HandleCompatMapFile(&info, file);

--- a/src/xkbcomp/expr.c
+++ b/src/xkbcomp/expr.c
@@ -6,6 +6,8 @@
 #include "config.h"
 
 #include "messages-codes.h"
+#include "utils.h"
+#include "xkbcommon/xkbcommon.h"
 #include "xkbcomp-priv.h"
 #include "text.h"
 #include "expr.h"
@@ -326,13 +328,46 @@ ExprResolveInteger(struct xkb_context *ctx, const ExprDef *expr,
     return ExprResolveIntegerLookup(ctx, expr, val_rtrn, NULL, NULL);
 }
 
+struct GroupLookupEntry {
+    xkb_layout_index_t num_groups;
+    const LookupEntry *simple_lookup;
+};
+
+static bool
+GroupLookup(struct xkb_context *ctx, const void *priv, xkb_atom_t field,
+            uint32_t *val_rtrn)
+{
+    if (!priv || field == XKB_ATOM_NONE)
+        return false;
+
+    const struct GroupLookupEntry * const lookup = priv;
+    const char * const str = xkb_atom_text(ctx, field);
+    if (istreq(str, "last")) {
+        if (lookup->num_groups == 0) {
+            log_err(ctx, XKB_ERROR_UNSUPPORTED_GROUP_INDEX,
+                    "Group index \"%s\" is only available when compiling\n"
+                    "a keymap using the RMLVO API.", str);
+            return false;
+        } else {
+            *val_rtrn = lookup->num_groups; /* 1-indexed */
+            return true;
+        }
+    }
+
+    return SimpleLookup(ctx, lookup->simple_lookup, field, val_rtrn);
+}
+
 bool
 ExprResolveGroup(struct xkb_context *ctx, xkb_layout_index_t max_groups,
-                 const ExprDef *expr, xkb_layout_index_t *group_rtrn)
+                 xkb_layout_index_t num_groups, const ExprDef *expr,
+                 xkb_layout_index_t *group_rtrn)
 {
     int64_t result = 0;
-    bool ok = ExprResolveIntegerLookup(ctx, expr, &result, SimpleLookup,
-                                       groupNames);
+    const struct GroupLookupEntry priv = {
+        .num_groups = num_groups,
+        .simple_lookup = groupNames
+    };
+    bool ok = ExprResolveIntegerLookup(ctx, expr, &result, GroupLookup, &priv);
     if (!ok)
         return false;
 

--- a/src/xkbcomp/expr.h
+++ b/src/xkbcomp/expr.h
@@ -39,7 +39,8 @@ ExprResolveLevel(struct xkb_context *ctx, const ExprDef *expr,
 
 bool
 ExprResolveGroup(struct xkb_context *ctx, xkb_layout_index_t max_groups,
-                 const ExprDef *expr, xkb_layout_index_t *group_rtrn);
+                 xkb_layout_index_t num_groups, const ExprDef *expr,
+                 xkb_layout_index_t *group_rtrn);
 
 bool
 ExprResolveButton(struct xkb_context *ctx, const ExprDef *expr,

--- a/src/xkbcomp/symbols.c
+++ b/src/xkbcomp/symbols.c
@@ -753,7 +753,8 @@ GetGroupIndex(SymbolsInfo *info, KeyInfo *keyi, ExprDef *arrayNdx,
         return true;
     }
 
-    if (!ExprResolveGroup(info->ctx, info->max_groups, arrayNdx, ndx_rtrn)) {
+    if (!ExprResolveGroup(info->ctx, info->max_groups, info->keymap->num_groups,
+                          arrayNdx, ndx_rtrn)) {
         log_err(info->ctx, XKB_ERROR_UNSUPPORTED_GROUP_INDEX,
                 "Illegal group index for %s of key %s\n"
                 "Definition with non-integer array index ignored\n",
@@ -929,6 +930,7 @@ AddActionsToKey(SymbolsInfo *info, KeyInfo *keyi, ExprDef *arrayNdx,
              act; act = (ExprDef *) act->common.next) {
             union xkb_action toAct = { 0 };
             if (!HandleActionDef(info->ctx, info->keymap->format,
+                                 info->keymap->num_groups,
                                  &info->default_actions, &info->mods,
                                  act, &toAct)) {
                 log_err(info->ctx, XKB_ERROR_INVALID_VALUE,
@@ -1020,7 +1022,8 @@ SetSymbolsField(SymbolsInfo *info, KeyInfo *keyi, const char *field,
             keyi->default_type = val;
             keyi->defined |= KEY_FIELD_DEFAULT_TYPE;
         }
-        else if (!ExprResolveGroup(info->ctx, info->max_groups, arrayNdx, &ndx)) {
+        else if (!ExprResolveGroup(info->ctx, info->max_groups,
+                                   info->keymap->num_groups, arrayNdx, &ndx)) {
             log_err(info->ctx, XKB_ERROR_UNSUPPORTED_GROUP_INDEX,
                     "Illegal group index for type of key %s; "
                     "Definition with non-integer array index ignored\n",
@@ -1135,7 +1138,8 @@ SetSymbolsField(SymbolsInfo *info, KeyInfo *keyi, const char *field,
              istreq(field, "redirectgroups")) {
         xkb_layout_index_t grp = 0;
 
-        if (!ExprResolveGroup(info->ctx, info->max_groups, value, &grp)) {
+        if (!ExprResolveGroup(info->ctx, info->max_groups,
+                              info->keymap->num_groups, value, &grp)) {
             log_err(info->ctx, XKB_ERROR_UNSUPPORTED_GROUP_INDEX,
                     "Illegal group index for redirect of key %s; "
                     "Definition with non-integer group ignored\n",
@@ -1170,7 +1174,8 @@ SetGroupName(SymbolsInfo *info, ExprDef *arrayNdx, ExprDef *value,
     }
 
     xkb_layout_index_t group = 0;
-    if (!ExprResolveGroup(info->ctx, info->max_groups, arrayNdx, &group)) {
+    if (!ExprResolveGroup(info->ctx, info->max_groups, info->keymap->num_groups,
+                          arrayNdx, &group)) {
         log_err(info->ctx, XKB_ERROR_UNSUPPORTED_GROUP_INDEX,
                 "Illegal index in group name definition; "
                 "Definition with non-integer array index ignored\n");
@@ -1276,6 +1281,7 @@ HandleGlobalVar(SymbolsInfo *info, VarDef *stmt)
     }
     else if (elem) {
         ret = SetDefaultActionField(info->ctx, info->keymap->format,
+                                    info->keymap->num_groups,
                                     &info->default_actions,
                                     &info->mods, elem, field, arrayNdx,
                                     stmt->value, stmt->merge);

--- a/src/xkbcomp/xkbcomp.c
+++ b/src/xkbcomp/xkbcomp.c
@@ -155,7 +155,7 @@ text_v1_keymap_new_from_names(struct xkb_keymap *keymap,
     /* Resolve the RMLVO components to KcCGST components and get the
      * expected number of layouts */
     ok = xkb_components_from_rules_names(keymap->ctx, rmlvo, &kccgst,
-                                   &keymap->num_groups);
+                                         &keymap->num_groups);
     if (!ok) {
         log_err(keymap->ctx, XKB_ERROR_KEYMAP_COMPILATION_FAILED,
                 "Couldn't look up rules '%s', model '%s', layout '%s', "

--- a/test/data/compat/iso9995-v2
+++ b/test/data/compat/iso9995-v2
@@ -53,3 +53,14 @@ xkb_compatibility "lockOnRelease" {
 	action= LockGroup(group=2, lockOnRelease);
     };
 };
+
+partial
+xkb_compatibility "group_bounds" {
+    interpret ISO_First_Group {
+	action= LockGroup(group=first);
+    };
+
+    interpret ISO_Last_Group {
+	action= LockGroup(group=last);
+    };
+};

--- a/test/data/rules/evdev
+++ b/test/data/rules/evdev
@@ -1177,9 +1177,10 @@
   caps:shiftlock	=	+ledcaps(shift_lock)
   caps:unlock-on-release	=	+caps(unlock-on-release)
   caps:unlock-on-press		=	+caps(unlock-on-press)
-  grab:break_actions    =       +xfree86(grab_break)
+  grab:break_actions	=	+xfree86(grab_break)
   grp:lockOnRelease	=	+iso9995-v2(lockOnRelease)
   grp:lockOnPress	=	+iso9995-v2(lockOnPress)
+  grp:group_bounds	=	+iso9995-v2(group_bounds)
   lv3:latchOnPress	=	+level3-v2(latchOnPress)
   lv3:latchOnRelease	=	+level3-v2(latchOnRelease)
 

--- a/test/data/rules/evdev-modern
+++ b/test/data/rules/evdev-modern
@@ -710,6 +710,7 @@
   grab:break_actions	=	+xfree86(grab_break)
   grp:lockOnRelease	=	+iso9995-v2(lockOnRelease)
   grp:lockOnPress	=	+iso9995-v2(lockOnPress)
+  grp:group_bounds	=	+iso9995-v2(group_bounds)
   lv3:latchOnPress	=	+level3-v2(latchOnPress)
   lv3:latchOnRelease	=	+level3-v2(latchOnRelease)
 

--- a/test/state.c
+++ b/test/state.c
@@ -3075,6 +3075,35 @@ test_extended_layout_indexes(struct xkb_context *ctx)
     xkb_keymap_unref(keymap);
 }
 
+static void
+test_layout_index_named_bounds(struct xkb_context *ctx)
+{
+    struct xkb_keymap * const keymap = test_compile_rules(
+        ctx, XKB_KEYMAP_FORMAT_TEXT_V2, "evdev-modern", "pc104",
+        "us,in,ch,cz,de", NULL, "grp:shift_caps_switch,grp:group_bounds"
+    );
+    assert(keymap);
+    struct xkb_state * const state = xkb_state_new(keymap);
+    assert(state);
+
+    /* Last layout */
+    xkb_state_update_key(state, KEY_LEFTSHIFT + EVDEV_OFFSET, XKB_KEY_DOWN);
+    xkb_state_update_key(state, KEY_CAPSLOCK + EVDEV_OFFSET, XKB_KEY_DOWN);
+    xkb_state_update_key(state, KEY_CAPSLOCK + EVDEV_OFFSET, XKB_KEY_UP);
+    xkb_state_update_key(state, KEY_LEFTSHIFT + EVDEV_OFFSET, XKB_KEY_UP);
+    assert(xkb_state_serialize_layout(state, XKB_STATE_LAYOUT_EFFECTIVE) == 4);
+
+    xkb_state_update_latched_locked(state, 0, 0, false, 0, 0, 0, true, 2);
+
+    /* First layout */
+    xkb_state_update_key(state, KEY_CAPSLOCK + EVDEV_OFFSET, XKB_KEY_DOWN);
+    xkb_state_update_key(state, KEY_CAPSLOCK + EVDEV_OFFSET, XKB_KEY_UP);
+    assert(xkb_state_serialize_layout(state, XKB_STATE_LAYOUT_EFFECTIVE) == 0);
+
+    xkb_state_unref(state);
+    xkb_keymap_unref(keymap);
+}
+
 int
 main(void)
 {
@@ -3124,6 +3153,7 @@ main(void)
     test_multiple_actions(context);
     test_void_action(context);
     test_extended_layout_indexes(context);
+    test_layout_index_named_bounds(context);
 
     xkb_context_unref(context);
     return EXIT_SUCCESS;


### PR DESCRIPTION
`first` is always equal to 1, but `last` is currently only available if using the RMLVO API.

Fixes #798