### PR TITLE
Fix C11 syntax

### DIFF
--- a/src/keymap-priv.c
+++ b/src/keymap-priv.c
@@ -167,6 +167,7 @@ action_equal(const union xkb_action *a, const union xkb_action *b)
         return (a->internal.flags == b->internal.flags) &&
                (a->internal.clear_latched_mods == b->internal.clear_latched_mods);
     default:
+        {} /* Label followed by declaration requires C23 */
         /* Ensure to not miss `xkb_action_type` updates */
         static_assert(ACTION_TYPE_INTERNAL == 18 &&
                       ACTION_TYPE_INTERNAL + 1 == _ACTION_TYPE_NUM_ENTRIES,

--- a/src/state.c
+++ b/src/state.c
@@ -346,6 +346,7 @@ xkb_action_breaks_latch(const union xkb_action *action,
         return (action->internal.flags & flag) &&
                ((action->internal.clear_latched_mods & mask) == mask);
     default:
+        {} /* Label followed by declaration requires C23 */
         /* Ensure to not miss `xkb_action_type` updates */
         static_assert(ACTION_TYPE_INTERNAL == 18 &&
                       ACTION_TYPE_INTERNAL + 1 == _ACTION_TYPE_NUM_ENTRIES,

--- a/src/xkbcomp/action.c
+++ b/src/xkbcomp/action.c
@@ -14,6 +14,8 @@
 
 #include "config.h"
 
+#include <assert.h>
+
 #include "xkbcommon/xkbcommon.h"
 #include "context.h"
 #include "keymap.h"

--- a/src/xkbcomp/keymap-dump.c
+++ b/src/xkbcomp/keymap-dump.c
@@ -581,6 +581,7 @@ void_action:
         break;
 
     default:
+        {} /* Label followed by declaration requires C23 */
         /* Ensure to not miss `xkb_action_type` updates */
         static_assert(ACTION_TYPE_INTERNAL == 18 &&
                       ACTION_TYPE_INTERNAL + 1 == _ACTION_TYPE_NUM_ENTRIES,


### PR DESCRIPTION
Label followed by declaration requires C23.

For some reason I missed the CI failures in #868.