### PR TITLE
tools: Improve interactive events output

### DIFF
--- a/changes/tools/+improved-interactive-output.feature.md
+++ b/changes/tools/+improved-interactive-output.feature.md
@@ -1,1 +1,3 @@
-`xkbcli interactive-*`: Print key release events.
+`xkbcli interactive-*`:
+- Print key release events.
+- Print detailed state change events.

--- a/changes/tools/+improved-interactive-output.feature.md
+++ b/changes/tools/+improved-interactive-output.feature.md
@@ -1,0 +1,1 @@
+`xkbcli interactive-*`: Print key release events.

--- a/changes/tools/+improved-interactive-output.feature.md
+++ b/changes/tools/+improved-interactive-output.feature.md
@@ -1,3 +1,6 @@
 `xkbcli interactive-*`:
 - Print key release events.
 - Print detailed state change events.
+- Added `--uniline` to enable uniline event output (default).
+- Added `--multiline` to enable multiline event output, which provides
+  more details than the uniline mode.

--- a/meson.build
+++ b/meson.build
@@ -454,6 +454,8 @@ if build_tools
         sources: [
             'tools/tools-common.h',
             'tools/tools-common.c',
+            'src/utf8-decoding.c',
+            'src/utf8-decoding.h',
         ],
         include_directories: [include_directories('tools', 'include')],
         dependencies: dep_libxkbcommon,
@@ -719,6 +721,8 @@ test_dep = declare_dependency(
         'bench/bench.c',
         'bench/bench.h',
         'src/utils-numbers.h',
+        'src/utf8-decoding.c',
+        'src/utf8-decoding.h',
         'test/common.c',
         'test/evdev-scancodes.h',
         'test/test.h',

--- a/test/common.c
+++ b/test/common.c
@@ -144,7 +144,9 @@ test_key_seq_va(struct xkb_keymap *keymap, va_list ap)
             xkb_state_update_key(state, kc, XKB_KEY_UP);
 
 #if HAVE_TOOLS
-        tools_print_keycode_state("", state, NULL, kc, XKB_CONSUMED_MODE_XKB, PRINT_ALL_FIELDS);
+        tools_print_keycode_state("", state, NULL, kc,
+                                  (op == DOWN ? XKB_KEY_DOWN : XKB_KEY_UP),
+                                  XKB_CONSUMED_MODE_XKB, PRINT_ALL_FIELDS);
 #endif
         fprintf(stderr, "op %-6s got %d syms for keycode %3"PRIu32": [", opstr, nsyms, kc);
 

--- a/test/common.c
+++ b/test/common.c
@@ -146,7 +146,8 @@ test_key_seq_va(struct xkb_keymap *keymap, va_list ap)
 #if HAVE_TOOLS
         tools_print_keycode_state("", state, NULL, kc,
                                   (op == DOWN ? XKB_KEY_DOWN : XKB_KEY_UP),
-                                  XKB_CONSUMED_MODE_XKB, PRINT_ALL_FIELDS);
+                                  XKB_CONSUMED_MODE_XKB,
+                                  PRINT_ALL_FIELDS | PRINT_UNILINE);
 #endif
         fprintf(stderr, "op %-6s got %d syms for keycode %3"PRIu32": [", opstr, nsyms, kc);
 

--- a/tools/interactive-evdev.c
+++ b/tools/interactive-evdev.c
@@ -258,12 +258,11 @@ process_event(struct keyboard *kbd, uint16_t type, uint16_t code, int32_t value)
         xkb_compose_state_feed(kbd->compose_state, keysym);
     }
 
-    if (value != KEY_STATE_RELEASE) {
-        tools_print_keycode_state(
-            NULL, kbd->state, kbd->compose_state, keycode,
-            consumed_mode, print_fields
-        );
-    }
+    tools_print_keycode_state(
+        NULL, kbd->state, kbd->compose_state, keycode,
+        (value == KEY_STATE_RELEASE) ? XKB_KEY_UP : XKB_KEY_DOWN,
+        consumed_mode, print_fields
+    );
 
     if (with_compose) {
         status = xkb_compose_state_get_status(kbd->compose_state);

--- a/tools/interactive-evdev.c
+++ b/tools/interactive-evdev.c
@@ -270,13 +270,13 @@ process_event(struct keyboard *kbd, uint16_t type, uint16_t code, int32_t value)
             xkb_compose_state_reset(kbd->compose_state);
     }
 
-    if (value == KEY_STATE_RELEASE)
-        changed = xkb_state_update_key(kbd->state, keycode, XKB_KEY_UP);
-    else
-        changed = xkb_state_update_key(kbd->state, keycode, XKB_KEY_DOWN);
+    changed = xkb_state_update_key(kbd->state, keycode,
+                                   (value == KEY_STATE_RELEASE
+                                        ? XKB_KEY_UP
+                                        : XKB_KEY_DOWN));
 
     if (report_state_changes)
-        tools_print_state_changes(changed);
+        tools_print_state_changes(NULL, kbd->state, changed);
 }
 
 static int

--- a/tools/interactive-wayland.c
+++ b/tools/interactive-wayland.c
@@ -478,8 +478,12 @@ kbd_modifiers(void *data, struct wl_keyboard *wl_kbd, uint32_t serial,
 {
     struct interactive_seat *seat = data;
 
-    xkb_state_update_mask(seat->state, mods_depressed, mods_latched,
-                          mods_locked, 0, 0, group);
+    const enum xkb_state_component changed = xkb_state_update_mask(
+        seat->state, mods_depressed, mods_latched, mods_locked, 0, 0, group
+    );
+    char * const prefix = asprintf_safe("%s: ", seat->name_str);
+    tools_print_state_changes(prefix, seat->state, changed);
+    free(prefix);
 }
 
 static void

--- a/tools/interactive-wayland.c
+++ b/tools/interactive-wayland.c
@@ -452,13 +452,12 @@ kbd_key(void *data, struct wl_keyboard *wl_kbd, uint32_t serial, uint32_t time,
         xkb_compose_state_feed(seat->compose_state, keysym);
     }
 
-    if (state != WL_KEYBOARD_KEY_STATE_RELEASED) {
-        char *prefix = asprintf_safe("%s: ", seat->name_str);
-        tools_print_keycode_state(prefix, seat->state, seat->compose_state, keycode,
-                                XKB_CONSUMED_MODE_XKB,
-                                PRINT_ALL_FIELDS);
-        free(prefix);
-    }
+    char * const prefix = asprintf_safe("%s: ", seat->name_str);
+    const enum xkb_key_direction direction =
+        (state == WL_KEYBOARD_KEY_STATE_RELEASED) ? XKB_KEY_UP : XKB_KEY_DOWN;
+    tools_print_keycode_state(prefix, seat->state, seat->compose_state, keycode,
+                              direction, XKB_CONSUMED_MODE_XKB, PRINT_ALL_FIELDS);
+    free(prefix);
 
     if (seat->compose_state) {
         enum xkb_compose_status status = xkb_compose_state_get_status(seat->compose_state);

--- a/tools/interactive-x11.c
+++ b/tools/interactive-x11.c
@@ -233,15 +233,18 @@ process_xkb_event(xcb_generic_event_t *gevent, struct keyboard *kbd)
         update_keymap(kbd);
         break;
 
-    case XCB_XKB_STATE_NOTIFY:
-        xkb_state_update_mask(kbd->state,
-                              event->state_notify.baseMods,
-                              event->state_notify.latchedMods,
-                              event->state_notify.lockedMods,
-                              event->state_notify.baseGroup,
-                              event->state_notify.latchedGroup,
-                              event->state_notify.lockedGroup);
+    case XCB_XKB_STATE_NOTIFY: {
+        const enum xkb_state_component changed =
+            xkb_state_update_mask(kbd->state,
+                                  event->state_notify.baseMods,
+                                  event->state_notify.latchedMods,
+                                  event->state_notify.lockedMods,
+                                  event->state_notify.baseGroup,
+                                  event->state_notify.latchedGroup,
+                                  event->state_notify.lockedGroup);
+        tools_print_state_changes(NULL, kbd->state, changed);
         break;
+    }
 
     default:
         /* Ignore */

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -16,6 +16,7 @@
 #include <limits.h>
 #include <fcntl.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
@@ -30,8 +31,10 @@
 #endif
 
 #include "xkbcommon/xkbcommon.h"
+#include "xkbcommon/xkbcommon-compose.h"
 #include "tools-common.h"
 #include "src/utils.h"
+#include "src/utf8-decoding.h"
 #include "src/keysym.h"
 #include "src/compose/parser.h"
 #include "src/keymap.h"
@@ -174,6 +177,8 @@ print_modifiers_names(struct xkb_state *state,
     }
 }
 
+#define INDENT "    "
+
 static void
 print_modifiers(struct xkb_state *state, enum xkb_state_component changed,
                 xkb_keycode_t keycode, bool show_consumed,
@@ -189,21 +194,42 @@ print_modifiers(struct xkb_state *state, enum xkb_state_component changed,
         { XKB_STATE_MODS_LOCKED,    3, "locked"    },
         { XKB_STATE_MODS_EFFECTIVE, 0, "effective" },
     };
-    if (changed) {
+    if (verbose) {
+        static const char label[] = INDENT "modifiers: ";
+        printf("%s", label);
         for (unsigned int k = 0; k < ARRAY_SIZE(types); k++) {
-            if (!(changed & types[k].component))
-                continue;
             const xkb_mod_mask_t mods =
                 xkb_state_serialize_mods(state, types[k].component);
-            printf("%s-mods: 0x%08"PRIx32"; ", types[k].label, mods);
+            const char * const changed_indicator = (changed)
+                ? (changed & types[k].component ? "*" : " ")
+                : "";
+            printf("%*s%s%s: %*s0x%08"PRIx32,
+                   (k == 0) ? 0 : (unsigned int) sizeof(label) - 1, "",
+                   changed_indicator, types[k].label,
+                   types[k].padding, "", mods);
+            print_modifiers_names(
+                state, types[k].component,
+                (show_consumed ? keycode : XKB_KEYCODE_INVALID), consumed_mode
+            );
+            printf("\n");
         }
     } else {
-        const xkb_mod_mask_t mods =
-            xkb_state_serialize_mods(state, XKB_STATE_MODS_EFFECTIVE);
-        printf("modifiers: 0x%08"PRIx32, mods);
-        print_modifiers_names(state, XKB_STATE_MODS_EFFECTIVE, keycode,
-                                consumed_mode);
-        printf("\n");
+        if (changed) {
+            for (unsigned int k = 0; k < ARRAY_SIZE(types); k++) {
+                if (!(changed & types[k].component))
+                    continue;
+                const xkb_mod_mask_t mods =
+                    xkb_state_serialize_mods(state, types[k].component);
+                printf("%s-mods: 0x%08"PRIx32"; ", types[k].label, mods);
+            }
+        } else {
+            const xkb_mod_mask_t mods =
+                xkb_state_serialize_mods(state, XKB_STATE_MODS_EFFECTIVE);
+            printf("modifiers: 0x%08"PRIx32, mods);
+            print_modifiers_names(state, XKB_STATE_MODS_EFFECTIVE, keycode,
+                                  consumed_mode);
+            printf("\n");
+        }
     }
 }
 
@@ -211,6 +237,8 @@ static void
 print_layouts(struct xkb_state *state, enum xkb_state_component changed,
               xkb_keycode_t keycode, bool verbose)
 {
+    struct xkb_keymap * const keymap = xkb_state_get_keymap(state);
+    static const char label[] = INDENT "layout: ";
     static const struct {
         enum xkb_state_component component;
         unsigned int padding;
@@ -221,13 +249,292 @@ print_layouts(struct xkb_state *state, enum xkb_state_component changed,
         { XKB_STATE_LAYOUT_LOCKED,    3, "locked"    },
         { XKB_STATE_LAYOUT_EFFECTIVE, 0, "effective" },
     };
-    for (unsigned int k = 0; k < ARRAY_SIZE(types); k++) {
-        if (!(changed & types[k].component))
-            continue;
-        const xkb_layout_index_t layout =
-            xkb_state_serialize_layout(state, types[k].component);
-        printf("%s-layout: %"PRId32"; ", types[k].label, layout);
+    if (verbose) {
+        printf("%s", label);
+        for (unsigned int k = 0; k < ARRAY_SIZE(types); k++) {
+            const xkb_layout_index_t layout =
+                xkb_state_serialize_layout(state, types[k].component);
+            const char * const changed_indicator = (changed)
+                ? (changed & types[k].component ? "*" : " ")
+                : "";
+            printf("%*s%s%s: %*s%"PRId32,
+                   (k == 0) ? 0 : (unsigned int) sizeof(label) - 1, "",
+                   changed_indicator, types[k].label,
+                   types[k].padding, "", layout);
+            if (types[k].component == XKB_STATE_LAYOUT_LOCKED ||
+                types[k].component == XKB_STATE_LAYOUT_EFFECTIVE)
+                printf(" \"%s\"\n", xkb_keymap_layout_get_name(keymap, layout));
+            else
+                printf("\n");
+        }
+    } else if (changed) {
+        for (unsigned int k = 0; k < ARRAY_SIZE(types); k++) {
+            if (!(changed & types[k].component))
+                continue;
+            const xkb_layout_index_t layout =
+                xkb_state_serialize_layout(state, types[k].component);
+            printf("%s-layout: %"PRId32"; ", types[k].label, layout);
+        }
     }
+    if (keycode != XKB_KEYCODE_INVALID) {
+        const xkb_layout_index_t layout =
+            xkb_state_key_get_layout(state, keycode);
+        if (verbose) {
+            printf("%*s%skey:       %"PRIu32" \"%s\"\n",
+                   (unsigned int) sizeof(label) - 1, "",
+                   (changed ? " " : ""),
+                   layout, xkb_keymap_layout_get_name(keymap, layout));
+        } else {
+            printf(INDENT "layout: %"PRIu32"  \"%s\"\n",
+                   layout, xkb_keymap_layout_get_name(keymap, layout));
+        }
+    }
+}
+
+static void
+print_leds(struct xkb_state *state, bool verbose) {
+    struct xkb_keymap * const keymap = xkb_state_get_keymap(state);
+    unsigned int count = 0;
+    for (xkb_led_index_t led = 0; led < xkb_keymap_num_leds(keymap); led++) {
+        if (xkb_state_led_index_is_active(state, led) <= 0)
+            continue;
+        if (count > 0)
+            printf(", ");
+        if (verbose) {
+            printf("%"PRIu32" \"%s\"",
+                   led, xkb_keymap_led_get_name(keymap, led));
+        } else {
+            printf("%s", xkb_keymap_led_get_name(keymap, led));
+        }
+        count++;
+    }
+}
+
+static void
+tools_print_detailed_keycode_state(const char *prefix,
+                                   struct xkb_state *state,
+                                   struct xkb_compose_state *compose_state,
+                                   xkb_keycode_t keycode,
+                                   enum xkb_key_direction direction,
+                                   enum xkb_consumed_mode consumed_mode,
+                                   enum print_state_options options)
+{
+    printf("------------\n");
+    if (prefix)
+        printf("%s", prefix);
+
+    struct xkb_keymap * const keymap = xkb_state_get_keymap(state);
+    const char * const keyname = xkb_keymap_key_get_name(keymap, keycode);
+    printf("key %s 0x%03"PRIx32" <%s>\n",
+           (direction == XKB_KEY_UP ? "up:  " : "down:"),
+           keycode, (keyname ? keyname : "(no name)"));
+
+    if (direction == XKB_KEY_UP)
+        return;
+
+    const xkb_layout_index_t layout = xkb_state_key_get_layout(state, keycode);
+
+    const bool verbose = options & PRINT_VERBOSE;
+
+    if (options & PRINT_LAYOUT)
+        print_layouts(state, 0, keycode, verbose);
+
+    if (verbose) {
+        print_modifiers(state, 0, keycode, true, consumed_mode, verbose);
+        printf(INDENT "level: %"PRIu32"\n",
+               xkb_state_key_get_level(state, keycode, layout));
+    } else {
+        printf(INDENT "level:  %"PRIu32",  ",
+               xkb_state_key_get_level(state, keycode, layout));
+        print_modifiers(state, 0, keycode, true, consumed_mode, verbose);
+    }
+
+    enum xkb_compose_status status = XKB_COMPOSE_NOTHING;
+    if (compose_state)
+        status = xkb_compose_state_get_status(compose_state);
+
+#define BUFFER_SIZE MAX(XKB_COMPOSE_MAX_STRING_SIZE, XKB_KEYSYM_NAME_MAX_SIZE)
+    static_assert(XKB_KEYSYM_UTF8_MAX_SIZE <= BUFFER_SIZE,
+                  "buffer too small");
+    char s[BUFFER_SIZE];
+#undef BUFFER_SIZE
+
+    bool show_unicode = false;
+    const xkb_keysym_t *syms;
+    const int nsyms = xkb_state_key_get_syms(state, keycode, &syms);
+    if (nsyms > 0) {
+        show_unicode = true;
+        printf(INDENT "%skeysyms:",
+               (status == XKB_COMPOSE_NOTHING ? "" : "raw "));
+        for (int i = 0; i < nsyms; i++) {
+            xkb_keysym_get_name(syms[i], s, sizeof(s));
+            printf(" %s", s);
+        }
+    }
+
+    switch (status) {
+    case XKB_COMPOSE_NOTHING:
+        break;
+    case XKB_COMPOSE_COMPOSING:
+        printf("\n" INDENT "compose: pending\n");
+        show_unicode = false;
+        break;
+    case XKB_COMPOSE_COMPOSED: {
+            const xkb_keysym_t sym = xkb_compose_state_get_one_sym(compose_state);
+            xkb_keysym_get_name(sym, s, sizeof(s));
+        printf("\n" INDENT "composed: %s", s);
+        show_unicode = true;
+        break;
+    }
+    case XKB_COMPOSE_CANCELLED:
+        printf("\n" INDENT "compose: cancelled\n");
+        show_unicode = false;
+        break;
+    default:
+        fprintf(stderr, "\nERROR: Unexpected compose state: %d\n", status);
+        assert(!"Unexpected compose state");
+    }
+
+    if ((options & PRINT_UNICODE) && show_unicode) {
+        if (status == XKB_COMPOSE_COMPOSED)
+            xkb_compose_state_get_utf8(compose_state, s, sizeof(s));
+        else
+            xkb_state_key_get_utf8(state, keycode, s, sizeof(s));
+        if (!*s) {
+            printf("\n");
+        } else {
+            /*
+             * HACK: escape single control characters from C0 set using the
+             * Unicode codepoint convention. Ideally we would like to escape
+             * any non-printable character in the string.
+             */
+            if (strlen(s) == 1 && (*s <= 0x1F || *s == 0x7F))
+                printf(" (");
+            else
+                printf(" \"%s\" (", s);
+
+            /* Print Unicode code points */
+            size_t offset = 0;
+            size_t count = 0;
+            uint32_t cp = utf8_next_code_point(s, sizeof(s), &offset);
+            while (cp && cp != INVALID_UTF8_CODE_POINT) {
+                if (count++ > 0)
+                    printf(" ");
+                printf("U+%04"PRIX32, cp);
+                cp = utf8_next_code_point(s + offset, sizeof(s) - offset,
+                                          &offset);
+            }
+            printf(", %zu code point%s)\n", count, (count > 1 ? "s" : ""));
+        }
+    } else if (show_unicode) {
+        printf("\n");
+    }
+
+    printf(INDENT "LEDs: ");
+    print_leds(state, true);
+    printf("\n");
+}
+
+static void
+tools_print_one_liner_keycode_state(const char *prefix,
+                                    struct xkb_state *state,
+                                    struct xkb_compose_state *compose_state,
+                                    xkb_keycode_t keycode,
+                                    enum xkb_key_direction direction,
+                                    enum xkb_consumed_mode consumed_mode,
+                                    enum print_state_options options)
+{
+    if (prefix)
+        printf("%s", prefix);
+
+    struct xkb_keymap * const keymap = xkb_state_get_keymap(state);
+    printf("key %s", (direction == XKB_KEY_UP ? "up  " : "down"));
+    print_keycode(keymap, " [ ", keycode, " ] ");
+
+    if (direction == XKB_KEY_UP)
+        return;
+
+    const xkb_keysym_t *syms;
+    int nsyms = xkb_state_key_get_syms(state, keycode, &syms);
+
+    if (nsyms <= 0)
+        return;
+
+    enum xkb_compose_status status = XKB_COMPOSE_NOTHING;
+    if (compose_state)
+        status = xkb_compose_state_get_status(compose_state);
+
+    xkb_keysym_t sym;
+    if (status == XKB_COMPOSE_COMPOSED) {
+        sym = xkb_compose_state_get_one_sym(compose_state);
+        syms = &sym;
+        nsyms = 1;
+    } else if (nsyms == 1) {
+        sym = xkb_state_key_get_one_sym(state, keycode);
+        syms = &sym;
+    }
+
+#define BUFFER_SIZE MAX(XKB_COMPOSE_MAX_STRING_SIZE, XKB_KEYSYM_NAME_MAX_SIZE)
+    static_assert(XKB_KEYSYM_UTF8_MAX_SIZE <= BUFFER_SIZE,
+                  "buffer too small");
+    char s[BUFFER_SIZE];
+#undef BUFFER_SIZE
+
+    printf("keysyms [ ");
+    for (int i = 0; i < nsyms; i++) {
+        xkb_keysym_get_name(syms[i], s, sizeof(s));
+        printf("%-*s ", XKB_KEYSYM_NAME_MAX_SIZE, s);
+    }
+    printf("] ");
+
+    if (!(options & PRINT_UNICODE)) {
+        /* Do nothing */
+    } else if (status == XKB_COMPOSE_COMPOSING) {
+        printf("composing [  ] ");
+    } else if (status == XKB_COMPOSE_CANCELLED) {
+        printf("cancelled [  ] ");
+    } else {
+        assert(status == XKB_COMPOSE_NOTHING || status == XKB_COMPOSE_COMPOSED);
+        if (status == XKB_COMPOSE_COMPOSED) {
+            printf("composed ");
+            xkb_compose_state_get_utf8(compose_state, s, sizeof(s));
+        } else {
+            printf("unicode ");
+            if (compose_state)
+                printf(" ");
+            xkb_state_key_get_utf8(state, keycode, s, sizeof(s));
+        }
+        if (!*s) {
+            printf("[   ] ");
+        } else if (strlen(s) == 1 && (*s <= 0x1F || *s == 0x7F)) {
+            /*
+             * HACK: escape single control characters from C0 set using the
+             * Unicode codepoint convention. Ideally we would like to escape
+             * any non-printable character in the string.
+             */
+            printf("[ U+%04hX ] ", *s);
+        } else {
+            printf("[ %s ] ", s);
+        }
+    }
+
+    const xkb_layout_index_t layout = xkb_state_key_get_layout(state, keycode);
+    if (options & PRINT_LAYOUT) {
+        printf("layout [ #%"PRIu32" %s ] ",
+               layout, xkb_keymap_layout_get_name(keymap, layout));
+    }
+
+    printf("level [ %"PRIu32" ] ",
+           xkb_state_key_get_level(state, keycode, layout));
+
+    printf("mods [");
+    print_modifiers_names(state, XKB_STATE_MODS_EFFECTIVE, keycode,
+                          consumed_mode);
+    printf(" ] ");
+
+    printf("leds [ ");
+    print_leds(state, false);
+    printf(" ] ");
 }
 
 void
@@ -237,131 +544,71 @@ tools_print_keycode_state(const char *prefix,
                           xkb_keycode_t keycode,
                           enum xkb_key_direction direction,
                           enum xkb_consumed_mode consumed_mode,
-                          print_state_fields_mask_t fields)
+                          enum print_state_options options)
 {
-    xkb_keysym_t sym;
-#define BUFFER_SIZE MAX(XKB_COMPOSE_MAX_STRING_SIZE, XKB_KEYSYM_NAME_MAX_SIZE)
-    static_assert(XKB_KEYSYM_UTF8_MAX_SIZE <= BUFFER_SIZE,
-                  "buffer too small");
-    char s[BUFFER_SIZE];
-#undef BUFFER_SIZE
-    xkb_layout_index_t layout;
-    enum xkb_compose_status status;
 
-    struct xkb_keymap * const keymap = xkb_state_get_keymap(state);
+    if (keycode == XKB_KEYCODE_INVALID)
+        return;
 
-    if (prefix)
-        printf("%s", prefix);
-    printf("key %s", (direction == XKB_KEY_UP ? "up  " : "down"));
-    print_keycode(keymap, " [ ", keycode, " ] ");
-
-    if (direction == XKB_KEY_UP)
-        goto out;
-
-    const xkb_keysym_t *syms;
-    int nsyms = xkb_state_key_get_syms(state, keycode, &syms);
-
-    if (nsyms <= 0)
-        goto out;
-
-    status = XKB_COMPOSE_NOTHING;
-    if (compose_state)
-        status = xkb_compose_state_get_status(compose_state);
-
-    if (status == XKB_COMPOSE_COMPOSING || status == XKB_COMPOSE_CANCELLED)
-        goto out;
-
-    if (status == XKB_COMPOSE_COMPOSED) {
-        sym = xkb_compose_state_get_one_sym(compose_state);
-        syms = &sym;
-        nsyms = 1;
+    if (options & PRINT_UNILINE) {
+        tools_print_one_liner_keycode_state(
+            prefix, state, compose_state, keycode, direction,
+            consumed_mode, options
+        );
+        printf("\n");
+    } else {
+        tools_print_detailed_keycode_state(
+            prefix, state, compose_state, keycode, direction,
+            consumed_mode, options
+        );
     }
-    else if (nsyms == 1) {
-        sym = xkb_state_key_get_one_sym(state, keycode);
-        syms = &sym;
-    }
-
-    if (prefix)
-        printf("%s", prefix);
-
-    print_keycode(keymap, "keycode [ ", keycode, " ] ");
-
-    printf("keysyms [ ");
-    for (int i = 0; i < nsyms; i++) {
-        xkb_keysym_get_name(syms[i], s, sizeof(s));
-        printf("%-*s ", XKB_KEYSYM_NAME_MAX_SIZE, s);
-    }
-    printf("] ");
-
-    if (fields & PRINT_UNICODE) {
-        if (status == XKB_COMPOSE_COMPOSED)
-            xkb_compose_state_get_utf8(compose_state, s, sizeof(s));
-        else
-            xkb_state_key_get_utf8(state, keycode, s, sizeof(s));
-        /* HACK: escape single control characters from C0 set using the
-        * Unicode codepoint convention. Ideally we would like to escape
-        * any non-printable character in the string.
-        */
-        if (!*s) {
-            printf("unicode [   ] ");
-        } else if (strlen(s) == 1 && (*s <= 0x1F || *s == 0x7F)) {
-            printf("unicode [ U+%04hX ] ", *s);
-        } else {
-            printf("unicode [ %s ] ", s);
-        }
-    }
-
-    layout = xkb_state_key_get_layout(state, keycode);
-    if (fields & PRINT_LAYOUT) {
-        printf("layout [ %s (%"PRIu32") ] ",
-               xkb_keymap_layout_get_name(keymap, layout), layout);
-    }
-
-    printf("level [ %"PRIu32" ] ",
-           xkb_state_key_get_level(state, keycode, layout));
-
-    printf("mods [ ");
-    for (xkb_mod_index_t mod = 0; mod < xkb_keymap_num_mods(keymap); mod++) {
-        if (xkb_state_mod_index_is_active(state, mod,
-                                          XKB_STATE_MODS_EFFECTIVE) <= 0)
-            continue;
-        if (xkb_state_mod_index_is_consumed2(state, keycode, mod,
-                                             consumed_mode))
-            printf("-%s ", xkb_keymap_mod_get_name(keymap, mod));
-        else
-            printf("%s ", xkb_keymap_mod_get_name(keymap, mod));
-    }
-    printf("] ");
-
-    printf("leds [ ");
-    for (xkb_led_index_t led = 0; led < xkb_keymap_num_leds(keymap); led++) {
-        if (xkb_state_led_index_is_active(state, led) <= 0)
-            continue;
-        printf("%s ", xkb_keymap_led_get_name(keymap, led));
-    }
-    printf("] ");
-
-out:
-    printf("\n");
 }
 
 void
 tools_print_state_changes(const char *prefix, struct xkb_state *state,
-                          enum xkb_state_component changed)
+                          enum xkb_state_component changed,
+                          enum print_state_options options)
 {
     if (changed == 0)
         return;
 
     if (prefix)
         printf("%s", prefix);
-    printf("state    [ ");
-    print_layouts(state, changed, XKB_KEYCODE_INVALID, false);
-    print_modifiers(state, changed, XKB_KEYCODE_INVALID, false,
-                    XKB_CONSUMED_MODE_XKB /* unused*/, false);
-    if (changed & XKB_STATE_LEDS)
-        printf("leds ");
-    printf("]\n");
+    if (options & PRINT_UNILINE) {
+        printf("state    [ ");
+        print_layouts(state, changed, XKB_KEYCODE_INVALID, false);
+        print_modifiers(state, changed, XKB_KEYCODE_INVALID, false,
+                        XKB_CONSUMED_MODE_XKB /* unused*/, false);
+        if (changed & XKB_STATE_LEDS)
+            printf("leds ");
+        printf("]\n");
+    } else {
+        printf("state changes:\n");
+
+        static const enum xkb_state_component mod_mask =
+            XKB_STATE_MODS_DEPRESSED | XKB_STATE_MODS_LATCHED |
+            XKB_STATE_MODS_LOCKED | XKB_STATE_MODS_EFFECTIVE;
+        if (changed & mod_mask) {
+            print_modifiers(state, changed, XKB_KEYCODE_INVALID,
+                            false, XKB_CONSUMED_MODE_XKB /* unused*/, true);
+        }
+
+        static const enum xkb_state_component layout_mask =
+            XKB_STATE_LAYOUT_DEPRESSED | XKB_STATE_LAYOUT_LATCHED |
+            XKB_STATE_LAYOUT_LOCKED | XKB_STATE_LAYOUT_EFFECTIVE;
+        if (changed & layout_mask) {
+            print_layouts(state, changed, XKB_KEYCODE_INVALID, true);
+        }
+
+        if (changed & XKB_STATE_LEDS) {
+            printf(INDENT "LEDs: ");
+            print_leds(state, true);
+            printf("\n");
+        }
+    }
 }
+
+#undef INDENT
 
 #ifdef _WIN32
 void

--- a/tools/tools-common.h
+++ b/tools/tools-common.h
@@ -48,7 +48,8 @@ tools_print_keycode_state(const char *prefix,
                           print_state_fields_mask_t fields);
 
 void
-tools_print_state_changes(enum xkb_state_component changed);
+tools_print_state_changes(const char *prefix, struct xkb_state *state,
+                          enum xkb_state_component changed);
 
 void
 tools_disable_stdin_echo(void);

--- a/tools/tools-common.h
+++ b/tools/tools-common.h
@@ -20,18 +20,20 @@
 #define ARRAY_SIZE(arr) ((sizeof(arr) / sizeof(*(arr))))
 
 /* Fields that are printed in the interactive tools. */
-enum print_state_fields {
-    PRINT_LAYOUT = (1u << 1),
-    PRINT_UNICODE = (1u << 2),
+enum print_state_options {
+    PRINT_LAYOUT = (1u << 0),
+    PRINT_UNICODE = (1u << 1),
     PRINT_ALL_FIELDS = ((PRINT_UNICODE << 1) - 1),
     /*
      * Fields that can be hidden with the option --short.
      * NOTE: If this value is modified, remember to update the documentation of
      *       the --short option in the corresponding tools.
      */
-    PRINT_VERBOSE_FIELDS = (PRINT_LAYOUT | PRINT_UNICODE)
+    PRINT_VERBOSE_ONE_LINE_FIELDS = (PRINT_LAYOUT | PRINT_UNICODE),
+    PRINT_VERBOSE = (1u << 2),
+    PRINT_UNILINE = (1u << 3),
+    DEFAULT_PRINT_OPTIONS = PRINT_ALL_FIELDS | PRINT_VERBOSE | PRINT_UNILINE
 };
-typedef uint32_t print_state_fields_mask_t;
 
 void
 print_modifiers_encodings(struct xkb_keymap *keymap);
@@ -45,11 +47,12 @@ tools_print_keycode_state(const char *prefix,
                           xkb_keycode_t keycode,
                           enum xkb_key_direction direction,
                           enum xkb_consumed_mode consumed_mode,
-                          print_state_fields_mask_t fields);
+                          enum print_state_options options);
 
 void
 tools_print_state_changes(const char *prefix, struct xkb_state *state,
-                          enum xkb_state_component changed);
+                          enum xkb_state_component changed,
+                          enum print_state_options options);
 
 void
 tools_disable_stdin_echo(void);

--- a/tools/tools-common.h
+++ b/tools/tools-common.h
@@ -43,6 +43,7 @@ tools_print_keycode_state(const char *prefix,
                           struct xkb_state *state,
                           struct xkb_compose_state *compose_state,
                           xkb_keycode_t keycode,
+                          enum xkb_key_direction direction,
                           enum xkb_consumed_mode consumed_mode,
                           print_state_fields_mask_t fields);
 

--- a/tools/xkbcli-interactive-evdev.1
+++ b/tools/xkbcli-interactive-evdev.1
@@ -94,8 +94,14 @@ Note that this option may affect the default values of the previous options.
 Specify a keymap path.
 This option is mutually exclusive with the RMLVO options.
 .
+.It Fl 1, \-uniline
+Enable uniline event output.
+.
+.It Fl 1, \-multiline
+Enable multiline event output.
+.
 .It Fl \-short
-Do not print layout nor Unicode keysym translation.
+Print shorter event output.
 .
 .It Fl \-report\-state\-changes
 Report changes to the keyboard state

--- a/tools/xkbcli-interactive-wayland.1
+++ b/tools/xkbcli-interactive-wayland.1
@@ -35,6 +35,12 @@ Specify the keymap format (numeric or label, e.g.\&
 .
 .It Fl \-enable\-compose
 Enable Compose functionality
+.
+.It Fl 1, \-uniline
+Enable uniline event output.
+.
+.It Fl 1, \-multiline
+Enable multiline event output.
 .El
 .
 .Sh SEE ALSO

--- a/tools/xkbcli-interactive-x11.1
+++ b/tools/xkbcli-interactive-x11.1
@@ -31,6 +31,12 @@ Print help and exit
 .
 .It Fl \-enable\-compose
 Enable Compose functionality
+.
+.It Fl 1, \-uniline
+Enable uniline event output.
+.
+.It Fl 1, \-multiline
+Enable multiline event output.
 .El
 .
 .Sh SEE ALSO


### PR DESCRIPTION
Improved the output of events for `xkbcli interactive-*` tools:
- Print key release events. This is particularly useful when analyzing the output sent by another person, in order to know the exact key sequence.
- Print detailed state change events.
- Added `--uniline` to enable uniline event output (default).
- Added `--multiline` to enable multiline event output.

TODO:
- [x] Split into smaller commits