### PR TITLE
compose: No fallback if no missing locale detection

### DIFF
--- a/changes/api/+879.bugfix.md
+++ b/changes/api/+879.bugfix.md
@@ -1,0 +1,1 @@
+compose: Fixed some C standard libraries such as musl not detecting missing locales.

--- a/include/xkbcommon/xkbcommon-compose.h
+++ b/include/xkbcommon/xkbcommon-compose.h
@@ -197,7 +197,8 @@ enum xkb_compose_format {
  *    preconfigured directory.
  *
  * Since 1.12, system locales not registered in `$XLOCALEDIR` will fallback
- * to `en_US.UTF-8`.
+ * to `en_US.UTF-8`, if missing locale detection is supported by the C standard
+ * library in use.
  *
  * @param context
  *     The library context in which to create the compose table.

--- a/meson.build
+++ b/meson.build
@@ -172,7 +172,20 @@ if not cc.has_header_symbol('limits.h', 'PATH_MAX', prefix: system_ext_define)
     endif
 endif
 if cc.has_header_symbol('locale.h', 'newlocale', prefix: system_ext_define)
-    configh_data.set('HAVE_NEWLOCALE', 1)
+    # Use newlocale only if it fails on missing locales
+    r = cc.run(
+        '''
+        #define _GNU_SOURCE
+        #include <locale.h>
+        int main(void){
+            locale_t loc = newlocale(LC_ALL_MASK, "¡NONSENSE!", (locale_t) 0);
+            return (loc != (locale_t) 0);
+        }''',
+        name: 'newlocale fails on invalid locales',
+    )
+    if r.compiled() and r.returncode() == 0
+        configh_data.set('HAVE_NEWLOCALE', 1)
+    endif
 endif
 
 # Silence some security & deprecation warnings on MSVC


### PR DESCRIPTION
Do not use `newlocale()` if it accepts missing locales. It happens with muslc, while glibc works as expected.

It fixes the incorrect behavior of the fallback introduced in 135b3204a15838205c97e793cd41faa742d429e2.

Fixes #879

@fany @ziyao233