### PR TITLE
state: Add options API

### DIFF
--- a/changes/api/+state-options-api.feature.md
+++ b/changes/api/+state-options-api.feature.md
@@ -1,0 +1,5 @@
+**state:** Added the following server API to configure the keyboard state:
+- `struct xkb_state_options`
+- `xkb_state_options_new()`
+- `xkb_state_options_destroy()`
+- `xkb_state_new2()`

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -313,7 +313,17 @@ typedef uint32_t xkb_led_mask_t;
  */
 struct xkb_rmlvo_builder;
 
+/**
+ * Flags for `xkb_rmlvo_builder_new()`.
+ *
+ * @since 1.11.0
+ */
 enum xkb_rmlvo_builder_flags {
+    /**
+     * Do not apply any flags.
+     *
+     * @since 1.11.0
+     */
     XKB_RMLVO_BUILDER_NO_FLAGS = 0
 };
 
@@ -1767,16 +1777,76 @@ xkb_keymap_key_repeats(struct xkb_keymap *keymap, xkb_keycode_t key);
  */
 
 /**
+ * Opaque options object to configure a keyboard state.
+ *
+ * @since 1.14.0
+ */
+struct xkb_state_options;
+
+/**
+ * Create a new keyboard state object options.
+ *
+ * @param context The context in which to create the options.
+ *
+ * @returns A new keyboard state options object, or `NULL` on failure.
+ *
+ * @since 1.14.0
+ *
+ * @memberof xkb_state
+ */
+XKB_EXPORT struct xkb_state_options *
+xkb_state_options_new(struct xkb_context *context);
+
+/**
+ * Free a keyboard state options object.
+ *
+ * @param options The state options. If it is `NULL`, this function does nothing.
+ *
+ * @since 1.14.0
+ *
+ * @memberof xkb_state
+ */
+XKB_EXPORT void
+xkb_state_options_destroy(struct xkb_state_options *options);
+
+/**
  * Create a new keyboard state object.
+ *
+ * This entry point is intended for both server and client applications.
+ * However, *server* applications may prefer to use `xkb_state_new2()` to get
+ * more control over the state configuration.
  *
  * @param keymap The keymap which the state will use.
  *
  * @returns A new keyboard state object, or `NULL` on failure.
  *
+ * @sa `xkb_state_new2()`
+ *
  * @memberof xkb_state
  */
 XKB_EXPORT struct xkb_state *
 xkb_state_new(struct xkb_keymap *keymap);
+
+/**
+ * Create a new keyboard state object with explicit options.
+ *
+ * This entry point is intended for *server* applications; *client* applications
+ * should use `xkb_state_new()` instead.
+ *
+ * @param keymap  The keymap which the state will use.
+ * @param options The options to configure the state.
+ *
+ * @returns A new keyboard state object, or `NULL` on failure.
+ *
+ * @sa `xkb_state_new()`
+ *
+ * @since 1.14.0
+ *
+ * @memberof xkb_state
+ */
+XKB_EXPORT struct xkb_state *
+xkb_state_new2(struct xkb_keymap *keymap,
+               const struct xkb_state_options *options);
 
 /**
  * Take a new reference on a keyboard state object.

--- a/src/state.c
+++ b/src/state.c
@@ -872,8 +872,34 @@ xkb_filter_apply_all(struct xkb_state *state,
     }
 }
 
+struct xkb_state_options {
+    struct xkb_context *ctx;
+};
+
+struct xkb_state_options *
+xkb_state_options_new(struct xkb_context *context)
+{
+    struct xkb_state_options* restrict const opt = calloc(1, sizeof(*opt));
+    if (!opt)
+        return NULL;
+
+    opt->ctx = xkb_context_ref(context);
+
+    return opt;
+}
+
+void
+xkb_state_options_destroy(struct xkb_state_options *options)
+{
+    if (options == NULL)
+        return;
+    xkb_context_unref(options->ctx);
+    free(options);
+}
+
 struct xkb_state *
-xkb_state_new(struct xkb_keymap *keymap)
+xkb_state_new2(struct xkb_keymap *keymap,
+               const struct xkb_state_options *options)
 {
     struct xkb_state* restrict const state = calloc(1, sizeof(*state));
     if (!state)
@@ -883,6 +909,17 @@ xkb_state_new(struct xkb_keymap *keymap)
     state->keymap = xkb_keymap_ref(keymap);
 
     return state;
+}
+
+struct xkb_state *
+xkb_state_new(struct xkb_keymap *keymap)
+{
+    /* Default state options */
+    static const struct xkb_state_options options = {
+        .ctx = NULL /* unused */
+    };
+
+    return xkb_state_new2(keymap, &options);
 }
 
 struct xkb_state *

--- a/test/state.c
+++ b/test/state.c
@@ -39,6 +39,25 @@ static const enum xkb_keymap_format keymap_formats[] = {
 #define XKB_KEY_Ssharp (XKB_KEYSYM_UNICODE_OFFSET + 0x1E9E)
 #endif
 
+static void
+test_state_options(struct xkb_context *ctx)
+{
+    struct xkb_state_options *options = xkb_state_options_new(ctx);
+    assert(options);
+
+    struct xkb_keymap *keymap =
+        xkb_keymap_new_from_names(ctx, NULL, XKB_KEYMAP_COMPILE_NO_FLAGS);
+    assert(keymap);
+
+    struct xkb_state *state = xkb_state_new2(keymap, options);
+    assert(state);
+    xkb_state_unref(state);
+
+    xkb_keymap_unref(keymap);
+
+    xkb_state_options_destroy(options);
+}
+
 /* Reference implementation from XkbAdjustGroup in Xorg xserver */
 static int32_t
 group_wrap_ref(int32_t g, int32_t num_groups)
@@ -3090,6 +3109,7 @@ main(void)
     xkb_keymap_unref(NULL);
     xkb_state_unref(NULL);
 
+    test_state_options(context);
     test_group_wrap(context);
 
     const char* rules[] = {"evdev", "evdev-pure-virtual-mods"};

--- a/xkbcommon.map
+++ b/xkbcommon.map
@@ -147,3 +147,10 @@ V_1.12.0 {
 global:
     xkb_keymap_get_as_string2;
 } V_1.11.0;
+
+V_1.14.0 {
+global:
+    xkb_state_options_new;
+    xkb_state_options_destroy;
+    xkb_state_new2;
+} V_1.12.0;


### PR DESCRIPTION
Introduce the following public API to enable state configuration:
- ~~`enum xkb_state_flags`~~
- `struct xkb_state_options`
- `xkb_state_options_new()`
- `xkb_state_options_destroy()`
- ~~`xkb_state_options_update_flags()`~~
- `xkb_state_new2()`

This only adds the initial API but does not bring any option yet.

This API is intended for *server* applications only.

Intended to provide base API for #739, #816 and #914.