### PR TITLE
test: retain const qualifier from pointer

### DIFF
--- a/test/utils-text.c
+++ b/test/utils-text.c
@@ -80,7 +80,7 @@ uncomment(const char *input, size_t input_length, const char *prefix)
     const char *start = input;
     const char *end = input + input_length;
 
-    char *next = strstr(start, prefix);
+    const char *next = strstr(start, prefix);
     size_t count;
     while (start < end && next != NULL) {
         count = (size_t)(next - start);
@@ -114,7 +114,7 @@ split_lines(const char *input, size_t input_length,
             struct text_line *output, size_t output_length)
 {
     const char *start = input;
-    char *next;
+    const char *next;
     size_t l;
     size_t i = 0;
 


### PR DESCRIPTION
Since glibc-2.43:

For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the in put argument is a pointer to a const-qualified type.

https://lists.gnu.org/archive/html/info-gnu/2026-01/msg00005.html

Resolves the following warnings:
    ../test/utils-text.c: In function 'uncomment':
    ../test/utils-text.c:82:18: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
       82 |     char *next = strstr(start, prefix);
          |                  ^~~~~~
    ../test/utils-text.c:94:14: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
       94 |         next = strchr(start, 0x0a);
          |              ^
    ../test/utils-text.c: In function 'split_lines':
    ../test/utils-text.c:122:14: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
      122 |         next = strchr(start, 0x0a);
          |              ^