### PR TITLE
interactive-wayland: Prevent buffer use after free

### DIFF
--- a/tools/interactive-wayland.c
+++ b/tools/interactive-wayland.c
@@ -238,7 +238,10 @@ os_create_anonymous_file(off_t size)
 static void
 buffer_release(void *data, struct wl_buffer *buffer)
 {
+    struct interactive_dpy *inter = data;
+
     wl_buffer_destroy(buffer);
+    inter->buf = NULL;
 }
 
 static const struct wl_buffer_listener buffer_listener = {


### PR DESCRIPTION
The tool would crash on the second call to `buffer_create` calling `wl_buffer_destroy` on a dangling `inter->buf`.

Fixes: e13faebb2a5a2b250a9c320515942edc1e652649