### PR TITLE
ci: Deactivate x11 tests on macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -70,5 +70,5 @@ jobs:
       - name: Test
         run: |
           source venv/bin/activate
-          # FIXME: deactivate x11comp test for now
-          meson test -C build --print-errorlogs --no-suite flaky
+          # FIXME: deactivate x11 tests for now
+          meson test -C build --print-errorlogs --no-suite x11


### PR DESCRIPTION
X11 tests are failing on X11 with no clear reason (see #1004). Deactivate them until a fix is found.
