### PR TITLE
Fix invalid macro in xkbcli-how-to-type.1

### DIFF
--- a/tools/xkbcli-how-to-type.1
+++ b/tools/xkbcli-how-to-type.1
@@ -78,7 +78,7 @@ hexadecimal code:
 in the default
 .Ar us
 layout.
-.Be
+.El
 .
 .Sh OPTIONS
 .Bl -tag -width Ds


### PR DESCRIPTION
`.Be` is not a valid macro. I believe the intent was to end the list opened with `.Bl`. The macro for that is `.El`, as used elsewhere.

https://mandoc.bsd.lv/man/mdoc.7.html#Displays_and_lists