### PR TITLE
Release 1.13.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+libxkbcommon [1.13.1] – 2025-12-03
+==================================
+
+[1.13.1]: https://github.com/xkbcommon/libxkbcommon/tree/xkbcommon-1.13.1
+
+# API
+
+## Fixes
+
+- Fixed segfault triggering in unlikely setups.
+  ([#934](https://github.com/xkbcommon/libxkbcommon/issues/934))
+
+
 libxkbcommon [1.13.0] – 2025-11-05
 ==================================
 
@@ -84,6 +97,19 @@ See @ref packaging-keyboard-layouts "" for further details.
   - `xkb_extra_path`
 
   See @ref packaging-keyboard-layouts "" for further details.
+
+
+libxkbcommon [1.12.4] – 2025-12-03
+==================================
+
+[1.12.4]: https://github.com/xkbcommon/libxkbcommon/tree/xkbcommon-1.12.4
+
+# API
+
+## Fixes
+
+- Fixed segfault triggering in unlikely setups.
+  ([#934](https://github.com/xkbcommon/libxkbcommon/issues/934))
 
 
 libxkbcommon [1.12.3] – 2025-10-29

--- a/changes/api/934.bugfix.md
+++ b/changes/api/934.bugfix.md
@@ -1,1 +1,0 @@
-Fixed segfault triggering in unlikely setups.

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'libxkbcommon',
     'c',
-    version: '1.13.0',
+    version: '1.13.1',
     default_options: [
         'c_std=c11',
         'warning_level=3',


### PR DESCRIPTION
# How to make a libxkbcommon release

### Prerequisites

- Have write access to xkbcommon Git repositories.
- Be subscribed to the [wayland-devel](https://lists.freedesktop.org/postorius/lists/wayland-devel.lists.freedesktop.org/) mailing list.
  <!-- Old link: https://lists.freedesktop.org/mailman/listinfo/wayland-devel -->

### Steps

#### Prepare the release

- [x] Ensure there is no issue in the tracker blocking the release. Make sure
  they have their milestone set to the relevant release and the relevant tag
  “critical”.

- [x] Ensure all items in the current milestone are processed. Remaining items
  must be *explicitly* postponed by changing their milestone.

- [x] Ensure the keysyms header is up-to-date (see [xorgproto])

- [x] Create a release branch: `git checkout -b release/vMAJOR.MINOR.PATCH master`

- [x] Update the `NEWS.md` file for the release, following [the corresponding instructions](changes/README.md).

- [x] Bump the `version` in `meson.build`.

- [x] Run `meson dist -C build` to make sure the release is good to go.

- [x] Commit `git commit -m 'Bump version to MAJOR.MINOR.PATCH'`.

- [x] Create a pull request using this template and ensure *all* CI is green.

- [x] Merge the pull request.

- [x] Tag `git switch master && git pull && git tag --annotate -m xkbcommon-<MAJOR.MINOR.PATCH> xkbcommon-<MAJOR.MINOR.PATCH>`.

- [x] Push the tag `git push origin xkbcommon-<MAJOR.MINOR.PATCH>`.

[xorgproto]: https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/tree/master/include/X11

#### Send announcement email to wayland-devel

- [x] Send an email to the wayland-devel@lists.freedesktop.org mailing list, using this template:

```
Subject: [ANNOUNCE] libxkbcommon MAJOR.MINOR.PATCH

<NEWS & comments for this release>

Git tag:
--------

git tag: xkbcommon-<MAJOR.MINOR.PATCH>
git commit: <git commit sha>

<YOUR NAME>
```

#### Update website

- [x] Pull the latest [website repository](https://github.com/xkbcommon/website).

- [x] Add the doc for the release: `cp -r <xkbommon>/build/html doc/<MAJOR.MINOR.PATCH>`.
  Check carefully that there is no warning during generation with Doxygen.
  It may be necessary to use another version of Doxygen to get a clean build.
  Building from source using the main branch is also a good option.

- [x] Apply manual Doxygen fixes:
  - [x] Fix labels of the TOC in the “Release notes” page.

- [x] Update the `current` symlink: `ln -nsrf doc/<MAJOR.MINOR.PATCH> doc/current`.

- [x] Grab a link to the announcement mail from the [wayland-devel archives](https://lore.freedesktop.org/wayland-devel/).
  <!-- Old archives: https://lists.freedesktop.org/archives/wayland-devel/ -->

- [x] Update the `index.html`:
    - "Our latest API- and ABI-stable release ..."
    - Add entry to the `releases` HTML list.

- [x] Commit `git commit -m MAJOR.MINOR.PATCH`.

- [x] Push `git push`. This automatically publishes the website after a few seconds.
