### PR TITLE
test: Improve Xorg xkbcomp handling

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1042,7 +1042,13 @@ if get_option('enable-x11')
     )
     test(
         'x11comp',
-        executable('test-x11comp', 'test/x11comp.c', dependencies: x11_xvfb_test_dep),
+        executable(
+            'test-x11comp',
+            'test/x11comp.c',
+            'test/utils-text.c',
+            'test/utils-text.h',
+            dependencies: x11_xvfb_test_dep
+        ),
         env: test_env,
         is_parallel : false,
     )

--- a/test/common.c
+++ b/test/common.c
@@ -285,15 +285,8 @@ test_get_path(const char *path_rel)
 }
 
 char *
-test_read_file(const char *path_rel)
+read_file(const char *path, FILE *file)
 {
-    char *path = test_get_path(path_rel);
-    if (!path)
-        return NULL;
-
-    FILE* file = fopen(path, "rb");
-    free(path);
-
     if (!file)
         return NULL;
 
@@ -317,16 +310,37 @@ test_read_file(const char *path_rel)
     const size_t count = fread(ret, sizeof(*ret), size, file);
     if (count != size) {
         if (!feof(file))
-            printf("Error reading file %s: unexpected end of file\n", path_rel);
+            printf("Error reading file %s: unexpected end of file\n", path);
         else if (ferror(file))
             perror("Error reading file");
         fclose(file);
         free(ret);
         return NULL;
     }
-    fclose(file);
     ret[count] = '\0';
 
+    return ret;
+}
+
+char *
+test_read_file(const char *path_rel)
+{
+    char *path = test_get_path(path_rel);
+    if (!path)
+        return NULL;
+
+    FILE* file = fopen(path, "rb");
+    char *ret = NULL;
+
+    if (!file)
+        goto out;
+
+    ret = read_file(path, file);
+
+out:
+    if (file)
+        fclose(file);
+    free(path);
     return ret;
 }
 

--- a/test/test.h
+++ b/test/test.h
@@ -74,6 +74,9 @@ char *
 test_get_path(const char *path_rel);
 
 char *
+read_file(const char *path, FILE *file);
+
+char *
 test_read_file(const char *path_rel);
 
 enum test_context_flags {

--- a/test/utils-text.c
+++ b/test/utils-text.c
@@ -68,7 +68,7 @@ strip_lines(const char *input, size_t input_length, const char *prefix)
     }
 
     darray_append(buf, '\0');
-    return buf.item;
+    return darray_items(buf);
 }
 
 char *
@@ -104,7 +104,7 @@ uncomment(const char *input, size_t input_length, const char *prefix)
     }
 
     darray_append(buf, '\0');
-    return buf.item;
+    return darray_items(buf);
 }
 
 /* Split string into lines */

--- a/test/x11comp.c
+++ b/test/x11comp.c
@@ -6,6 +6,7 @@
 #include "config.h"
 
 #include <assert.h>
+#include <getopt.h>
 #include <signal.h>
 #include <spawn.h>
 #include <stdint.h>
@@ -15,55 +16,175 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#include "test.h"
-#include "evdev-scancodes.h"
 #include "xkbcommon/xkbcommon.h"
 #include "xkbcommon/xkbcommon-keysyms.h"
 #include "xkbcommon/xkbcommon-names.h"
 #include "xkbcommon/xkbcommon-x11.h"
+
+#include "evdev-scancodes.h"
+#include "test.h"
+#include "tools/tools-common.h"
+#include "utils.h"
+#include "utils-text.h"
 #include "xvfb-wrapper.h"
 
 /* Offset between evdev keycodes (where KEY_ESCAPE is 1), and the evdev XKB
  * keycode set (where ESC is 9). */
 #define EVDEV_OFFSET 8
 
-X11_TEST(test_basic)
+enum update_files {
+    NO_UPDATE = 0,
+    UPDATE_USING_TEST_INPUT,
+    UPDATE_USING_TEST_OUTPUT
+};
+
+static enum update_files update_test_files = NO_UPDATE;
+
+
+static char *
+prepare_keymap(const char *original, bool strip_all_comments)
 {
-    struct xkb_keymap *keymap = NULL;
-    struct xkb_state *state = NULL;
-    xcb_connection_t *conn;
-    int32_t device_id;
-    int ret, status;
-    char *xkb_path;
-    char *original, *dump;
+    if (strip_all_comments) {
+        return strip_lines(original, strlen(original), "//");
+    } else {
+        char *tmp = uncomment(original, strlen(original), "//");
+        char *ret = strip_lines(tmp, strlen(tmp), "//");
+        free(tmp);
+        return ret;
+    }
+}
+
+/*
+ * Reset keymap to `empty` on the server.
+ * It seems that xkbcomp does not fully set the keymap on the server and
+ * the conflicting leftovers may raise errors.
+ */
+static int
+reset_keymap(const char* display)
+{
     char *envp[] = { NULL };
-    char *xkbcomp_argv[] = {
-        (char *) "xkbcomp", (char *) "-I", NULL /* xkb_path */, display, NULL
+    const char* setxkbmap_argv[] = {
+        "setxkbmap", "-display", display,
+        "-geometry", "pc",
+        "-keycodes", "evdev",
+        "-compat", "basic",
+        "-types", "basic+numpad", /* Avoid extra types */
+        "-symbols", "us",
+        // "-v", "10",
+        NULL
     };
+
+    /* Launch xkbcomp */
+    pid_t setxkbmap_pid;
+    int ret = posix_spawnp(&setxkbmap_pid, "setxkbmap", NULL, NULL,
+                           (char* const*)setxkbmap_argv, envp);
+    if (ret != 0) {
+        fprintf(stderr,
+                "[ERROR] Cannot run setxkbmap. posix_spawnp error %d: %s\n",
+                ret, strerror(ret));
+        if (ret == ENOENT) {
+            fprintf(stderr,
+                    "[ERROR] setxkbmap may be missing. "
+                    "Please install the corresponding package, "
+                    "e.g. \"setxkbmap\" or \"x11-xkb-utils\".\n");
+        }
+        return TEST_SETUP_FAILURE;
+    }
+    int status;
+    ret = waitpid(setxkbmap_pid, &status, 0);
+    return (ret < 0 || !WIFEXITED(status) || WEXITSTATUS(status) != 0)
+        ? TEST_SETUP_FAILURE
+        : EXIT_SUCCESS;
+}
+
+// TODO: unused for now
+// /* Use xkbcomp to load a keymap from a file */
+// static int
+// run_xkbcomp_file(const char* display, xcb_connection_t *conn, int32_t device_id,
+//                  const char *xkb_path)
+// {
+//     /* Prepare xkbcomp parameters */
+//     char *envp[] = { NULL };
+//     const char* xkbcomp_argv[] = {"xkbcomp", "-I", xkb_path, display, NULL};
+//
+//     /* Launch xkbcomp */
+//     pid_t xkbcomp_pid;
+//     int ret = posix_spawnp(&xkbcomp_pid, "xkbcomp", NULL, NULL,
+//                            (char* const*)xkbcomp_argv, envp);
+//     if (ret != 0) {
+//         fprintf(stderr,
+//                 "[ERROR] Cannot run xkbcomp. posix_spawnp error %d: %s\n",
+//                 ret, strerror(ret));
+//         if (ret == ENOENT) {
+//             fprintf(stderr,
+//                     "[ERROR] xkbcomp may be missing. "
+//                     "Please install the corresponding package, "
+//                     "e.g. \"xkbcomp\" or \"x11-xkb-utils\".\n");
+//         }
+//         return TEST_SETUP_FAILURE;
+//     }
+//
+//     /* Wait for xkbcomp to complete */
+//     int status;
+//     ret = waitpid(xkbcomp_pid, &status, 0);
+//     return (ret < 0 || !WIFEXITED(status) || WEXITSTATUS(status) != 0)
+//         ? TEST_SETUP_FAILURE
+//         : EXIT_SUCCESS;
+// }
+
+enum {
+    PIPE_READ  = 0,
+    PIPE_WRITE = 1
+};
+
+/* Use xkbcomp to load a keymap from a string */
+static int
+run_xkbcomp_str(const char* display, const char *include_path, const char *keymap)
+{
+    int ret = EXIT_FAILURE;
+    assert(keymap);
+
+    /* Prepare xkbcomp parameters */
+    char *envp[] = { NULL };
+    char include_path_arg[PATH_MAX+2] = "-I";
+    const char *xkbcomp_argv[] = {
+        "xkbcomp", "-I" /* reset include path*/, include_path_arg,
+        "-opt", "g", "-w", "10", "-" /* stdin */, display, NULL
+    };
+    if (include_path) {
+        ret = snprintf(include_path_arg, ARRAY_SIZE(include_path_arg),
+                       "-I%s", include_path);
+        if (ret < 0 || ret >= (int)ARRAY_SIZE(include_path_arg)) {
+            return TEST_SETUP_FAILURE;
+        }
+    }
+
+    /* Prepare input */
+    int stdin_pipe[2];
+    posix_spawn_file_actions_t action;
+    if (pipe(stdin_pipe) == -1) {
+        perror("pipe");
+        ret = TEST_SETUP_FAILURE;
+        goto pipe_error;
+    }
+    if (posix_spawn_file_actions_init(&action)) {
+        perror("spawn_file_actions_init error");
+        goto posix_spawn_file_actions_init_error;
+    }
+
+    /* Make spawned process close unused write-end of pipe, else it will not
+     * receive EOF when write-end of the pipe is closed below and it will result
+     * in a deadlock. */
+    if (posix_spawn_file_actions_addclose(&action, stdin_pipe[PIPE_WRITE]))
+        goto posix_spawn_file_actions_error;
+    /* Make spawned process replace stdin with read end of the pipe */
+    if (posix_spawn_file_actions_adddup2(&action, stdin_pipe[PIPE_READ], STDIN_FILENO))
+        goto posix_spawn_file_actions_error;
+
+    /* Launch xkbcomp */
     pid_t xkbcomp_pid;
-
-    conn = xcb_connect(display, NULL);
-    if (xcb_connection_has_error(conn)) {
-        ret = TEST_SETUP_FAILURE;
-        goto err_conn;
-    }
-    ret = xkb_x11_setup_xkb_extension(conn,
-                                      XKB_X11_MIN_MAJOR_XKB_VERSION,
-                                      XKB_X11_MIN_MINOR_XKB_VERSION,
-                                      XKB_X11_SETUP_XKB_EXTENSION_NO_FLAGS,
-                                      NULL, NULL, NULL, NULL);
-    if (!ret) {
-        ret = TEST_SETUP_FAILURE;
-        goto err_xcb;
-    }
-    device_id = xkb_x11_get_core_keyboard_device_id(conn);
-    assert(device_id != -1);
-
-    xkb_path = test_get_path("keymaps/host.xkb");
-    assert(ret >= 0);
-    xkbcomp_argv[2] = xkb_path;
-    ret = posix_spawnp(&xkbcomp_pid, "xkbcomp", NULL, NULL, xkbcomp_argv, envp);
-    free(xkb_path);
+    ret = posix_spawnp(&xkbcomp_pid, "xkbcomp", &action, NULL,
+                       (char* const*)xkbcomp_argv, envp);
     if (ret != 0) {
         fprintf(stderr,
                 "[ERROR] Cannot run xkbcomp. posix_spawnp error %d: %s\n",
@@ -74,42 +195,211 @@ X11_TEST(test_basic)
                     "Please install the corresponding package, "
                     "e.g. \"xkbcomp\" or \"x11-xkb-utils\".\n");
         }
-        ret = TEST_SETUP_FAILURE;
-        goto err_xcb;
+        goto posix_spawn_file_actions_init_error;
     }
+    /* Close unused read-end of pipe */
+    close(stdin_pipe[PIPE_READ]);
+    const ssize_t count = write(stdin_pipe[PIPE_WRITE], keymap, strlen(keymap));
+    /* Close write-end of the pipe, to emit EOF */
+    close(stdin_pipe[PIPE_WRITE]);
+    if (count == -1) {
+        perror("Cannot write keymap to stdin");
+        kill(xkbcomp_pid, SIGTERM);
+    }
+
+    /* Wait for xkbcomp to complete */
+    int status;
     ret = waitpid(xkbcomp_pid, &status, 0);
-    if (ret < 0 || !WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+    ret = (ret < 0 || !WIFEXITED(status) || WEXITSTATUS(status) != 0)
+        ? TEST_SETUP_FAILURE
+        : EXIT_SUCCESS;
+    goto cleanup;
+
+posix_spawn_file_actions_error:
+    perror("posix_spawn_file_actions_* error");
+posix_spawn_file_actions_init_error:
+    close(stdin_pipe[PIPE_WRITE]);
+    close(stdin_pipe[PIPE_READ]);
+    ret = TEST_SETUP_FAILURE;
+cleanup:
+    posix_spawn_file_actions_destroy(&action);
+pipe_error:
+    return ret;
+}
+
+// TODO: implement tests to ensure compatibility with xkbcomp
+// struct compile_buffer_private {
+//     const char* display;
+//     xcb_connection_t *conn;
+//     int32_t device_id;
+// };
+//
+// static struct xkb_keymap *
+// compile_buffer(struct xkb_context *ctx, const char *buf, size_t len,
+//                void *private)
+// {
+//     const struct compile_buffer_private *config = private;
+//     assert(buf[len - 1] == '\0');
+//
+//     char *include_path = test_get_path("");
+//     int ret = run_xkbcomp_str(config->display, config->conn,
+//                               config->device_id, include_path, buf);
+//     free(include_path);
+//
+//     if (ret != EXIT_SUCCESS)
+//         return NULL;
+//
+//     return xkb_x11_keymap_new_from_device(ctx, config->conn, config->device_id,
+//                                           XKB_KEYMAP_COMPILE_NO_FLAGS);
+// }
+
+static int
+test_keymap_roundtrip(struct xkb_context *ctx,
+                      const char* display, xcb_connection_t *conn,
+                      int32_t device_id, bool print_keymap, bool tweak,
+                      const char *keymap_path)
+{
+    /* Get raw keymap */
+    FILE *file = NULL;
+    if (isempty(keymap_path) || strcmp(keymap_path, "-") == 0) {
+        /* Read stdin */
+        file = tools_read_stdin();
+        if (!file)
+            return TEST_SETUP_FAILURE;
+    } else {
+        /* Read file from path */
+        file = fopen(keymap_path, "rb");
+        if (!file) {
+            perror("Unable to read file");
+            return TEST_SETUP_FAILURE;
+        }
+    }
+    char *original = read_file(keymap_path, file);
+    fclose(file);
+    if (!original)
+        return TEST_SETUP_FAILURE;
+
+    /* Pre-process keymap string */
+    char* expected = prepare_keymap(original, tweak);
+    free(original);
+    if (!expected) {
+        return TEST_SETUP_FAILURE;
+    }
+
+    /* Prepare X server */
+    int ret = reset_keymap(display);
+    if (ret != EXIT_SUCCESS) {
+#ifdef __APPLE__
+        /* Brew may not provide setxkbmap */
+#else
+        goto xkbcomp_error;
+#endif
+    }
+
+    /* Load keymap into X server */
+    ret = run_xkbcomp_str(display, NULL, expected);
+    if (ret != EXIT_SUCCESS)
+        goto xkbcomp_error;
+
+    /* Get keymap from X server */
+    struct xkb_keymap *keymap =
+        xkb_x11_keymap_new_from_device(ctx, conn, device_id,
+                                       XKB_KEYMAP_COMPILE_NO_FLAGS);
+    assert(keymap);
+    if (!keymap) {
+        ret = EXIT_FAILURE;
+        fprintf(stderr, "ERROR: Failed to get keymap from X server.\n");
+        goto xkbcomp_error;
+    }
+
+    /* Dump keymap and compare to expected */
+    char *got = xkb_keymap_get_as_string(keymap, XKB_KEYMAP_USE_ORIGINAL_FORMAT);
+    if (!got) {
+        ret = EXIT_FAILURE;
+        fprintf(stderr, "ERROR: Failed to dump keymap.\n");
+    } else {
+        if (print_keymap)
+            fprintf(stdout, "%s\n", got);
+        if (!streq(got, expected)) {
+            ret = EXIT_FAILURE;
+            fprintf(stderr,
+                    "ERROR: roundtrip failed. "
+                    "Lengths difference: got %zu, expected %zu.\n",
+                    strlen(got), strlen(expected));
+        } else {
+            ret = EXIT_SUCCESS;
+            fprintf(stderr, "Roundtrip succeed.\n");
+        }
+        free(got);
+    }
+
+    xkb_keymap_unref(keymap);
+xkbcomp_error:
+    free(expected);
+    return ret;
+}
+
+static int
+init_x11_connection(const char *display, xcb_connection_t **conn_rtrn,
+                    int32_t *device_id_rtrn)
+{
+    xcb_connection_t *conn = xcb_connect(display, NULL);
+    if (xcb_connection_has_error(conn)) {
+        return TEST_SETUP_FAILURE;
+    }
+
+    int ret = xkb_x11_setup_xkb_extension(conn,
+                                          XKB_X11_MIN_MAJOR_XKB_VERSION,
+                                          XKB_X11_MIN_MINOR_XKB_VERSION,
+                                          XKB_X11_SETUP_XKB_EXTENSION_NO_FLAGS,
+                                          NULL, NULL, NULL, NULL);
+    if (!ret)
+        goto err_xcb;
+
+    int32_t device_id = xkb_x11_get_core_keyboard_device_id(conn);
+    if (device_id == -1)
+        goto err_xcb;
+
+    *conn_rtrn = conn;
+    *device_id_rtrn = device_id;
+    return EXIT_SUCCESS;
+
+err_xcb:
+    xcb_disconnect(conn);
+    return TEST_SETUP_FAILURE;
+}
+
+X11_TEST(test_basic)
+{
+    if (update_test_files != NO_UPDATE)
+        return EXIT_SUCCESS;
+
+    xcb_connection_t *conn = NULL;
+    int32_t device_id = 0;
+    int ret = init_x11_connection(display, &conn, &device_id);
+    if (ret != EXIT_SUCCESS) {
         ret = TEST_SETUP_FAILURE;
         goto err_xcb;
     }
 
-    struct xkb_context *ctx = test_get_context(0);
-    keymap = xkb_x11_keymap_new_from_device(ctx, conn, device_id,
-                                            XKB_KEYMAP_COMPILE_NO_FLAGS);
-    assert(keymap);
+    struct xkb_context *ctx = test_get_context(CONTEXT_NO_FLAG);
+    assert(ctx);
 
-    original = test_read_file("keymaps/host.xkb");
-    assert(original);
+    char *keymap_path = test_get_path("keymaps/host.xkb");
+    assert(keymap_path);
+    ret = test_keymap_roundtrip(ctx, display, conn, device_id,
+                                false, false, keymap_path);
+    free(keymap_path);
+    assert(ret == EXIT_SUCCESS);
 
-    dump = xkb_keymap_get_as_string(keymap, XKB_KEYMAP_USE_ORIGINAL_FORMAT);
-    assert(dump);
-
-    if (!streq(original, dump)) {
-        fprintf(stderr,
-                "round-trip test failed: dumped map differs from original\n");
-        fprintf(stderr, "length: dumped %zu, original %zu\n",
-                strlen(dump),
-                strlen(original));
-        fprintf(stderr, "dumped map:\n");
-        fprintf(stderr, "%s\n", dump);
-        ret = 1;
-        goto err_dump;
-    }
-
-    state = xkb_x11_state_new_from_device(keymap, conn, device_id);
-    assert(state);
+    struct xkb_keymap *keymap =
+        xkb_x11_keymap_new_from_device(ctx, conn, device_id,
+                                       XKB_KEYMAP_COMPILE_NO_FLAGS);
 
     /* Check capitalization transformation */
+    struct xkb_state *state =
+        xkb_x11_state_new_from_device(keymap, conn, device_id);
+    assert(state);
     xkb_keysym_t sym;
     sym = xkb_state_key_get_one_sym(state, KEY_A + EVDEV_OFFSET);
     assert(sym == XKB_KEY_a);
@@ -124,22 +414,127 @@ X11_TEST(test_basic)
     assert(sym == XKB_KEY_A);
     sym = xkb_state_key_get_one_sym(state, KEY_LEFT + EVDEV_OFFSET);
     assert(sym == XKB_KEY_Left);
-
-    ret = EXIT_SUCCESS;
-err_dump:
-    free(original);
-    free(dump);
     xkb_state_unref(state);
+
     xkb_keymap_unref(keymap);
     xkb_context_unref(ctx);
+
+    ret = EXIT_SUCCESS;
+
 err_xcb:
-    xcb_disconnect(conn);
-err_conn:
+    if (conn != NULL)
+        xcb_disconnect(conn);
     return ret;
 }
 
-int main(void) {
+struct xkbcomp_roundtrip_data {
+    const char *path;
+    bool tweak_comments;
+};
+
+static int
+xkbcomp_roundtrip(const char *display, void *private) {
+    const struct xkbcomp_roundtrip_data *priv = private;
+
+    xcb_connection_t *conn = NULL;
+    int32_t device_id = 0;
+    int ret = init_x11_connection(display, &conn, &device_id);
+    if (ret != EXIT_SUCCESS) {
+        ret = TEST_SETUP_FAILURE;
+        goto error_xcb;
+    }
+
+    struct xkb_context *ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    if (!ctx) {
+        ret = EXIT_FAILURE;
+        goto error_context;
+    }
+
+    ret = test_keymap_roundtrip(ctx, display, conn, device_id, true,
+                                priv->tweak_comments, priv->path);
+
+    xkb_context_unref(ctx);
+error_context:
+error_xcb:
+    xcb_disconnect(conn);
+    return ret;
+}
+
+static void
+usage(FILE *fp, char *progname)
+{
+    fprintf(fp,
+            "Usage: %s [--update] [--update-obtained] "
+            "[--keymap KEYMAP_FILE] [--tweak] [--help]\n",
+            progname);
+}
+
+int
+main(int argc, char **argv) {
     test_init();
 
-    return x11_tests_run();
+    enum options {
+        OPT_UPDATE_GOLDEN_TEST_WITH_OUTPUT,
+        OPT_UPDATE_GOLDEN_TEST_WITH_INPUT,
+        OPT_FILE,
+        OPT_TWEAK_COMMENTS,
+    };
+    static struct option opts[] = {
+        {"help",            no_argument,       0, 'h'},
+        {"update-obtained", no_argument,       0, OPT_UPDATE_GOLDEN_TEST_WITH_OUTPUT},
+        {"update",          no_argument,       0, OPT_UPDATE_GOLDEN_TEST_WITH_INPUT},
+        {"keymap",          required_argument, 0, OPT_FILE},
+        {"tweak",           no_argument,       0, OPT_TWEAK_COMMENTS},
+        {0, 0, 0, 0},
+    };
+
+    bool tweak_comments = false;
+    const char *path = NULL;
+
+    while (1) {
+        int opt;
+        int option_index = 0;
+
+        opt = getopt_long(argc, argv, "h", opts, &option_index);
+        if (opt == -1)
+            break;
+
+        switch (opt) {
+        case OPT_UPDATE_GOLDEN_TEST_WITH_OUTPUT:
+            update_test_files = UPDATE_USING_TEST_OUTPUT;
+            break;
+        case OPT_UPDATE_GOLDEN_TEST_WITH_INPUT:
+            update_test_files = UPDATE_USING_TEST_INPUT;
+            break;
+        case OPT_FILE:
+            path = optarg;
+            break;
+        case OPT_TWEAK_COMMENTS:
+            tweak_comments = optarg;
+            break;
+        case 'h':
+            usage(stdout, argv[0]);
+            return EXIT_SUCCESS;
+        default:
+            usage(stderr, argv[0]);
+            return EXIT_INVALID_USAGE;
+        }
+    }
+
+    if (update_test_files != NO_UPDATE && path != NULL) {
+        fprintf(stderr,
+                "ERROR: --update* and --keymap are mutually exclusive.\n");
+        usage(stderr, argv[0]);
+        return EXIT_INVALID_USAGE;
+    }
+
+    if (path == NULL) {
+        return x11_tests_run();
+    } else {
+        struct xkbcomp_roundtrip_data priv = {
+            .path = path,
+            .tweak_comments = tweak_comments
+        };
+        return xvfb_wrapper(xkbcomp_roundtrip, &priv);
+    }
 }

--- a/test/xvfb-wrapper.c
+++ b/test/xvfb-wrapper.c
@@ -17,7 +17,7 @@
 #include "test.h"
 #include "xvfb-wrapper.h"
 
-static bool xvfb_is_ready;
+static volatile bool xvfb_is_ready;
 
 static void
 sigusr1_handler(int signal)
@@ -26,7 +26,7 @@ sigusr1_handler(int signal)
 }
 
 int
-xvfb_wrapper(int (*test_func)(char* display))
+xvfb_wrapper(x11_test_func_t test_func, void *private)
 {
     int ret = EXIT_SUCCESS;
     FILE * display_fd;
@@ -50,15 +50,17 @@ xvfb_wrapper(int (*test_func)(char* display))
     }
     snprintf(display_fd_string, sizeof(display_fd_string), "%d", fileno(display_fd));
 
-    /* Set SIGUSR1 to SIG_IGN so Xvfb will send us that signal
-     * when it's ready to accept connections */
+    /* Set SIGUSR1 to SIG_IGN so Xvfb will send us that signal when it's ready
+     * to accept connections. In order to avoid race condition, we block the
+     * until we are ready to process it. */
     sigemptyset(&mask);
     sigaddset(&mask, SIGUSR1);
     sigprocmask(SIG_BLOCK, &mask, NULL);
-    sa.sa_handler = SIG_IGN;
-    sa.sa_flags = 0;
+    sa.sa_handler = sigusr1_handler;
+    sa.sa_flags = SA_RESTART;
     sigemptyset(&sa.sa_mask);
-    sigaction(SIGUSR1, &sa, NULL);
+    struct sigaction sa_old;
+    sigaction(SIGUSR1, &sa, &sa_old);
 
     xvfb_is_ready = false;
 
@@ -85,12 +87,7 @@ xvfb_wrapper(int (*test_func)(char* display))
         goto err_xvfd;
     }
 
-    sa.sa_handler = SIG_DFL;
-    sa.sa_flags = 0;
-    sigemptyset(&sa.sa_mask);
-    sigaction(SIGUSR1, &sa, NULL);
-    signal(SIGUSR1, sigusr1_handler);
-    sigprocmask (SIG_UNBLOCK, &mask, NULL);
+    sigprocmask(SIG_UNBLOCK, &mask, NULL);
 
     /* Now wait for the SIGUSR1 signal that Xvfb is ready */
     while (!xvfb_is_ready) {
@@ -99,12 +96,20 @@ xvfb_wrapper(int (*test_func)(char* display))
             break;
     }
 
-    signal(SIGUSR1, SIG_DFL);
+    sigaction(SIGUSR1, &sa_old, NULL);
+
+    /* Check if Xvfb is still alive */
+    pid_t pid = waitpid(xvfb_pid, NULL, WNOHANG);
+    if (pid != 0) {
+        fprintf(stderr, "ERROR: Xvfb not alive\n");
+        ret = TEST_SETUP_FAILURE;
+        goto err_xvfd;
+    }
 
     /* Retrieve the display number: Xvfd writes the display number as a newline-
      * terminated string; copy this number to form a proper display string. */
     fseek(display_fd, 0, SEEK_SET);
-    length = fread(&display[1], 1, sizeof(display) - 1, display_fd);
+    length = fread(&display[1], 1, sizeof(display) - 2, display_fd);
     if (length <= 0) {
         fprintf(stderr, "fread error: length=%zu\n", length);
         ret = TEST_SETUP_FAILURE;
@@ -114,12 +119,50 @@ xvfb_wrapper(int (*test_func)(char* display))
         display[length] = '\0';
     }
 
-    /* Run the function requiring a running X server */
-    ret = test_func(display);
+    /* Run the function requiring a running X server.
+     * Because it may call abort() via assert(), we fork to be able to
+     * exit gracefully and not hang waiting for Xvfb. */
+    pid_t test_pid = fork();
+    switch (test_pid) {
+        case -1:
+            perror("fork");
+            ret = TEST_SETUP_FAILURE;
+            break;
+        case 0:
+            fprintf(stderr, "Running test using Xvfb wrapper...\n");
+            ret = test_func(display, private);
+            fprintf(stderr,
+                    "Test using Xvfb wrapper finished with code %d.\n", ret);
+            _exit(ret);
+        default:
+            {
+                int test_status = 0;
+                pid_t test_pid2 = waitpid(test_pid, &test_status, 0);
+                ret = (test_pid2 > 0 && WIFEXITED(test_status))
+                    ? WEXITSTATUS(test_status)
+                    : EXIT_FAILURE;
+                fprintf(stderr,
+                        "Test finished with code %d. "
+                        "Shutting down Xvfb (pid: %d)...\n",
+                        ret, xvfb_pid);
+            }
+    }
 
 err_xvfd:
-    if (xvfb_pid > 0)
+    if (xvfb_pid > 0) {
+        fprintf(stderr, "Sending SIGTERM to Xvfb...\n");
         kill(xvfb_pid, SIGTERM);
+        fprintf(stderr, "Waiting for Xvfb to exit (pid: %d)...\n", xvfb_pid);
+        int xvfb_status = 0;
+        if (waitpid(xvfb_pid, &xvfb_status, 0) <= 0) {
+            perror("Xvfb waitpid failed.");
+        } else if (WIFEXITED(xvfb_status)) {
+            fprintf(stderr, "Xvfb shut down (pid: %d) with exit code %d.\n",
+                    xvfb_pid, WEXITSTATUS(xvfb_status));
+        } else {
+            fprintf(stderr, "Xvfb shut down (pid: %d) abnormally.\n", xvfb_pid);
+        }
+    }
     fclose(display_fd);
 err_display_fd:
     return ret;
@@ -138,8 +181,9 @@ x11_tests_run(void)
     for (const struct test_function *t = &__start_test_func_sec;
          t < &__stop_test_func_sec;
          t++) {
-        fprintf(stderr, "Running test: %s from %s\n", t->name, t->file);
-        rc = xvfb_wrapper(t->func);
+        fprintf(stderr, "------ Running test: %s from %s ------\n",
+                t->name, t->file);
+        rc = xvfb_wrapper(t->func, NULL);
         if (rc != EXIT_SUCCESS) {
             break;
         }

--- a/test/xvfb-wrapper.h
+++ b/test/xvfb-wrapper.h
@@ -24,11 +24,12 @@
 
 #include "config.h"
 
-int xvfb_wrapper(int (*f)(char* display));
+typedef int (* x11_test_func_t)(const char* display, void *private);
+
+int xvfb_wrapper(x11_test_func_t f, void *private);
 
 int x11_tests_run(void);
 
-typedef int (* x11_test_func_t)(char* display);
 
 struct test_function {
     const char *name;     /* function name */
@@ -67,11 +68,11 @@ extern const struct test_function CONCAT2(__stop_, _section) \
 #endif
 
 #define X11_TEST(_func) \
-static int _func(char* display); \
+static int _func(const char* display, void *private); \
 static const struct test_function _test_##_func \
 SET_TEST_ELF_SECTION(TEST_ELF_SECTION) = { \
     .name = #_func, \
     .func = (_func), \
     .file = __FILE__, \
 }; \
-static int _func(char* display)
+static int _func(const char* display, void *private)


### PR DESCRIPTION
- More robust call to xkbcomp.
- Enable to test roundtrip with user-provided keymap, e.g. to help designing #858.

Extracted from #591.