### PR TITLE
tools: Added xkbcli info

### DIFF
--- a/changes/tools/+xkbcli-info.feature.md
+++ b/changes/tools/+xkbcli-info.feature.md
@@ -1,0 +1,2 @@
+Added new tool `xkbcli info` to print information about libxkbcommon configuration,
+for debugging purposes.

--- a/meson.build
+++ b/meson.build
@@ -664,6 +664,17 @@ if build_tools
                      install_dir: bash_completion_path)
     endif
 
+    # Tool: info
+    xkbcli_info = executable(
+        'xkbcli-info',
+        'tools/info.c',
+        dependencies: tools_dep,
+        install: true,
+        install_dir: dir_libexec
+    )
+    install_man('tools/xkbcli-info.1')
+    configh_data.set10('HAVE_XKBCLI_INFO', true)
+
     # Tool: compile-keymap
     xkbcli_compile_keymap = executable('xkbcli-compile-keymap',
                                        'tools/compile-keymap.c',

--- a/tools/info.c
+++ b/tools/info.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2025 Pierre Le Marre <dev@wismill.eu>
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "config.h"
+
+#include <getopt.h>
+#include <locale.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "xkbcommon/xkbcommon.h"
+#include "src/utils.h"
+#include "tools-common.h"
+
+static void
+usage(FILE *fp, char *progname)
+{
+    fprintf(fp, "Usage: %s\n", progname);
+}
+
+static bool
+parse_options(int argc, char **argv)
+{
+    enum options {
+        OPT_HELP = 'h',
+    };
+
+    static struct option opts[] = {
+        {"help",                 no_argument,            0, OPT_HELP},
+        {0, 0, 0, 0},
+    };
+
+    while (1) {
+        int option_index = 0;
+        int opt = getopt_long(argc, argv, "h", opts, &option_index);
+
+        if (opt == -1)
+            break;
+
+        switch (opt) {
+        case OPT_HELP:
+            usage(stdout, argv[0]);
+            exit(EXIT_SUCCESS);
+        default:
+// invalid_usage:
+            usage(stderr, argv[0]);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+int
+main(int argc, char **argv)
+{
+    setlocale(LC_ALL, "");
+
+    if (!parse_options(argc, argv)) {
+        return EXIT_INVALID_USAGE;
+    }
+
+    printf("Version: \"%s\"\n", LIBXKBCOMMON_VERSION);
+    printf("Website: https://xkbcommon.org\n");
+
+    printf("Tools path: \"%s\"\n", LIBXKBCOMMON_TOOL_PATH);
+
+    /* Features */
+    printf("Features:\n");
+    printf("  Extensions directories: "
+#if HAVE_XKB_EXTENSIONS_DIRECTORIES
+    "true"
+#else
+    "false"
+#endif
+    "\n");
+
+    /* Built-in settings */
+    printf("Built-in values:\n");
+    static const struct {
+        const char * var;
+        const char * value;
+    } builtins[] = {
+        { "XKB_CONFIG_ROOT", DFLT_XKB_CONFIG_ROOT },
+        { "XKB_CONFIG_LEGACY_ROOT", DFLT_XKB_LEGACY_ROOT },
+        { "XKB_CONFIG_EXTRA_PATH", DFLT_XKB_CONFIG_EXTRA_PATH },
+        { "XKB_CONFIG_UNVERSIONED_EXTENSIONS_PATH", DFLT_XKB_CONFIG_UNVERSIONED_EXTENSIONS_PATH },
+        { "XKB_CONFIG_VERSIONED_EXTENSIONS_PATH", DFLT_XKB_CONFIG_VERSIONED_EXTENSIONS_PATH },
+        { "XKB_DEFAULT_RULES", DEFAULT_XKB_RULES },
+        { "XKB_DEFAULT_MODEL", DEFAULT_XKB_MODEL },
+        { "XKB_DEFAULT_LAYOUT", DEFAULT_XKB_LAYOUT },
+        { "XKB_DEFAULT_VARIANT", DEFAULT_XKB_VARIANT },
+        { "XKB_DEFAULT_OPTIONS", DEFAULT_XKB_OPTIONS },
+        { "XLOCALEDIR", XLOCALEDIR },
+    };
+    for (size_t v = 0; v < ARRAY_SIZE(builtins); v++) {
+        printf("  %s: ", builtins[v].var);
+        const char * const value = builtins[v].value;
+        if (value)
+            printf("\"%s\"\n", value);
+        else
+            printf("null\n");
+    }
+
+    struct xkb_context * const ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+
+    /* Environment variable */
+    printf("Environment variables:\n");
+    static const char * vars[] = {
+        "XKB_CONFIG_ROOT",
+        "XKB_CONFIG_EXTRA_PATH",
+        "XKB_CONFIG_UNVERSIONED_EXTENSIONS_PATH",
+        "XKB_CONFIG_VERSIONED_EXTENSIONS_PATH",
+        "XKB_DEFAULT_RULES",
+        "XKB_DEFAULT_MODEL",
+        "XKB_DEFAULT_LAYOUT",
+        "XKB_DEFAULT_VARIANT",
+        "XKB_DEFAULT_OPTIONS",
+        "HOME",
+        "XDG_CONFIG_HOME",
+        "XLOCALEDIR",
+        "XCOMPOSEFILE",
+    };
+    for (size_t v = 0; v < ARRAY_SIZE(vars); v++) {
+        printf("  %s: ", vars[v]);
+        const char * const value = secure_getenv(vars[v]);
+        if (value)
+            printf("\"%s\"\n", value);
+        else
+            printf("null\n");
+    }
+
+    /* Include paths */
+    const unsigned int num_paths = xkb_context_num_include_paths(ctx);
+    printf("XKB include paths:\n");
+    for (unsigned int p = 0; p < num_paths; p++) {
+        printf("- \"%s\"\n", xkb_context_include_path_get(ctx, p));
+    }
+
+    xkb_context_unref(ctx);
+
+    return EXIT_SUCCESS;
+}

--- a/tools/xkbcli-info.1
+++ b/tools/xkbcli-info.1
@@ -1,0 +1,19 @@
+.Dd February 4, 2026
+.Dt XKBCLI\-INFO 1
+.Os
+.
+.Sh NAME
+.Nm "xkbcli\-info"
+.Nd print information about libxkbcommon configuration
+.
+.Sh SYNOPSIS
+.Nm
+.Ar command Bo arguments Bc
+.
+.Sh DESCRIPTION
+Print information about libxkbcommon configuration.
+The output is in YAML 1.2 format.
+.
+.Sh SEE ALSO
+.Xr xkbcli 1 ,
+.Lk https://xkbcommon.org "The libxkbcommon online documentation"

--- a/tools/xkbcli.1
+++ b/tools/xkbcli.1
@@ -27,6 +27,8 @@ Print the version and exit
 .
 .Ss COMMANDS
 .Bl -tag -width Ds
+.It Ic info
+Print information about libxkbcommon configuration
 .It Ic compile\-keymap
 Compile an XKB keymap, see
 .Xr xkbcli\-compile\-keymap 1

--- a/tools/xkbcli.c
+++ b/tools/xkbcli.c
@@ -24,6 +24,11 @@ usage(void)
             *          Any change to the format (in particular to the indentation)
             *          should kept in the script in sync. */
            "Commands:\n"
+#if HAVE_XKBCLI_INFO
+           "  info\n"
+           "    Print information about libxkbcommon configuration\n"
+           "\n"
+#endif
 #if HAVE_XKBCLI_LIST
            "  list\n"
            "    List available rules, models, layouts, variants and options\n"


### PR DESCRIPTION
Added new tool `xkbcli info` to print information about libxkbcommon configuration, for debugging purposes.

The output is in YAML 1.2 format.

@bluetech @whot 