### PR TITLE
xkbcomp: Fix fallback interpret

### DIFF
--- a/src/keymap.h
+++ b/src/keymap.h
@@ -416,6 +416,24 @@ struct xkb_group {
     struct xkb_level *levels;
 };
 
+enum {
+    DEFAULT_KEY_REPEAT = false,
+    /**
+     * Any key with no explicit key repeat value that trigger the default
+     * interpret, e.g. some explicit symbols in a group with no action that do
+     * not trigger any explicit interpret.
+     */
+    DEFAULT_INTERPRET_KEY_REPEAT = true,
+    FALLBACK_INTERPRET_KEY_REPEAT = DEFAULT_KEY_REPEAT
+};
+
+enum {
+    DEFAULT_KEY_VMODMAP = 0,
+    DEFAULT_INTERPRET_VMOD = XKB_MOD_INVALID,
+    DEFAULT_INTERPRET_VMODMAP = DEFAULT_KEY_VMODMAP,
+    FALLBACK_INTERPRET_VMODMAP = DEFAULT_KEY_VMODMAP
+};
+
 struct xkb_key {
     xkb_keycode_t keycode;
     xkb_atom_t name;

--- a/src/xkbcomp/compat.c
+++ b/src/xkbcomp/compat.c
@@ -133,6 +133,8 @@ InitInterp(SymInterpInfo *info)
 {
     info->merge = MERGE_DEFAULT; /* Unused */
     info->interp.virtual_mod = XKB_MOD_INVALID;
+    static_assert(!DEFAULT_KEY_VMODMAP, "invalid initial value");
+    static_assert(!DEFAULT_KEY_REPEAT, "invalid initial value");
 }
 
 static inline void

--- a/src/xkbcomp/keymap-dump.c
+++ b/src/xkbcomp/keymap-dump.c
@@ -923,6 +923,17 @@ write_actions(struct xkb_keymap *keymap, enum xkb_keymap_format format,
     return true;
 }
 
+static const struct xkb_sym_interpret fallback_interpret = {
+    .sym = XKB_KEY_VoidSymbol,
+    .required = true,
+    .repeat = FALLBACK_INTERPRET_KEY_REPEAT,
+    .match = MATCH_ANY_OR_NONE,
+    .mods = 0,
+    .virtual_mod = (xkb_mod_index_t) DEFAULT_INTERPRET_VMOD,
+    .num_actions = 0,
+    .a = { .action = { .type = ACTION_TYPE_NONE } },
+};
+
 static bool
 write_compat(struct xkb_keymap *keymap, enum xkb_keymap_format format,
              xkb_layout_index_t max_groups, bool drop_unused, bool pretty,
@@ -949,7 +960,7 @@ write_compat(struct xkb_keymap *keymap, enum xkb_keymap_format format,
     const struct xkb_sym_interpret* const sym_interprets
         = keymap->num_sym_interprets
         ? keymap->sym_interprets
-        : &default_interpret;
+        : &fallback_interpret;
 
     for (darray_size_t i = 0; i < num_sym_interprets; i++) {
         const struct xkb_sym_interpret *si = &sym_interprets[i];

--- a/src/xkbcomp/keymap.c
+++ b/src/xkbcomp/keymap.c
@@ -65,14 +65,12 @@ UpdateActionMods(struct xkb_keymap *keymap, union xkb_action *act,
     }
 }
 
-const struct xkb_sym_interpret default_interpret = {
-    /* Keysym unused for when applying interpretation, but used as a default
-     * entry when dumping the keymap */
-    .sym = XKB_KEY_VoidSymbol,
-    .repeat = true,
+static const struct xkb_sym_interpret default_interpret = {
+    .sym = XKB_KEY_NoSymbol /* unused */,
     .match = MATCH_ANY_OR_NONE,
     .mods = 0,
-    .virtual_mod = XKB_MOD_INVALID,
+    .repeat = DEFAULT_INTERPRET_KEY_REPEAT,
+    .virtual_mod = (xkb_mod_index_t) DEFAULT_INTERPRET_VMOD,
     .num_actions = 0,
     .a = { .action = { .type = ACTION_TYPE_NONE } },
 };
@@ -208,9 +206,12 @@ ApplyInterpsToKey(struct xkb_keymap *keymap, struct xkb_key *key)
                     if (!(key->explicit & EXPLICIT_REPEAT) && interp->repeat)
                         key->repeats = true;
 
-                if ((group == 0 && level == 0) || !interp->level_one_only)
+                if ((group == 0 && level == 0) || !interp->level_one_only) {
+                    static_assert(DEFAULT_INTERPRET_VMOD == XKB_MOD_INVALID, "");
+                    static_assert(!DEFAULT_INTERPRET_VMODMAP, "");
                     if (interp->virtual_mod != XKB_MOD_INVALID)
                         vmodmap |= (UINT32_C(1) << interp->virtual_mod);
+                }
 
                 switch (interp->num_actions) {
                 case 0:

--- a/src/xkbcomp/symbols.c
+++ b/src/xkbcomp/symbols.c
@@ -144,6 +144,8 @@ static void
 InitKeyInfo(struct xkb_context *ctx, KeyInfo *keyi)
 {
     memset(keyi, 0, sizeof(*keyi));
+    static_assert(!DEFAULT_KEY_REPEAT, "key repeat not initialized properly");
+    static_assert(!DEFAULT_KEY_VMODMAP, "key vmodmap not initialized properly");
     keyi->name = xkb_atom_intern_literal(ctx, "*");
     keyi->out_of_range_group_action = RANGE_WRAP;
 }

--- a/src/xkbcomp/xkbcomp-priv.h
+++ b/src/xkbcomp/xkbcomp-priv.h
@@ -90,8 +90,6 @@ CompileSymbols(XkbFile *file, struct xkb_keymap_info *keymap_info);
 bool
 CompileKeymap(XkbFile *file, struct xkb_keymap *keymap);
 
-extern const struct xkb_sym_interpret default_interpret;
-
 /***====================================================================***/
 
 static inline bool

--- a/test/data/keymaps/bidi.xkb
+++ b/test/data/keymaps/bidi.xkb
@@ -15,7 +15,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/escape-sequences.xkb
+++ b/test/data/keymaps/escape-sequences.xkb
@@ -27,7 +27,7 @@ xkb_compatibility "Le_c≈_ur_a___ses_raisons_que_la_raison_ne_con_na√_t_point" {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 	indicator "\n‚å®Ô∏è" {
 		modifiers= Shift;

--- a/test/data/keymaps/high-keycodes-1.xkb
+++ b/test/data/keymaps/high-keycodes-1.xkb
@@ -15,7 +15,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/high-keycodes-2.xkb
+++ b/test/data/keymaps/high-keycodes-2.xkb
@@ -15,7 +15,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/high-keycodes-3.xkb
+++ b/test/data/keymaps/high-keycodes-3.xkb
@@ -16,7 +16,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/high-keycodes-4.xkb
+++ b/test/data/keymaps/high-keycodes-4.xkb
@@ -19,7 +19,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/include-banana-implicit-default.xkb
+++ b/test/data/keymaps/include-banana-implicit-default.xkb
@@ -15,7 +15,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/include-capslock-custom.xkb
+++ b/test/data/keymaps/include-capslock-custom.xkb
@@ -15,7 +15,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/include-capslock-system.xkb
+++ b/test/data/keymaps/include-capslock-system.xkb
@@ -15,7 +15,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/include-level3-explicit-default.xkb
+++ b/test/data/keymaps/include-level3-explicit-default.xkb
@@ -34,7 +34,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/integers-overflow.xkb
+++ b/test/data/keymaps/integers-overflow.xkb
@@ -15,7 +15,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/integers.xkb
+++ b/test/data/keymaps/integers.xkb
@@ -16,7 +16,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/keycodes-aliases-1.xkb
+++ b/test/data/keymaps/keycodes-aliases-1.xkb
@@ -17,7 +17,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/keycodes-aliases-2.xkb
+++ b/test/data/keymaps/keycodes-aliases-2.xkb
@@ -31,7 +31,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/keycodes-aliases-3.xkb
+++ b/test/data/keymaps/keycodes-aliases-3.xkb
@@ -31,7 +31,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/keycodes-bounds-multiple-1.xkb
+++ b/test/data/keymaps/keycodes-bounds-multiple-1.xkb
@@ -16,7 +16,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/keycodes-bounds-multiple-2.xkb
+++ b/test/data/keymaps/keycodes-bounds-multiple-2.xkb
@@ -16,7 +16,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/keycodes-bounds-multiple-3.xkb
+++ b/test/data/keymaps/keycodes-bounds-multiple-3.xkb
@@ -16,7 +16,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/keycodes-bounds-single-1.xkb
+++ b/test/data/keymaps/keycodes-bounds-single-1.xkb
@@ -15,7 +15,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/keycodes-bounds-single-2.xkb
+++ b/test/data/keymaps/keycodes-bounds-single-2.xkb
@@ -15,7 +15,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/keycodes-long-names-1-v1.xkb
+++ b/test/data/keymaps/keycodes-long-names-1-v1.xkb
@@ -22,7 +22,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/keycodes-long-names-1-v2.xkb
+++ b/test/data/keymaps/keycodes-long-names-1-v2.xkb
@@ -22,7 +22,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/keycodes-long-names-2.xkb
+++ b/test/data/keymaps/keycodes-long-names-2.xkb
@@ -33,7 +33,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/level-index-names.xkb
+++ b/test/data/keymaps/level-index-names.xkb
@@ -16,7 +16,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/masks-extra-bits.xkb
+++ b/test/data/keymaps/masks-extra-bits.xkb
@@ -19,7 +19,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/masks.xkb
+++ b/test/data/keymaps/masks.xkb
@@ -19,7 +19,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/merge-modes/vmods-other-component-direct.xkb
+++ b/test/data/keymaps/merge-modes/vmods-other-component-direct.xkb
@@ -18,7 +18,7 @@ xkb_compatibility "" {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/merge-modes/vmods-same-component-include-default-augment.xkb
+++ b/test/data/keymaps/merge-modes/vmods-same-component-include-default-augment.xkb
@@ -18,7 +18,7 @@ xkb_compatibility "" {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/merge-modes/vmods-same-component-include-default-override.xkb
+++ b/test/data/keymaps/merge-modes/vmods-same-component-include-default-override.xkb
@@ -18,7 +18,7 @@ xkb_compatibility "" {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/no_void_action-v1.xkb
+++ b/test/data/keymaps/no_void_action-v1.xkb
@@ -17,7 +17,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/no_void_action-v2.xkb
+++ b/test/data/keymaps/no_void_action-v2.xkb
@@ -17,7 +17,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/optional-components-basic.xkb
+++ b/test/data/keymaps/optional-components-basic.xkb
@@ -15,7 +15,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/optional-components-no-real-led.xkb
+++ b/test/data/keymaps/optional-components-no-real-led.xkb
@@ -15,7 +15,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 	indicator "XXX" {
 		modifiers= Lock;

--- a/test/data/keymaps/optional-components-none.xkb
+++ b/test/data/keymaps/optional-components-none.xkb
@@ -14,7 +14,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/redirect-key-1.xkb
+++ b/test/data/keymaps/redirect-key-1.xkb
@@ -17,7 +17,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/symbols-modifier_map.xkb
+++ b/test/data/keymaps/symbols-modifier_map.xkb
@@ -48,7 +48,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 

--- a/test/data/keymaps/unicode-keysyms.xkb
+++ b/test/data/keymaps/unicode-keysyms.xkb
@@ -300,7 +300,7 @@ xkb_compatibility {
 	interpret.useModMapMods= AnyLevel;
 	interpret.repeat= False;
 	interpret VoidSymbol+AnyOfOrNone(none) {
-		repeat= True;
+		action= NoAction();
 	};
 };
 


### PR DESCRIPTION
The interpret fallback should be:

```c
interpret VoidSymbol+AnyOfOrNone(none) {
	action= NoAction();
};
```

not:

```c
interpret VoidSymbol+AnyOfOrNone(none) {
        repeat= True;
};
```