### PR TITLE
ci: Bump macOS runner image

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   macos:
-    runs-on: macos-13
+    runs-on: macos-14
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
See the [deprecation announcement](https://github.com/actions/runner-images/issues/13046).