### PR TITLE
rules: Add new lookup mechanism: pre & post

### DIFF
--- a/changes/api/+partial-rules-files.feature.md
+++ b/changes/api/+partial-rules-files.feature.md
@@ -1,0 +1,17 @@
+rules: Added lightweight composition of rules files: for a given ruleset `<ruleset>`,
+the *optional* files `<ruleset>.pre` and `<ruleset>.post` of each include
+path are respectively *prepended* and *appended* to the main rules file.
+
+The resulting rule set is equivalent to:
+
+```
+! include <include path 1>/rules/<ruleset>.pre // only if defined
+…
+! include <include path n>/rules/<ruleset>.pre // only if defined
+
+! include <ruleset> // main rules file
+
+! include <include path 1>/rules/<ruleset>.post // only if defined
+…
+! include <include path n>/rules/<ruleset>.post // only if defined
+```

--- a/doc/compatibility.md
+++ b/doc/compatibility.md
@@ -767,6 +767,16 @@ Obsolete legacy file format tied to X11 ecosystem.
 <tbody>
 <!-- Additions -->
 <tr>
+<th>Partial `*.pre` and `*.post` rules files</th>
+<td>❌️ No support</td>
+<td colspan="2">
+<details>
+<summary>✅ Full support (since 1.13)</summary>
+See @ref rmlvo-resolution "" for further details.
+</details>
+</td>
+</tr>
+<tr>
 <th>`! include` statement</th>
 <td>❌️ No support</td>
 <td colspan="2">

--- a/doc/rules-format.md
+++ b/doc/rules-format.md
@@ -375,12 +375,51 @@ or %%H seems to do the job though.
 
 ## Process
 
-First of all, the rules *file* is extracted from the provided
-[<em>R</em>MLVO][RMLVO] configuration (usually `evdev`). Then its path
-is resolved and the file is parsed to get the [rule sets].
+First of all, the main rules *file* `<ruleset>` is extracted from the provided
+[<em>R</em>MLVO][RMLVO] configuration (usually `evdev`). Then the following
+files are parsed and their results are collected sequentially to form the final
+[rule sets][]:
+
+<dl>
+<dt>Partial `<ruleset>.pre` files</dt>
+<dd>
+*Optional:* for each include path `<ipath>`, parse and append the [rule sets]
+of the file `<ipath>/rules/<ruleset>.pre`, if it exists. Multiple such files may
+be parsed enabling lightweight composition fo rules files.
+
+@since 1.13.0
+</dd>
+<dt>Main `<ruleset>` file</dt>
+<dd>
+Parse and append the [rule sets] of the *canonical* `<ruleset>` file, e.g. the
+*first* file in the included paths matching `rules/<ruleset>`.
+</dd>
+<dt>Partial `<ruleset>.post` files</dt>
+<dd>
+*Optional:* for each include path `<ipath>`, parse and append the [rule sets]
+of the file `<ipath>/rules/<ruleset>.post`, if it exists. Multiple such files
+may be parsed enabling lightweight composition fo rules files.
+
+@since 1.13.0
+</dd>
+</dl>
+
+The resulting rule sets are equivalent to:
+
+```
+! include <include path 1>/rules/<ruleset>.pre  // only if defined
+…
+! include <include path n>/rules/<ruleset>.pre  // only if defined
+
+! include <ruleset>                             // main rules file
+
+! include <include path 1>/rules/<ruleset>.post // only if defined
+…
+! include <include path n>/rules/<ruleset>.post // only if defined
+```
 
 Then *each rule set* is checked against the provided [MLVO] configuration,
-following their *order* in the rules file.
+following their *order* in the rules files.
 
 @important @anchor irrelevant-options-order Contrary to layouts and variants,
 the *options order* in a [MLVO] configuration (e.g. via `xkbcli`) is irrelevant

--- a/test/data/extra/rules/partial.post
+++ b/test/data/extra/rules/partial.post
@@ -1,0 +1,6 @@
+! layout[any]	=	symbols
+  l2		=	+extra-bis:%i
+
+! layout[any]	option		=	symbols
+  *		opt:a		=	+a-bis:%i
+  *		opt:b		=	+b:%i

--- a/test/data/extra/rules/partial.pre
+++ b/test/data/extra/rules/partial.pre
@@ -1,0 +1,11 @@
+! model	=	keycodes
+  m1	=	m1-bis
+
+! model	=	keycodes
+  m1	=	+m1-ter
+
+! model	=	symbols
+  m2	=	m2
+
+! model	=	symbols
+  m2	=	+m2-bis

--- a/test/data/rules/partial
+++ b/test/data/rules/partial
@@ -1,0 +1,16 @@
+// To be completed with partial rules *.pre and *.post
+
+! model	= keycodes
+  *	= evdev
+
+! model	= symbols
+  *	= pc
+
+! layout[any]	= symbols
+  *		= +%l[%i]%(v[%i]):%i
+
+! model	= types
+  *	= complete
+
+! model	= compat
+  *	= complete

--- a/test/data/rules/partial.post
+++ b/test/data/rules/partial.post
@@ -1,0 +1,5 @@
+! layout[any]	=	symbols
+  l2		=	+extra:%i
+
+! layout[any]	option		=	symbols
+  *		opt:a		=	+a:%i

--- a/test/data/rules/partial.pre
+++ b/test/data/rules/partial.pre
@@ -1,0 +1,5 @@
+! model	=	keycodes
+  m1	=	m1
+
+! model	=	symbols
+  m1	=	m1


### PR DESCRIPTION
Before this commit, the only way to extend rules was to override the default rules files by creating a file with the same name in an include directory with a higher priority than the default rules file. However, this prevented to *compose* any rules extension by other mean than explicit includes/inlining all rules in the higher priority rules files.

This commit introduces a new lookup mechanism that enables to extend rules without altering the main rules file and facilitate *rules composition*. The main motivation is to support composing custom rules with the upcoming XKB *extensions mechanism* (see #876). This is done by enabling *partial* rules files `<rules>.pre` and `<rules>.post`.

The previous lookup mechanism:
1. Find the rules file `<rules>`
2. Fail if not found
3. Otherwise resolves the rules
4. Fail if any required component is missing
5. Otherwise return the resolved KcCGST names

is replaced with:
1. Find the main rules file `<rules>`
2. Fail if not found
3. For each include directory:
   1. Try to find the *partial* rules file `<rules>.pre` in the directory
   2. If none is found, continue to the next directory
   3. Otherwise resolve the rules from `<rules>.pre` by appending the resolved components to the previous result

   This may combine *multiple* `<rules>.pre` files.
4. resolve the rules from `<rules>` by appending to the previous result;
5. same as step 3, but with the rules file `<rules>.post`.

Example: given the following tree:
- `~/.config/xkb/rules`
  - `evdev.post`
- `/etc/xkb/rules`
  - `evdev.pre`
  - `evdev.post`
- `/usr/share/xkeyboard-config-2/rules`
  - `evdev`

the new mechanism is equivalent to parsing the following rules file:

    // .pre rules
    include %E/evdev.pre // only .pre file

    // main rules
    include %S/evdev

    // .post rules
    include %H/.config/xkb/evdev.post // higher priority than /etc/xkb
    include %E/evdev.post

@bluetech @whot @mahkoh 