### PR TITLE
keymap: Rename long key/alias names in v1 format

### DIFF
--- a/changes/api/+rename-long-keys.breaking.md
+++ b/changes/api/+rename-long-keys.breaking.md
@@ -1,0 +1,3 @@
+Rename keys and aliases with names longer than 4 characters when serializing
+using `::XKB_KEYMAP_FORMAT_TEXT_V1`, to ensure compatibility with the X11
+ecosystem.

--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -130,10 +130,17 @@ Support all Linux keycodes using **32**-bit keycodes.
 Limited to **4**-character names.
 </details>
 </td>
-<td colspan="2">
+<td>
+<details>
+<summary>⚠️ Serializing requires renaming</summary>
+- *Parse* keys and aliases names of any length.
+- *Serialize* names > 4 characters by renaming them (since 1.14)
+</details>
+</td>
+<td>
 <details>
 <summary>✅ Full support</summary>
-Support any key names of any length.
+Support any key and aliases names of any length.
 </details>
 </td>
 </tr>

--- a/test/data/keymaps/keycodes-long-names-1-v1.xkb
+++ b/test/data/keymaps/keycodes-long-names-1-v1.xkb
@@ -1,0 +1,39 @@
+xkb_keymap {
+xkb_keycodes {
+	minimum = 8;
+	maximum = 65535;
+	<0008>               = 8;
+	<!09>                = 9;
+	<!00a>               = 10;
+	<!fff>               = 4095;
+	<#001>               = 65535;
+	alias <#002>         = <!00a>;
+	alias <#003>         = <!fff>;
+	alias <#004>         = <#001>;
+};
+
+xkb_types {
+	type "ONE_LEVEL" {
+		modifiers= none;
+	};
+};
+
+xkb_compatibility {
+	interpret.useModMapMods= AnyLevel;
+	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
+};
+
+xkb_symbols {
+	key <0008>               {	[      0x00000008 ] };
+	key <!09>                {	[      0x00000009 ] };
+	key <!00a>               {	[      0x0000000a ] };
+	key <!fff>               {	[      0x00000fff ] };
+	key <#001>               {	[          Delete ] };
+	modifier_map Shift { <0008>, <!09> };
+	modifier_map Lock { <!00a>, <!fff>, <#001> };
+};
+
+};

--- a/test/data/keymaps/keycodes-long-names-1-v2.xkb
+++ b/test/data/keymaps/keycodes-long-names-1-v2.xkb
@@ -1,0 +1,39 @@
+xkb_keymap {
+xkb_keycodes {
+	minimum = 8;
+	maximum = 65535;
+	<0008>               = 8;
+	<!09>                = 9;
+	<long-name-000axxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx> = 10;
+	<long-name-0fffxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx> = 4095;
+	<long-name-ffffxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx> = 65535;
+	alias <long-alias-000axxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx> = <long-name-000axxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx>;
+	alias <long-alias-0fffxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx> = <long-name-0fffxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx>;
+	alias <long-alias-ffffxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx> = <long-name-ffffxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx>;
+};
+
+xkb_types {
+	type "ONE_LEVEL" {
+		modifiers= none;
+	};
+};
+
+xkb_compatibility {
+	interpret.useModMapMods= AnyLevel;
+	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
+};
+
+xkb_symbols {
+	key <0008>               {	[      0x00000008 ] };
+	key <!09>                {	[      0x00000009 ] };
+	key <long-name-000axxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx> {	[      0x0000000a ] };
+	key <long-name-0fffxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx> {	[      0x00000fff ] };
+	key <long-name-ffffxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx> {	[          Delete ] };
+	modifier_map Shift { <0008>, <!09> };
+	modifier_map Lock { <long-name-000axxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx>, <long-name-0fffxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx>, <long-name-ffffxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx> };
+};
+
+};

--- a/test/data/keymaps/keycodes-long-names-2.xkb
+++ b/test/data/keymaps/keycodes-long-names-2.xkb
@@ -1,0 +1,43 @@
+xkb_keymap {
+xkb_keycodes {
+	minimum = 8;
+	maximum = 255;
+	<!008>               = 8;
+	<#009>               = 9;
+	<$010>               = 10;
+	<%011>               = 11;
+	<&012>               = 12;
+	<'013>               = 13;
+	<(014>               = 14;
+	<)015>               = 15;
+	<*016>               = 16;
+	<+017>               = 17;
+	<,018>               = 18;
+	<-019>               = 19;
+	<.020>               = 20;
+	</021>               = 21;
+	<0022>               = 22;
+	<long-name-0100xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx> = 100;
+	<long-name-0101xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx> = 101;
+	alias <long-alias-0100xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx> = <long-name-0100xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx>;
+	alias <long-alias-0101xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx> = <long-name-0101xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx>;
+};
+
+xkb_types {
+	type "ONE_LEVEL" {
+		modifiers= none;
+	};
+};
+
+xkb_compatibility {
+	interpret.useModMapMods= AnyLevel;
+	interpret.repeat= False;
+	interpret VoidSymbol+AnyOfOrNone(none) {
+		repeat= True;
+	};
+};
+
+xkb_symbols {
+};
+
+};


### PR DESCRIPTION
Rename keys and aliases with names longer than 4 characters when serializing using `XKB_KEYMAP_FORMAT_TEXT_V1`, to ensure compatibility with the X11 ecosystem.

See #849 for an example of such keymap in use.