### PR TITLE
logging: Encode verbosity values in an enum

### DIFF
--- a/bench/compose-traversal.c
+++ b/bench/compose-traversal.c
@@ -52,8 +52,7 @@ main(int argc, char *argv[])
     }
     free(path);
 
-    xkb_context_set_log_level(ctx, XKB_LOG_LEVEL_CRITICAL);
-    xkb_context_set_log_verbosity(ctx, 0);
+    xkb_enable_quiet_logging(ctx);
 
     table = xkb_compose_table_new_from_file(ctx, file, "",
                                             XKB_COMPOSE_FORMAT_TEXT_V1,

--- a/bench/compose.c
+++ b/bench/compose.c
@@ -36,8 +36,7 @@ main(void)
         return -1;
     }
 
-    xkb_context_set_log_level(ctx, XKB_LOG_LEVEL_CRITICAL);
-    xkb_context_set_log_verbosity(ctx, 0);
+    xkb_enable_quiet_logging(ctx);
 
     bench_start(&bench);
     for (int i = 0; i < BENCHMARK_ITERATIONS; i++) {

--- a/bench/key-proc.c
+++ b/bench/key-proc.c
@@ -8,9 +8,9 @@
 #include <stdlib.h>
 #include <time.h>
 
+#include "xkbcommon/xkbcommon.h"
 #include "../test/test.h"
 #include "bench.h"
-#include "xkbcommon/xkbcommon.h"
 
 #define BENCHMARK_ITERATIONS 20000000
 
@@ -56,8 +56,7 @@ main(void)
     state = xkb_state_new(keymap);
     assert(state);
 
-    xkb_context_set_log_level(ctx, XKB_LOG_LEVEL_CRITICAL);
-    xkb_context_set_log_verbosity(ctx, 0);
+    xkb_enable_quiet_logging(ctx);
 
     srand((unsigned) time(NULL));
 

--- a/bench/rules.c
+++ b/bench/rules.c
@@ -162,8 +162,7 @@ main(int argc, char *argv[])
     if (!context)
         exit(EXIT_FAILURE);
 
-    xkb_context_set_log_level(context, XKB_LOG_LEVEL_CRITICAL);
-    xkb_context_set_log_verbosity(context, 0);
+    xkb_enable_quiet_logging(context);
 
     if (explicit_iterations) {
         stdev = 0;

--- a/bench/rulescomp.c
+++ b/bench/rulescomp.c
@@ -25,8 +25,7 @@ main(int argc, char *argv[])
     ctx = test_get_context(0);
     assert(ctx);
 
-    xkb_context_set_log_level(ctx, XKB_LOG_LEVEL_CRITICAL);
-    xkb_context_set_log_verbosity(ctx, 0);
+    xkb_enable_quiet_logging(ctx);
 
     bench_start(&bench);
     for (i = 0; i < BENCHMARK_ITERATIONS; i++) {

--- a/src/context.c
+++ b/src/context.c
@@ -14,8 +14,9 @@
 #include <sys/stat.h>
 
 #include "xkbcommon/xkbcommon.h"
-#include "utils.h"
 #include "context.h"
+#include "messages-codes.h"
+#include "utils.h"
 
 
 /**
@@ -256,7 +257,7 @@ log_verbosity(const char *verbosity) {
         return (int) v;
     }
 
-    return 0;
+    return XKB_LOG_VERBOSITY_DEFAULT;
 }
 
 /**
@@ -274,7 +275,7 @@ xkb_context_new(enum xkb_context_flags flags)
     ctx->refcnt = 1;
     ctx->log_fn = default_log_fn;
     ctx->log_level = XKB_LOG_LEVEL_ERROR;
-    ctx->log_verbosity = 0;
+    ctx->log_verbosity = XKB_LOG_VERBOSITY_DEFAULT;
     ctx->use_environment_names = !(flags & XKB_CONTEXT_NO_ENVIRONMENT_NAMES);
     ctx->use_secure_getenv = !(flags & XKB_CONTEXT_NO_SECURE_GETENV);
 

--- a/src/context.h
+++ b/src/context.h
@@ -106,17 +106,17 @@ xkb_context_sanitize_rule_names(struct xkb_context *ctx,
 #define xkb_log_with_code(ctx, level, verbosity, msg_id, fmt, ...) \
     xkb_log(ctx, level, verbosity, PREPEND_MESSAGE_ID(msg_id, fmt), ##__VA_ARGS__)
 #define log_dbg(ctx, id, ...) \
-    xkb_log_with_code((ctx), XKB_LOG_LEVEL_DEBUG, 0, id, __VA_ARGS__)
+    xkb_log_with_code((ctx), XKB_LOG_LEVEL_DEBUG, XKB_LOG_VERBOSITY_MINIMAL, id, __VA_ARGS__)
 #define log_info(ctx, id, ...) \
-    xkb_log_with_code((ctx), XKB_LOG_LEVEL_INFO, 0, id, __VA_ARGS__)
+    xkb_log_with_code((ctx), XKB_LOG_LEVEL_INFO, XKB_LOG_VERBOSITY_MINIMAL, id, __VA_ARGS__)
 #define log_warn(ctx, id, ...) \
-    xkb_log_with_code((ctx), XKB_LOG_LEVEL_WARNING, 0, id, __VA_ARGS__)
+    xkb_log_with_code((ctx), XKB_LOG_LEVEL_WARNING, XKB_LOG_VERBOSITY_MINIMAL, id, __VA_ARGS__)
 #define log_vrb(ctx, vrb, id, ...) \
     xkb_log_with_code((ctx), XKB_LOG_LEVEL_WARNING, (vrb), id, __VA_ARGS__)
 #define log_err(ctx, id, ...) \
-    xkb_log_with_code((ctx), XKB_LOG_LEVEL_ERROR, 0, id, __VA_ARGS__)
+    xkb_log_with_code((ctx), XKB_LOG_LEVEL_ERROR, XKB_LOG_VERBOSITY_MINIMAL, id, __VA_ARGS__)
 #define log_wsgo(ctx, id, ...) \
-    xkb_log_with_code((ctx), XKB_LOG_LEVEL_CRITICAL, 0, id, __VA_ARGS__)
+    xkb_log_with_code((ctx), XKB_LOG_LEVEL_CRITICAL, XKB_LOG_VERBOSITY_MINIMAL, id, __VA_ARGS__)
 
 /*
  * Variants which are prefixed by the name of the function they're

--- a/src/messages-codes.h
+++ b/src/messages-codes.h
@@ -36,6 +36,19 @@
 #define PREPEND_MESSAGE_ID(id, fmt) JOIN(FORMAT_MESSAGE_, CHECK_ID(id))(id, fmt)
 
 /**
+ * Set of verbosity levels
+ */
+enum xkb_log_verbosity {
+    XKB_LOG_VERBOSITY_SILENT = -1,
+    XKB_LOG_VERBOSITY_MINIMAL = 0,
+    XKB_LOG_VERBOSITY_BRIEF = 1,
+    XKB_LOG_VERBOSITY_DETAILED = 5,
+    XKB_LOG_VERBOSITY_VERBOSE = 10,
+    XKB_LOG_VERBOSITY_COMPREHENSIVE = 11,
+    XKB_LOG_VERBOSITY_DEFAULT = XKB_LOG_VERBOSITY_MINIMAL,
+};
+
+/**
  * Special case when no message identifier is defined.
  */
 #define XKB_LOG_MESSAGE_NO_ID 0

--- a/src/messages-codes.h.jinja
+++ b/src/messages-codes.h.jinja
@@ -36,6 +36,19 @@
 #define PREPEND_MESSAGE_ID(id, fmt) JOIN(FORMAT_MESSAGE_, CHECK_ID(id))(id, fmt)
 
 /**
+ * Set of verbosity levels
+ */
+enum xkb_log_verbosity {
+    XKB_LOG_VERBOSITY_SILENT = -1,
+    XKB_LOG_VERBOSITY_MINIMAL = 0,
+    XKB_LOG_VERBOSITY_BRIEF = 1,
+    XKB_LOG_VERBOSITY_DETAILED = 5,
+    XKB_LOG_VERBOSITY_VERBOSE = 10,
+    XKB_LOG_VERBOSITY_COMPREHENSIVE = 11,
+    XKB_LOG_VERBOSITY_DEFAULT = XKB_LOG_VERBOSITY_MINIMAL,
+};
+
+/**
  * Special case when no message identifier is defined.
  */
 #define XKB_LOG_MESSAGE_NO_ID 0

--- a/src/scanner-utils.h
+++ b/src/scanner-utils.h
@@ -87,13 +87,13 @@ scanner_token_location(struct scanner *s);
                       loc.column, ##__VA_ARGS__);                                   \
 } while(0)
 
-#define scanner_err(scanner, id, fmt, ...)                     \
-    scanner_log_with_code(scanner, XKB_LOG_LEVEL_ERROR, 0, id, \
-                          fmt, ##__VA_ARGS__)
+#define scanner_err(scanner, id, fmt, ...)              \
+    scanner_log_with_code(scanner, XKB_LOG_LEVEL_ERROR, \
+                          XKB_LOG_VERBOSITY_MINIMAL, id, fmt, ##__VA_ARGS__)
 
-#define scanner_warn(scanner, id, fmt, ...)                      \
-    scanner_log_with_code(scanner, XKB_LOG_LEVEL_WARNING, 0, id, \
-                          fmt, ##__VA_ARGS__)
+#define scanner_warn(scanner, id, fmt, ...)               \
+    scanner_log_with_code(scanner, XKB_LOG_LEVEL_WARNING, \
+                          XKB_LOG_VERBOSITY_MINIMAL, id, fmt, ##__VA_ARGS__)
 
 #define scanner_vrb(scanner, verbosity, id, fmt, ...)                    \
     scanner_log_with_code(scanner, XKB_LOG_LEVEL_WARNING, verbosity, id, \

--- a/src/xkbcomp/action.c
+++ b/src/xkbcomp/action.c
@@ -945,7 +945,7 @@ SetDefaultActionField(struct xkb_context *ctx, enum xkb_keymap_format format,
      */
     if (!action_equal(into, &from)) {
         const bool replace = (merge != MERGE_AUGMENT);
-        log_vrb(ctx, 9, XKB_LOG_MESSAGE_NO_ID,
+        log_vrb(ctx, XKB_LOG_VERBOSITY_VERBOSE, XKB_LOG_MESSAGE_NO_ID,
                 "Conflicting field \"%s\" for default action \"%s\"; "
                 "Using %s, ignore %s\n",
                 fieldText(action_field), ActionTypeText(action),

--- a/src/xkbcomp/keycodes.c
+++ b/src/xkbcomp/keycodes.c
@@ -615,7 +615,7 @@ CopyKeyAliasesToKeymap(struct xkb_keymap *keymap, KeyNamesInfo *info)
     darray_foreach(alias, info->aliases) {
         /* Check that ->real is a key. */
         if (!XkbKeyByName(keymap, alias->real, false)) {
-            log_vrb(info->ctx, 5,
+            log_vrb(info->ctx, XKB_LOG_VERBOSITY_DETAILED,
                     XKB_WARNING_UNDEFINED_KEYCODE,
                     "Attempt to alias %s to non-existent key %s; Ignored\n",
                     KeyNameText(info->ctx, alias->alias),
@@ -626,7 +626,7 @@ CopyKeyAliasesToKeymap(struct xkb_keymap *keymap, KeyNamesInfo *info)
 
         /* Check that ->alias is not a key. */
         if (XkbKeyByName(keymap, alias->alias, false)) {
-            log_vrb(info->ctx, 5,
+            log_vrb(info->ctx, XKB_LOG_VERBOSITY_DETAILED,
                     XKB_WARNING_ILLEGAL_KEYCODE_ALIAS,
                     "Attempt to create alias with the name of a real key; "
                     "Alias \"%s = %s\" ignored\n",

--- a/src/xkbcomp/keymap.c
+++ b/src/xkbcomp/keymap.c
@@ -461,7 +461,7 @@ CompileKeymap(XkbFile *file, struct xkb_keymap *keymap)
         if (file->file_type < FIRST_KEYMAP_FILE_TYPE ||
             file->file_type > LAST_KEYMAP_FILE_TYPE) {
             if (file->file_type == FILE_TYPE_GEOMETRY) {
-                log_vrb(ctx, 1,
+                log_vrb(ctx, XKB_LOG_VERBOSITY_BRIEF,
                         XKB_WARNING_UNSUPPORTED_GEOMETRY_SECTION,
                         "Geometry sections are not supported; ignoring\n");
             } else {

--- a/src/xkbcomp/parser.y
+++ b/src/xkbcomp/parser.y
@@ -1067,7 +1067,7 @@ parse(struct xkb_context *ctx, struct scanner *scanner, const char *map)
     }
 
     if (first)
-        log_vrb(ctx, 5,
+        log_vrb(ctx, XKB_LOG_VERBOSITY_DETAILED,
                 XKB_WARNING_MISSING_DEFAULT_SECTION,
                 "No map in include statement, but \"%s\" contains several; "
                 "Using first defined map, \"%s\"\n",

--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -1321,7 +1321,7 @@ expand_qualifier_in_kccgst_value(
     if ((*i + 3 <= value.len || is_merge_mode_prefix(str[*i + 3])) &&
         str[*i] == 'a' && str[*i+1] == 'l' && str[*i+2] == 'l') {
         if (has_layout_idx_range)
-            scanner_vrb(s, 2, XKB_LOG_MESSAGE_NO_ID,
+            scanner_vrb(s, XKB_LOG_VERBOSITY_DETAILED, XKB_LOG_MESSAGE_NO_ID,
                         "Using :all qualifier with indices range "
                         "is not recommended.");
         /* Add at least one layout */

--- a/src/xkbcomp/symbols.c
+++ b/src/xkbcomp/symbols.c
@@ -1065,7 +1065,8 @@ SetSymbolsField(SymbolsInfo *info, KeyInfo *keyi, const char *field,
     else if (istreq(field, "locking") ||
              istreq(field, "lock") ||
              istreq(field, "locks")) {
-        log_vrb(info->ctx, 1, XKB_WARNING_UNSUPPORTED_SYMBOLS_FIELD,
+        log_vrb(info->ctx, XKB_LOG_VERBOSITY_BRIEF,
+                XKB_WARNING_UNSUPPORTED_SYMBOLS_FIELD,
                 "Key behaviors not supported; "
                 "Ignoring locking specification for key %s\n",
                 KeyInfoText(info, keyi));
@@ -1073,14 +1074,16 @@ SetSymbolsField(SymbolsInfo *info, KeyInfo *keyi, const char *field,
     else if (istreq(field, "radiogroup") ||
              istreq(field, "permanentradiogroup") ||
              istreq(field, "allownone")) {
-        log_vrb(info->ctx, 1, XKB_WARNING_UNSUPPORTED_SYMBOLS_FIELD,
+        log_vrb(info->ctx, XKB_LOG_VERBOSITY_BRIEF,
+                XKB_WARNING_UNSUPPORTED_SYMBOLS_FIELD,
                 "Radio groups not supported; "
                 "Ignoring radio group specification for key %s\n",
                 KeyInfoText(info, keyi));
     }
     else if (istreq_prefix("overlay", field) ||
              istreq_prefix("permanentoverlay", field)) {
-        log_vrb(info->ctx, 1, XKB_WARNING_UNSUPPORTED_SYMBOLS_FIELD,
+        log_vrb(info->ctx, XKB_LOG_VERBOSITY_BRIEF,
+                XKB_WARNING_UNSUPPORTED_SYMBOLS_FIELD,
                 "Overlays not supported; "
                 "Ignoring overlay specification for key %s\n",
                 KeyInfoText(info, keyi));
@@ -1163,7 +1166,8 @@ SetGroupName(SymbolsInfo *info, ExprDef *arrayNdx, ExprDef *value,
              enum merge_mode merge)
 {
     if (!arrayNdx) {
-        log_vrb(info->ctx, 1, XKB_WARNING_MISSING_SYMBOLS_GROUP_NAME_INDEX,
+        log_vrb(info->ctx, XKB_LOG_VERBOSITY_BRIEF,
+                XKB_WARNING_MISSING_SYMBOLS_GROUP_NAME_INDEX,
                 "You must specify an index when specifying a group name; "
                 "Group name definition without array subscript ignored\n");
         return false;
@@ -1677,7 +1681,8 @@ CopySymbolsDefToKeymap(struct xkb_keymap *keymap, SymbolsInfo *info,
      */
     key = XkbKeyByName(keymap, keyi->name, false);
     if (!key) {
-        log_vrb(info->ctx, 5, XKB_WARNING_UNDEFINED_KEYCODE,
+        log_vrb(info->ctx, XKB_LOG_VERBOSITY_DETAILED,
+                XKB_WARNING_UNDEFINED_KEYCODE,
                 "Key %s not found in keycodes; Symbols ignored\n",
                 KeyInfoText(info, keyi));
         return false;
@@ -1732,7 +1737,8 @@ CopySymbolsDefToKeymap(struct xkb_keymap *keymap, SymbolsInfo *info,
         if (type->num_levels < darray_size(groupi->levels)) {
             struct xkb_level *leveli;
 
-            log_vrb(info->ctx, 1, XKB_WARNING_EXTRA_SYMBOLS_IGNORED,
+            log_vrb(info->ctx, XKB_LOG_VERBOSITY_BRIEF,
+                    XKB_WARNING_EXTRA_SYMBOLS_IGNORED,
                     "Type \"%s\" has %"PRIu32" levels, but %s has %u levels; "
                     "Ignoring extra symbols\n",
                     xkb_atom_text(keymap->ctx, type->name), type->num_levels,
@@ -1834,7 +1840,8 @@ CopyModMapDefToKeymap(struct xkb_keymap *keymap, SymbolsInfo *info,
     if (!entry->haveSymbol) {
         key = XkbKeyByName(keymap, entry->u.keyName, true);
         if (!key) {
-            log_vrb(info->ctx, 5, XKB_WARNING_UNDEFINED_KEYCODE,
+            log_vrb(info->ctx, XKB_LOG_VERBOSITY_DETAILED,
+                    XKB_WARNING_UNDEFINED_KEYCODE,
                     "Key %s not found in keycodes; "
                     "Modifier map entry for %s not updated\n",
                     KeyNameText(info->ctx, entry->u.keyName),
@@ -1845,7 +1852,8 @@ CopyModMapDefToKeymap(struct xkb_keymap *keymap, SymbolsInfo *info,
     else {
         key = FindKeyForSymbol(keymap, entry->u.keySym);
         if (!key) {
-            log_vrb(info->ctx, 5, XKB_WARNING_UNRESOLVED_KEYMAP_SYMBOL,
+            log_vrb(info->ctx, XKB_LOG_VERBOSITY_DETAILED,
+                    XKB_WARNING_UNRESOLVED_KEYMAP_SYMBOL,
                     "Key \"%s\" not found in symbol map; "
                     "Modifier map entry for %s not updated\n",
                     KeysymText(info->ctx, entry->u.keySym),

--- a/src/xkbcomp/types.c
+++ b/src/xkbcomp/types.c
@@ -145,7 +145,7 @@ AddKeyType(KeyTypesInfo *info, KeyTypeInfo *new, bool same_file)
         }
 
         if (same_file)
-            log_vrb(info->ctx, 4,
+            log_vrb(info->ctx, XKB_LOG_VERBOSITY_DETAILED,
                     XKB_WARNING_CONFLICTING_KEY_TYPE_DEFINITIONS,
                     "Multiple definitions of the %s key type; "
                     "Later definition ignored\n",
@@ -304,7 +304,8 @@ AddMapEntry(KeyTypesInfo *info, KeyTypeInfo *type,
                      (clobber ? old->level : new->level) + 1);
         }
         else {
-            log_vrb(info->ctx, 10, XKB_WARNING_CONFLICTING_KEY_TYPE_MAP_ENTRY,
+            log_vrb(info->ctx, XKB_LOG_VERBOSITY_VERBOSE,
+                    XKB_WARNING_CONFLICTING_KEY_TYPE_MAP_ENTRY,
                     "Multiple occurrences of map[%s]= %"PRIu32" in %s; Ignored\n",
                     MapEntryTxt(info, new), new->level + 1,
                     TypeTxt(info, type));
@@ -342,7 +343,8 @@ SetMapEntry(KeyTypesInfo *info, KeyTypeInfo *type, ExprDef *arrayNdx,
                                  type, "map entry", "modifier mask");
 
     if (entry.mods.mods & (~type->mods)) {
-        log_vrb(info->ctx, 1, XKB_WARNING_UNDECLARED_MODIFIERS_IN_KEY_TYPE,
+        log_vrb(info->ctx, XKB_LOG_VERBOSITY_BRIEF,
+                XKB_WARNING_UNDECLARED_MODIFIERS_IN_KEY_TYPE,
                 "Map entry for modifiers not used by type %s; "
                 "Using %s instead of %s\n",
                 TypeTxt(info, type),
@@ -385,7 +387,8 @@ AddPreserve(KeyTypesInfo *info, KeyTypeInfo *type,
 
         /* Map exists with same preserve; do nothing. */
         if (entry->preserve.mods == preserve_mods) {
-            log_vrb(info->ctx, 10, XKB_WARNING_DUPLICATE_ENTRY,
+            log_vrb(info->ctx, XKB_LOG_VERBOSITY_VERBOSE,
+                    XKB_WARNING_DUPLICATE_ENTRY,
                     "Identical definitions for preserve[%s] in %s; "
                     "Ignored\n",
                     ModMaskText(info->ctx, MOD_BOTH, &info->mods, mods),
@@ -394,7 +397,8 @@ AddPreserve(KeyTypesInfo *info, KeyTypeInfo *type,
         }
 
         /* Map exists with different preserve; latter wins. */
-        log_vrb(info->ctx, 1, XKB_WARNING_CONFLICTING_KEY_TYPE_PRESERVE_ENTRIES,
+        log_vrb(info->ctx, XKB_LOG_VERBOSITY_BRIEF,
+                XKB_WARNING_CONFLICTING_KEY_TYPE_PRESERVE_ENTRIES,
                 "Multiple definitions for preserve[%s] in %s; "
                 "Using %s, ignoring %s\n",
                 ModMaskText(info->ctx, MOD_BOTH, &info->mods, mods),
@@ -439,7 +443,8 @@ SetPreserve(KeyTypesInfo *info, KeyTypeInfo *type, ExprDef *arrayNdx,
         mods &= type->mods;
         after = ModMaskText(info->ctx, MOD_BOTH, &info->mods, mods);
 
-        log_vrb(info->ctx, 1, XKB_WARNING_UNDECLARED_MODIFIERS_IN_KEY_TYPE,
+        log_vrb(info->ctx, XKB_LOG_VERBOSITY_BRIEF,
+                XKB_WARNING_UNDECLARED_MODIFIERS_IN_KEY_TYPE,
                 "Preserve entry for modifiers not used by the %s type; "
                 "Index %s converted to %s\n",
                 TypeTxt(info, type), before, after);
@@ -463,7 +468,8 @@ SetPreserve(KeyTypesInfo *info, KeyTypeInfo *type, ExprDef *arrayNdx,
         preserve_mods &= mods;
         after = ModMaskText(info->ctx, MOD_BOTH, &info->mods, preserve_mods);
 
-        log_vrb(info->ctx, 1, XKB_WARNING_ILLEGAL_KEY_TYPE_PRESERVE_RESULT,
+        log_vrb(info->ctx, XKB_LOG_VERBOSITY_BRIEF,
+                XKB_WARNING_ILLEGAL_KEY_TYPE_PRESERVE_RESULT,
                 "Illegal value for preserve[%s] in type %s; "
                 "Converted %s to %s\n",
                 ModMaskText(info->ctx, MOD_BOTH, &info->mods, mods),
@@ -487,7 +493,7 @@ AddLevelName(KeyTypesInfo *info, KeyTypeInfo *type,
 
     /* Same level, same name. */
     if (darray_item(type->level_names, level) == name) {
-        log_vrb(info->ctx, 10, XKB_WARNING_DUPLICATE_ENTRY,
+        log_vrb(info->ctx, XKB_LOG_VERBOSITY_VERBOSE, XKB_WARNING_DUPLICATE_ENTRY,
                 "Duplicate names for level %"PRIu32" of key type %s; Ignored\n",
                 level + 1, TypeTxt(info, type));
         return true;
@@ -499,7 +505,8 @@ AddLevelName(KeyTypesInfo *info, KeyTypeInfo *type,
         old = xkb_atom_text(info->ctx,
                             darray_item(type->level_names, level));
         new = xkb_atom_text(info->ctx, name);
-        log_vrb(info->ctx, 1, XKB_WARNING_CONFLICTING_KEY_TYPE_LEVEL_NAMES,
+        log_vrb(info->ctx, XKB_LOG_VERBOSITY_BRIEF,
+                XKB_WARNING_CONFLICTING_KEY_TYPE_LEVEL_NAMES,
                 "Multiple names for level %"PRIu32" of key type %s; "
                 "Using %s, ignoring %s\n",
                 level + 1, TypeTxt(info, type),

--- a/test/log.c
+++ b/test/log.c
@@ -82,7 +82,7 @@ test_basic(void)
     log_err(ctx, XKB_ERROR_MALFORMED_NUMBER_LITERAL, "second error: %lu\n", 115415UL);
     log_vrb(ctx, 6, XKB_LOG_MESSAGE_NO_ID, "second verbose 6\n");
 
-    xkb_context_set_log_verbosity(ctx, 0);
+    xkb_context_set_log_verbosity(ctx, XKB_LOG_VERBOSITY_MINIMAL);
     xkb_context_set_log_level(ctx, XKB_LOG_LEVEL_CRITICAL);
     log_warn(ctx, XKB_LOG_MESSAGE_NO_ID, "third warning: %d\n", 87);
     log_dbg(ctx, XKB_LOG_MESSAGE_NO_ID, "third debug: %s %s\n", "hello", "world");
@@ -123,7 +123,7 @@ test_keymaps(void)
     xkb_context_set_log_fn(ctx, log_fn);
 
     xkb_context_set_log_level(ctx, XKB_LOG_LEVEL_WARNING);
-    xkb_context_set_log_verbosity(ctx, 10);
+    xkb_context_set_log_verbosity(ctx, XKB_LOG_VERBOSITY_VERBOSE);
 
     const struct test_data keymaps[] = {
         {
@@ -331,7 +331,7 @@ test_compose(void)
     xkb_context_set_log_fn(ctx, log_fn);
 
     xkb_context_set_log_level(ctx, XKB_LOG_LEVEL_WARNING);
-    xkb_context_set_log_verbosity(ctx, 10);
+    xkb_context_set_log_verbosity(ctx, XKB_LOG_VERBOSITY_VERBOSE);
 
     const struct test_data composes[] = {
         {

--- a/test/test.h
+++ b/test/test.h
@@ -15,6 +15,7 @@
 #define _XKBCOMMON_COMPAT_H
 #include "xkbcommon/xkbcommon.h"
 #include "xkbcommon/xkbcommon-compose.h"
+#include "src/messages-codes.h"
 #include "utils.h"
 
 /* Automake test exit code to signify SKIP (à la PASS, FAIL, etc).
@@ -129,6 +130,12 @@ test_compile_rules(struct xkb_context *context, enum xkb_keymap_format format,
                    const char *rules, const char *model, const char *layout,
                    const char *variant, const char *options);
 
+static inline void
+xkb_enable_quiet_logging(struct xkb_context *ctx)
+{
+    xkb_context_set_log_level(ctx, XKB_LOG_LEVEL_CRITICAL);
+    xkb_context_set_log_verbosity(ctx, XKB_LOG_VERBOSITY_MINIMAL);
+}
 
 #ifdef _WIN32
 #define setenv(varname, value, overwrite) _putenv_s((varname), (value))

--- a/tools/compile-keymap.c
+++ b/tools/compile-keymap.c
@@ -537,10 +537,8 @@ main(int argc, char **argv)
     ctx = xkb_context_new(ctx_flags);
     assert(ctx);
 
-    if (verbose) {
-        xkb_context_set_log_level(ctx, XKB_LOG_LEVEL_DEBUG);
-        xkb_context_set_log_verbosity(ctx, 10);
-    }
+    if (verbose)
+        tools_enable_verbose_logging(ctx);
 
     if (num_includes == 0)
         includes[num_includes++] = DEFAULT_INCLUDE_PATH_PLACEHOLDER;

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -38,6 +38,7 @@
 #include "src/utf8-decoding.h"
 #include "src/keysym.h"
 #include "src/keymap.h"
+#include "src/messages-codes.h"
 
 #ifdef _WIN32
 #define S_ISFIFO(mode) 0
@@ -657,7 +658,7 @@ void
 tools_enable_verbose_logging(struct xkb_context *ctx)
 {
     xkb_context_set_log_level(ctx, XKB_LOG_LEVEL_DEBUG);
-    xkb_context_set_log_verbosity(ctx, 10);
+    xkb_context_set_log_verbosity(ctx, XKB_LOG_VERBOSITY_VERBOSE);
 }
 
 static inline bool


### PR DESCRIPTION
This enables to provide semantics and to ensure we use the values uniformly in the code base.

While one could expect that verbosity `0` silences the logging, it is actually our default verbosity level for a long time. So this commit does not change that in order to avoid possible breakage.

Silencing the logging is achieved by using a negative value for the verbosity level.