### PR TITLE
state: Fix restrict in public header

### DIFF
--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -2174,7 +2174,7 @@ xkb_state_machine_options_shortcuts_update_mods(
  */
 XKB_EXPORT int
 xkb_state_machine_options_shortcuts_set_mapping(
-    struct xkb_state_machine_options* restrict options,
+    struct xkb_state_machine_options* options,
     xkb_layout_index_t source, xkb_layout_index_t target
 );
 

--- a/src/state.c
+++ b/src/state.c
@@ -2466,7 +2466,7 @@ xkb_state_machine_options_shortcuts_update_mods(
 
 int
 xkb_state_machine_options_shortcuts_set_mapping(
-    struct xkb_state_machine_options* restrict options,
+    struct xkb_state_machine_options* options,
     xkb_layout_index_t source, xkb_layout_index_t target
 )
 {


### PR DESCRIPTION
`restrict` is not useful in this case and is not a valid C++ keyword, so remove it.

Closes #967