### PR TITLE
build: Enable using default XKB root from recent xkeyboard-config

### DIFF
--- a/changes/build/+default-xkb-root.breaking.md
+++ b/changes/build/+default-xkb-root.breaking.md
@@ -1,0 +1,5 @@
+The *default* XKB root directory is now set from the *most recent*
+[xkeyboard-config](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config)
+installed package, in case [multiple versions](https://xkeyboard-config.freedesktop.org/doc/versioning/)
+are installed in parallel.
+If no such package is found, it fallbacks to the historical X11 directory, as previously.

--- a/meson.build
+++ b/meson.build
@@ -56,12 +56,27 @@ add_project_arguments(cc.get_supported_arguments(cflags), language: 'c')
 # The XKB config root.
 XKBCONFIGROOT = get_option('xkb-config-root')
 if XKBCONFIGROOT == ''
-    xkeyboard_config_dep = dependency('xkeyboard-config', required: false)
-    if xkeyboard_config_dep.found()
-        XKBCONFIGROOT = xkeyboard_config_dep.get_variable(pkgconfig: 'xkb_base')
-    else
-        XKBCONFIGROOT = get_option('prefix')/get_option('datadir')/'X11'/'xkb'
-  endif
+    # Try to set from the xkeyboard-config package, from the most recent to the
+    # oldest major version. The hard-coded major versions list should cover at
+    # least a decade (and probably much more!), given the expected pace of
+    # xkeyboard-config format changes.
+    foreach v: [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2]
+        xkeyboard_config_dep = dependency(f'xkeyboard-config-@v@', required: false)
+        if xkeyboard_config_dep.found()
+            XKBCONFIGROOT = xkeyboard_config_dep.get_variable(pkgconfig: 'xkb_root')
+            break
+        endif
+    endforeach
+    if XKBCONFIGROOT == ''
+        # Try old unversioned pkg-config (xkeyboard-config < 2.45)
+        xkeyboard_config_dep = dependency('xkeyboard-config', required: false)
+        if xkeyboard_config_dep.found()
+            XKBCONFIGROOT = xkeyboard_config_dep.get_variable(pkgconfig: 'xkb_base')
+        else
+            # Fallback to the legacy X11 directory
+            XKBCONFIGROOT = get_option('prefix')/get_option('datadir')/'X11'/'xkb'
+        endif
+    endif
 endif
 
 XKBCONFIGEXTRAPATH = get_option('xkb-config-extra-path')


### PR DESCRIPTION
The *default* XKB root directory is now set from the *most recent* xkeyboard-config installed package, in case [multiple versions] are installed in parallel. It also try to use the package-specific XKB root (if available) rather than the X11 root, respectively defined by the pkg-config variables `xkb_root` (xkeyboard-config ≥ 2.45) and `xkb_base`.

If no such package is found, it fallbacks to the historical X11 directory, as previously.

[multiple versions]: https://xkeyboard-config.freedesktop.org/doc/versioning/

See: related [xkeyboard-config discussion](https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/issues/553) about the v3 format fork.