### PR TITLE
Make -Wstrict-prototypes -Wold-style-definition clean

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -227,7 +227,7 @@ configh_data.set10('HAVE_DIRENT_H', have_dirent_h)
 has_extensions_directories = have_unistd_h and have_dirent_h
 configh_data.set10('HAVE_XKB_EXTENSIONS_DIRECTORIES', has_extensions_directories)
 if cc.links(
-    'int main(){if(__builtin_expect(1<0,0)){}}',
+    'int main(void){if(__builtin_expect(1<0,0)){}}',
     name: '__builtin_expect',
 )
     configh_data.set10('HAVE___BUILTIN_EXPECT', true)
@@ -357,7 +357,7 @@ xkbcommon_map = meson.current_source_dir() / 'xkbcommon.map'
 # Supports -Wl,--version-script?
 meson_test_map = meson.current_source_dir() / 'test' / 'meson_test.map'
 have_version_script = cc.links(
-    'int main() { return 0; }',
+    'int main(void) { return 0; }',
     args: f'-Wl,--version-script=@meson_test_map@',
     name: '-Wl,--version-script',
 )


### PR DESCRIPTION
```
--- before
+++ after
@@ -43,7 +43,7 @@
 Dependency xkeyboard-config-2 found: YES 2.47 (cached)
 Has header "unistd.h" : YES
 Has header "dirent.h" : YES
-Checking if "__builtin_expect" links: NO
+Checking if "__builtin_expect" links: YES
 Compiler for C supports arguments -Werror=attributes: YES
 Checking if "counted_by attribute for pointers" compiles: NO
 Header "unistd.h" has symbol "eaccess" : YES
@@ -63,7 +63,7 @@
 Checking for function "gnu_get_libc_version" : YES
 Header "locale.h" has symbol "newlocale" : YES
 Checking if "newlocale fails on invalid locales" runs: YES
-Checking if "-Wl,--version-script" links: NO
+Checking if "-Wl,--version-script" links: YES
 Program scripts/map-to-def found: YES (/home/soap/git/libxkbcommon/scripts/map-to-def)
 Program bison found: YES 3.8.2 3.8.2 (/usr/bin/bison)
 Found pkg-config: YES (/usr/bin/pkg-config) 2.5.1
```
We'd like to make all our packages compile with `-Wstrict-prototypes -Wold-style-definition`, since that's how we can smoke out all the old and likely buggy K&R C code.