### PR TITLE
Add xkb_get_version()

### DIFF
--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -314,6 +314,16 @@ typedef uint32_t xkb_led_mask_t;
 #define xkb_keycode_is_legal_x11(key) ((key) >= 8 && (key) <= 255)
 
 /**
+ * Get the version of libxkbcommon in use.
+ *
+ * @returns a triplet representing MAJOR.MINOR.PATCH library version.
+ *
+ * @since 1.14.0
+ */
+XKB_EXPORT const uint8_t *
+xkb_get_version(void);
+
+/**
  * @defgroup rules-api Rules
  * Utility functions related to *rules*, whose purpose is introduced in:
  * @ref xkb-the-config "".

--- a/meson.build
+++ b/meson.build
@@ -324,6 +324,15 @@ yacc_gen = generator(
     output: ['@BASENAME@.c', '@BASENAME@.h'],
     arguments: ['--defines=@OUTPUT1@', '-o', '@OUTPUT0@', '-p', '_xkbcommon_', '@INPUT@'],
 )
+version_file = configure_file(
+    input: 'src/version.c.in',
+    output: 'version.c',
+    configuration: {
+        'MAJOR': xkbcommon_project_version[0],
+        'MINOR': xkbcommon_project_version[1],
+        'PATCH': xkbcommon_project_version[2],
+    },
+)
 libxkbcommon_sources = [
     'src/compose/constants.h',
     'src/compose/parser.c',
@@ -394,6 +403,7 @@ libxkbcommon_sources = [
     'src/utils-numbers.h',
     'src/utils-paths.c',
     'src/utils-paths.h',
+    version_file,
 ]
 libxkbcommon_link_args = []
 libxkbcommon_link_deps = []

--- a/src/version.c.in
+++ b/src/version.c.in
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2025 Pierre Le Marre
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "config.h"
+
+#include <stdint.h>
+
+#include "xkbcommon/xkbcommon.h"
+
+static const uint8_t version[] = { @MAJOR@, @MINOR@, @PATCH@ };
+
+const uint8_t *
+xkb_get_version(void)
+{
+    return version;
+}

--- a/xkbcommon.map
+++ b/xkbcommon.map
@@ -150,6 +150,7 @@ global:
 
 V_1.14.0 {
 global:
+    xkb_get_version;
     xkb_keymap_key_iterator_new;
     xkb_keymap_key_iterator_destroy;
     xkb_keymap_key_iterator_next;


### PR DESCRIPTION
Enable to apps to query the version of the libxkbcommon library actually in use and adapt their behavior: e.g. supported flags and available symbols, etc.

Fixes #932

---

TODO:
- [ ] Better commit message
- [ ] Documentation with examples (do and don’t)
- [ ] Changelog
- [ ] Add a flag arg to enable future developments?