### PR TITLE
State: refactor `xkb_machine_options` into a builder

### DIFF
--- a/bench/key-proc.c
+++ b/bench/key-proc.c
@@ -136,8 +136,12 @@ main(void)
      * Full server state machine API
      */
 
-    struct xkb_machine *sm = xkb_machine_new(keymap, NULL);
+    struct xkb_machine_builder *builder =
+        xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
+    assert(builder);
+    struct xkb_machine *sm = xkb_machine_new(builder);
     assert(sm);
+    xkb_machine_builder_destroy(builder);
     struct xkb_events *events = xkb_events_new_batch(ctx, XKB_EVENTS_NO_FLAGS);
     assert(events);
     state = xkb_state_new(keymap);

--- a/changes/api/+state-event-api.feature.md
+++ b/changes/api/+state-event-api.feature.md
@@ -6,10 +6,11 @@ Added the **server machine API:**
   - `xkb_machine_get_keymap()`
   - `xkb_machine_process_key()`
   - `xkb_machine_process_synthetic()`
-- `struct xkb_machine_options` (new):
-  - `xkb_machine_options_new()`
-  - `xkb_machine_options_destroy()`
-  - `xkb_machine_options_update_a11y_flags()`
+- `struct xkb_machine_builder` (new):
+  - `xkb_machine_builder_new()`
+  - `xkb_machine_builder_destroy()`
+  - `xkb_machine_builder_update_a11y_flags()`
+- `enum xkb_machine_builder_flags` (new)
 - `enum xkb_events_flags` (new)
 - `struct xkb_events` (new):
   - `xkb_events_new_batch()`

--- a/changes/api/+state-event-api.feature.md
+++ b/changes/api/+state-event-api.feature.md
@@ -9,7 +9,11 @@ Added the **server machine API:**
 - `struct xkb_machine_builder` (new):
   - `xkb_machine_builder_new()`
   - `xkb_machine_builder_destroy()`
+  - `xkb_machine_builder_get_keymap()`
   - `xkb_machine_builder_update_a11y_flags()`
+  - `xkb_machine_builder_remap_mods()`
+  - `xkb_machine_builder_update_shortcut_mods()`
+  - `xkb_machine_builder_remap_shortcut_layout()`
 - `enum xkb_machine_builder_flags` (new)
 - `enum xkb_events_flags` (new)
 - `struct xkb_events` (new):

--- a/changes/api/753.feature.md
+++ b/changes/api/753.feature.md
@@ -15,5 +15,5 @@ defined hereinabove, the active layout is switched to the target layout defined
 in the mapping, if any, otherwise it is left unchanged.
 
 Added API:
-- `xkb_machine_options::xkb_machine_options_update_shortcut_mods()`
-- `xkb_machine_options::xkb_machine_options_remap_shortcut_layout()`
+- `xkb_machine_builder::xkb_machine_builder_update_shortcut_mods()`
+- `xkb_machine_builder::xkb_machine_builder_remap_shortcut_layout()`

--- a/changes/api/914.feature.md
+++ b/changes/api/914.feature.md
@@ -1,2 +1,2 @@
-Added `xkb_machine_options::xkb_machine_options_remap_mods()` to enable remapping modifiers combos, e.g. to make `Control+Alt` map to `LevelThree` (`AltGr`).
+Added `xkb_machine_builder::xkb_machine_builder_remap_mods()` to enable remapping modifiers combos, e.g. to make `Control+Alt` map to `LevelThree` (`AltGr`).
 This help improving *compatibility* across platforms.

--- a/data/enums/xkbcommon-features.yaml
+++ b/data/enums/xkbcommon-features.yaml
@@ -35,6 +35,8 @@ xkb_feature:
     value: 24820
   - name: XKB_FEATURE_ENUM_CONSUMED_MODE
     value: 24840
+  - name: XKB_FEATURE_ENUM_MACHINE_BUILDER_FLAGS
+    value: 25200
   - name: XKB_FEATURE_ENUM_EVENT_TYPE
     value: 27000
   - name: XKB_FEATURE_ENUM_KEY_DIRECTION

--- a/data/enums/xkbcommon.yaml
+++ b/data/enums/xkbcommon.yaml
@@ -108,6 +108,9 @@ xkb_keyboard_control_flags:
 xkb_events_flags:
   - name: XKB_EVENTS_NO_FLAGS
     value: 0
+xkb_machine_builder_flags:
+  - name: XKB_MACHINE_BUILDER_NO_FLAGS
+    value: 0
 xkb_a11y_flags:
   - name: XKB_A11Y_NO_FLAGS
     value: 0

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -92,7 +92,7 @@ to encourage developers to implement the relevant [API][shortcuts-api].
 </dd>
 </dl>
 
-[shortcuts-api]: @ref xkb_machine_options::xkb_machine_options_remap_shortcut_layout
+[shortcuts-api]: @ref xkb_machine_builder::xkb_machine_builder_remap_shortcut_layout
 [keycodes]: @ref keycode-def
 [keysyms]: @ref keysym-def
 
@@ -560,7 +560,7 @@ the following functions from the `xkb_machine` API:
 
 <dl>
 <dt>
-`xkb_machine_options::xkb_machine_options_update_shortcut_mods()`
+`xkb_machine_builder::xkb_machine_builder_update_shortcut_mods()`
 </dt>
 <dd>
 Set the modifiers that will trigger the shortcuts tweak, typically
@@ -571,14 +571,14 @@ const xkb_mod_mask_t ctrl = xkb_keymap_mod_get_mask(keymap, XKB_MOD_NAME_CTRL);
 const xkb_mod_mask_t alt = xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_ALT);
 const xkb_mod_mask_t super = xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_SUPER);
 const xkb_mod_mask_t shortcuts_mask = ctrl | alt | super;
-if (xkb_machine_options_update_shortcut_mods(options, shortcuts_mask, shortcuts_mask)) {
+if (xkb_machine_builder_update_shortcut_mods(options, shortcuts_mask, shortcuts_mask)) {
     /* handle error */
     …
 }
 ```
 </dd>
 <dt>
-`xkb_machine_options::xkb_machine_options_remap_shortcut_layout()`
+`xkb_machine_builder::xkb_machine_builder_remap_shortcut_layout()`
 </dt>
 <dd>
 Set the layout to use for shortcuts for each relevant layout. There are 2 typical
@@ -593,7 +593,7 @@ be configured with *2* layouts: the user layout then the shortcut layout (e.g.
 `ara,us`).
 
 ```c
-if (xkb_machine_options_remap_shortcut_layout(options, 0, 1)) {
+if (xkb_machine_builder_remap_shortcut_layout(options, 0, 1)) {
     /* handle error */
     …
 }
@@ -608,7 +608,7 @@ all the layouts, typically using the first layout as the reference.
 // When using shortcuts, all layouts will behave as if using the *first* layout.
 const xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(keymap);
 for (xkb_layout_index_t source = 1; source < num_layouts; source++) {
-    if (xkb_machine_options_remap_shortcut_layout(options, source, 0)) {
+    if (xkb_machine_builder_remap_shortcut_layout(options, source, 0)) {
         /* handle error */
         …
     }

--- a/doc/quick-guide.md
+++ b/doc/quick-guide.md
@@ -280,9 +280,11 @@ int new_keyboard(…)
     * Initialize the keymap
     */
 
-    struct xkb_machine *machine;
-
-    machine = xkb_machine_new(keymap, NULL);
+    struct xkb_machine_builder *machine_builder =
+        xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
+    if (!machine_builder) <error>
+    struct xkb_machine *machine = xkb_machine_new(machine_builder);
+    xkb_machine_builder_destroy(machine_builder);
     if (!machine) <error>
 
     struct xkb_events *events;

--- a/include/xkbcommon/xkbcommon-features.h
+++ b/include/xkbcommon/xkbcommon-features.h
@@ -62,8 +62,8 @@ extern "C" {
  *     21    Keymap
  *  22-23    (reserved for keymap and state -related objects)
  *     24    Keyboard state components
- *     25    Keyboard state machine (reserved)
- *     26    (reserved for state-related object)
+ *     25    Keyboard state machine builder
+ *     26    Keyboard state machine (reserved)
  *     27    Keyboard events / input
  *  28-29    (spare)
  *     30    Compose table
@@ -198,6 +198,12 @@ enum xkb_feature {
      * @since 1.14.0
      */
     XKB_FEATURE_ENUM_CONSUMED_MODE = 24840,
+    /**
+     * The enumeration @ref xkb_machine_builder_flags
+     *
+     * @since 1.14.0
+     */
+    XKB_FEATURE_ENUM_MACHINE_BUILDER_FLAGS = 25200,
     /**
      * The enumeration @ref xkb_event_type
      *

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -2653,53 +2653,70 @@ XKB_EXPORT const struct xkb_event *
 xkb_events_next(struct xkb_events *events);
 
 /**
- * @struct xkb_machine_options
- * Opaque options object to configure an `xkb_machine`.
+ * @struct xkb_machine_builder
+ * Opaque builder object to configure an `xkb_machine`.
  *
- * Create with `xkb_machine_options_new()`, configure with the
- * `xkb_machine_options_*` functions, then pass to
+ * Create with `xkb_machine_builder_new()`, configure with the
+ * `xkb_machine_builder_*` functions, then pass to
  * `xkb_machine::xkb_machine_new()`.
- * The options object may be destroyed immediately after
+ * The builder object may be destroyed immediately after
  * `xkb_machine::xkb_machine_new()` returns.
  *
  * @since 1.14.0
  *
- * @sa `xkb_machine_options::xkb_machine_options_new()`
+ * @sa `xkb_machine_builder::xkb_machine_builder_new()`
  * @sa `xkb_machine::xkb_machine_new()`
  */
-struct xkb_machine_options;
+struct xkb_machine_builder;
 
 /**
- * Create a new `xkb_machine` options object.
+ * @enum xkb_machine_builder_flags
+ * Flags for `xkb_machine_builder::xkb_machine_builder_new()`
  *
- * @param context The context in which to create the options.
+ * @since 1.14.0
+ */
+enum xkb_machine_builder_flags {
+    /**
+     * Do not apply any flags.
+     *
+     * @since 1.14.0
+     */
+    XKB_MACHINE_BUILDER_NO_FLAGS = 0,
+};
+
+/**
+ * Create a new `xkb_machine` builder object.
  *
- * @returns A new `xkb_machine` options object, or `NULL` on failure.
+ * @param[in] keymap  The keymap which the state machine will use.
+ * @param[in] flags   Flags to control the builder behavior, or 0.
+ *
+ * @returns A new `xkb_machine` builder object, or `NULL` on failure.
  *
  * @since 1.14.0
  *
- * @memberof xkb_machine_options
+ * @memberof xkb_machine_builder
  */
-XKB_EXPORT struct xkb_machine_options *
-xkb_machine_options_new(struct xkb_context *context);
+XKB_EXPORT struct xkb_machine_builder *
+xkb_machine_builder_new(struct xkb_keymap *keymap,
+                        enum xkb_machine_builder_flags flags);
 
 /**
- * Free a `xkb_machine` options object.
+ * Free a `xkb_machine` builder object.
  *
- * @param options The `xkb_machine` options. If it is `NULL`, this function does
+ * @param builder The `xkb_machine` builder. If it is `NULL`, this function does
  * nothing.
  *
  * @since 1.14.0
  *
- * @memberof xkb_machine_options
+ * @memberof xkb_machine_builder
  */
 XKB_EXPORT void
-xkb_machine_options_destroy(struct xkb_machine_options *options);
+xkb_machine_builder_destroy(struct xkb_machine_builder *builder);
 
 /**
  * @enum xkb_a11y_flags
  * Flags for
- * `xkb_machine_options::xkb_machine_options_update_a11y_flags()`.
+ * `xkb_machine_builder::xkb_machine_builder_update_a11y_flags()`.
  *
  * These flags configure the accessibility (*a11y*) features.
  *
@@ -2763,22 +2780,22 @@ enum xkb_a11y_flags {
 };
 
 /**
- * Update the accessibility flags of an `xkb_machine_options` object.
+ * Update the accessibility flags of an `xkb_machine_builder` object.
  *
- * @param options The `state_machine` options object to modify.
- * @param affect  Accessibility flags to modify.
- * @param flags   Accessibility flags to set or unset. Only the flags in
- * @p affect are considered.
+ * @param[in,out] builder The `state_machine` builder object to modify.
+ * @param[in]     affect  Accessibility flags to modify.
+ * @param[in]     flags   Accessibility flags to set or unset. Only the flags in
+ *                        @p affect are considered.
  *
  * @returns `::XKB_SUCCESS` on success, otherwise an error code.
  *
  * @since 1.14.0
  *
- * @memberof xkb_machine_options
+ * @memberof xkb_machine_builder
  */
 XKB_EXPORT enum xkb_error_code
-xkb_machine_options_update_a11y_flags(
-    struct xkb_machine_options *options,
+xkb_machine_builder_update_a11y_flags(
+    struct xkb_machine_builder *builder,
     enum xkb_a11y_flags affect,
     enum xkb_a11y_flags flags
 );
@@ -2797,13 +2814,14 @@ xkb_machine_options_update_a11y_flags(
  * - There is no other remapping entry with the source modifiers being a
  *   superset of this entry. E.g. `Control+Alt` has priority over `Control`.
  *
- * @param options The `state_machine` options object to modify.
- * @param source  Modifier combination to remap, using their [encoding].
- *                Must be non-zero, unless both @p source and @p target are 0
- *                to clear all entries.
- * @param target  Modifier combination to remap to, using their [encoding],
- *                or 0 to remove the entry for @p source. If both @p source and
- *                @p target are 0, all entries are cleared.
+ * @param[in,out] builder The `state_machine` builder object to modify.
+ * @param[in]     source  Modifier combination to remap, using their [encoding].
+ *                        Must be non-zero, unless both @p source and @p target
+ *                        are 0 to clear all entries.
+ * @param[in]     target  Modifier combination to remap to, using their
+ *                        [encoding], or 0 to remove the entry for @p source.
+ *                        If both @p source and @p target are 0, all entries are
+ *                        cleared.
  *
  * @returns `::XKB_SUCCESS` on success, otherwise an error code.
  *
@@ -2814,7 +2832,7 @@ xkb_machine_options_update_a11y_flags(
  * const xkb_mod_mask_t ctrl = xkb_keymap_mod_get_mask(keymap, XKB_MOD_NAME_CTRL);
  * const xkb_mod_mask_t alt = xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_ALT);
  * const xkb_mod_mask_t level3 = xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_LEVEL3);
- * if (xkb_machine_options_remap_mods(options, ctrl | alt, level3)) {
+ * if (xkb_machine_builder_remap_mods(builder, ctrl | alt, level3)) {
  *     // handle error
  *     …
  * }
@@ -2822,13 +2840,13 @@ xkb_machine_options_update_a11y_flags(
  *
  * @since 1.14.0
  *
- * @memberof xkb_machine_options
+ * @memberof xkb_machine_builder
  *
  * [encoding]: @ref modifiers-encoding
  */
 XKB_EXPORT enum xkb_error_code
-xkb_machine_options_remap_mods(
-    struct xkb_machine_options *options,
+xkb_machine_builder_remap_mods(
+    struct xkb_machine_builder *builder,
     xkb_mod_mask_t source,
     xkb_mod_mask_t target
 );
@@ -2838,11 +2856,11 @@ xkb_machine_options_remap_mods(
  *
  * When any of the specified modifiers is active, the effective layout
  * is substituted according to the mapping set by
- * `xkb_machine_options_remap_shortcut_layout()`.
+ * `xkb_machine_builder_remap_shortcut_layout()`.
  * This ensures a consistent user experience with keyboard shortcuts
  * across the layouts.
  *
- * @param[in,out] options The `state_machine` options object to modify.
+ * @param[in,out] builder The `state_machine` builder object to modify.
  * @param[in]     affect  Modifiers to consider, using their [encoding].
  *                        Only modifiers present in this mask are modified
  *                        by @p mask.
@@ -2851,39 +2869,39 @@ xkb_machine_options_remap_mods(
  *
  * @returns `::XKB_SUCCESS` on success, otherwise an error code.
  *
- * @sa `xkb_machine_options_remap_shortcut_layout()`
+ * @sa `xkb_machine_builder_remap_shortcut_layout()`
  * @sa `xkb_keymap::xkb_keymap_mod_get_mask2()`
  * @since 1.14.0
- * @memberof xkb_machine_options
+ * @memberof xkb_machine_builder
  *
  * [encoding]: @ref modifiers-encoding
  */
 XKB_EXPORT enum xkb_error_code
-xkb_machine_options_update_shortcut_mods(struct xkb_machine_options *options,
+xkb_machine_builder_update_shortcut_mods(struct xkb_machine_builder *builder,
                                          xkb_mod_mask_t affect,
                                          xkb_mod_mask_t mask);
 
 /**
  * Set a layout substitution for the shortcut layout override.
  *
- * When any modifier set via `xkb_machine_options_update_shortcut_mods()` is
+ * When any modifier set via `xkb_machine_builder_update_shortcut_mods()` is
  * active, the effective layout @p source is substituted with layout @p target
  * in key processing. This allows shortcuts defined in layout @p target
  * (typically a Latin layout) to remain reachable when layout @p source is
  * active.
  *
- * @param[in,out] options The `state_machine` options object to modify.
+ * @param[in,out] builder The `state_machine` builder object to modify.
  * @param[in]     source  Source layout to substitute.
  * @param[in]     target  Target layout to use instead of @p source.
  *
  * @returns `::XKB_SUCCESS` on success, otherwise an error code.
  *
- * @sa `xkb_machine_options_update_shortcut_mods()`
+ * @sa `xkb_machine_builder_update_shortcut_mods()`
  * @since 1.14.0
- * @memberof xkb_machine_options
+ * @memberof xkb_machine_builder
  */
 XKB_EXPORT enum xkb_error_code
-xkb_machine_options_remap_shortcut_layout(struct xkb_machine_options *options,
+xkb_machine_builder_remap_shortcut_layout(struct xkb_machine_builder *builder,
                                           xkb_layout_index_t source,
                                           xkb_layout_index_t target);
 
@@ -2896,9 +2914,7 @@ xkb_machine_options_remap_shortcut_layout(struct xkb_machine_options *options,
  * `xkb_state::xkb_state_update_mask()`.
  * See @ref server-client-state for  further information.
  *
- * @param keymap  The keymap which the state machine will use.
- * @param options The options to configure the state machine, or `NULL` to use
- * the defaults.
+ * @param builder The builder object to configure the state machine.
  *
  * @returns A new keyboard state machine object, or `NULL` on failure.
  *
@@ -2907,8 +2923,7 @@ xkb_machine_options_remap_shortcut_layout(struct xkb_machine_options *options,
  * @memberof xkb_machine
  */
 XKB_EXPORT struct xkb_machine *
-xkb_machine_new(struct xkb_keymap *keymap,
-                const struct xkb_machine_options *options);
+xkb_machine_new(const struct xkb_machine_builder *builder);
 
 /**
  * Take a new reference on a `xkb_machine` object.

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -4311,7 +4311,7 @@ xkb_state_layout_name_is_active(struct xkb_state *state, const char *name,
  * Test whether a layout is active in a given keyboard state by index.
  *
  * @param[in] state The keyboard state.
- * @param[in] name  The layout index to test.
+ * @param[in] idx   The layout index to test.
  * @param[in] type  The component of the state against which to match the
  * given layout.
  *
@@ -4331,8 +4331,6 @@ xkb_state_layout_index_is_active(struct xkb_state *state,
  *
  * @param[in] state The keyboard state.
  * @param[in] name  The LED name to test (`NULL`-terminated string).
- * @param[in] type  The component of the state against which to match the
- * given LED.
  *
  * @returns 1 if the LED is active, 0 if it not.  If no LED with this name
  * exists in the keymap, returns -1.
@@ -4348,8 +4346,6 @@ xkb_state_led_name_is_active(struct xkb_state *state, const char *name);
  *
  * @param[in] state The keyboard state.
  * @param[in] idx   The LED index to test.
- * @param[in] type  The component of the state against which to match the
- * given LED.
  *
  * @returns 1 if the LED is active, 0 if it not.  If the LED index is not
  * valid in the keymap, returns -1.

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -2714,6 +2714,25 @@ XKB_EXPORT void
 xkb_machine_builder_destroy(struct xkb_machine_builder *builder);
 
 /**
+ * Get the keymap which a `xkb_machine_builder` object is using.
+ *
+ * @param builder The state machine builder.
+ *
+ * @returns The keymap which was passed to `xkb_machine_builder_new()` when
+ * creating this `xkb_machine` object.
+ *
+ * @warning This function does not take a new reference on the keymap; you must
+ * explicitly reference it yourself if you plan to use it beyond the
+ * lifetime of the `xkb_machine_builder` object.
+ *
+ * @since 1.14.0
+ *
+ * @memberof xkb_machine_builder
+ */
+XKB_EXPORT struct xkb_keymap *
+xkb_machine_builder_get_keymap(const struct xkb_machine_builder *builder);
+
+/**
  * @enum xkb_a11y_flags
  * Flags for
  * `xkb_machine_builder::xkb_machine_builder_update_a11y_flags()`.

--- a/src/features.c
+++ b/src/features.c
@@ -105,6 +105,10 @@ xkb_feature_supported(enum xkb_feature feature, uint32_t value)
         );
     case XKB_FEATURE_ENUM_CONSUMED_MODE:
         return is_supported_enum_value_mask(XKB_CONSUMED_MODE_VALUES, value);
+    case XKB_FEATURE_ENUM_MACHINE_BUILDER_FLAGS:
+        return is_supported_flag_value(
+            XKB_MACHINE_BUILDER_FLAGS_VALUES, true, value
+        );
     case XKB_FEATURE_ENUM_EVENT_TYPE:
         return is_supported_enum_value_mask(XKB_EVENT_TYPE_VALUES, value);
     case XKB_FEATURE_ENUM_KEY_DIRECTION:

--- a/src/features/enums.h
+++ b/src/features/enums.h
@@ -145,6 +145,9 @@ enum xkb_enumerations_values {
     XKB_EVENTS_FLAGS_VALUES
         = XKB_EVENTS_NO_FLAGS
     ,
+    XKB_MACHINE_BUILDER_FLAGS_VALUES
+        = XKB_MACHINE_BUILDER_NO_FLAGS
+    ,
     XKB_A11Y_FLAGS_VALUES
         = XKB_A11Y_NO_FLAGS
         | XKB_A11Y_LATCH_TO_LOCK
@@ -306,6 +309,12 @@ static const uint32_t xkb_events_flags_values[] = {
 #endif
 
 #ifdef ENABLE_PRIVATE_APIS
+static const uint32_t xkb_machine_builder_flags_values[] = {
+    XKB_MACHINE_BUILDER_NO_FLAGS,
+};
+#endif
+
+#ifdef ENABLE_PRIVATE_APIS
 static const uint32_t xkb_a11y_flags_values[] = {
     XKB_A11Y_NO_FLAGS,
     XKB_A11Y_LATCH_TO_LOCK,
@@ -417,6 +426,7 @@ static const uint32_t xkb_feature_values[] = {
     XKB_FEATURE_ENUM_STATE_MODE,
     XKB_FEATURE_ENUM_STATE_MATCH,
     XKB_FEATURE_ENUM_CONSUMED_MODE,
+    XKB_FEATURE_ENUM_MACHINE_BUILDER_FLAGS,
     XKB_FEATURE_ENUM_EVENT_TYPE,
     XKB_FEATURE_ENUM_KEY_DIRECTION,
     XKB_FEATURE_ENUM_EVENTS_FLAGS,

--- a/src/state.c
+++ b/src/state.c
@@ -2881,6 +2881,13 @@ xkb_machine_builder_destroy(struct xkb_machine_builder *builder)
     free(builder);
 }
 
+struct xkb_keymap *
+xkb_machine_builder_get_keymap(const struct xkb_machine_builder *builder)
+{
+    /* Reference count is not updated. See API doc. */
+    return builder->keymap;
+}
+
 enum xkb_error_code
 xkb_machine_builder_update_a11y_flags(
     struct xkb_machine_builder *builder,

--- a/src/state.c
+++ b/src/state.c
@@ -32,6 +32,7 @@
 #include "xkbcommon/xkbcommon-errors.h"
 #include "xkbcommon/xkbcommon-features.h"
 #include "darray.h"
+#include "features/enums.h"
 #include "keymap.h"
 #include "keysym.h"
 #include "messages-codes.h"
@@ -1895,9 +1896,9 @@ log_abi_error(struct xkb_context * restrict ctx,
 
 /* Check ABI compatibility */
 static enum xkb_error_code
-check_state_update_abi_(struct xkb_context *restrict ctx,
-                        const char *restrict func,
-                        const struct xkb_state_update *restrict update)
+check_state_update_abi_(struct xkb_context * restrict ctx,
+                        const char * restrict func,
+                        const struct xkb_state_update * restrict update)
 {
     enum xkb_error_code error = XKB_SUCCESS;
     if ((error = xkb_check_state_update_size(update)) ||
@@ -1914,8 +1915,8 @@ check_state_update_abi_(struct xkb_context *restrict ctx,
     check_state_update_abi_(ctx, __func__, update)
 
 enum xkb_error_code
-xkb_state_update_synthetic(struct xkb_state *base_state,
-                           const struct xkb_state_update *update,
+xkb_state_update_synthetic(struct xkb_state * base_state,
+                           const struct xkb_state_update * update,
                            enum xkb_state_component *changed)
 {
     /* Guard against client-only state */
@@ -1947,7 +1948,7 @@ xkb_state_update_synthetic(struct xkb_state *base_state,
     }
 
     if (update->components) {
-        const struct xkb_state_components_update * restrict const components =
+        const struct xkb_state_components_update * const components =
             update->components;
         /* Update boolean controls first */
         state_update_enabled_controls(state,
@@ -2805,10 +2806,17 @@ struct xkb_machine {
 
 typedef darray(struct machine_mods_mapping) machine_mods_mappings;
 
-struct xkb_machine_options {
-    /** Accessibility flags */
-    enum xkb_a11y_flags a11y_affect;
-    enum xkb_a11y_flags a11y_flags;
+struct xkb_machine_builder {
+    struct xkb_keymap *keymap;
+
+    /** Controls */
+    struct {
+        /** Accessibility flags */
+        struct {
+            enum xkb_a11y_flags affect;
+            enum xkb_a11y_flags flags;
+        } a11y;
+    } controls;
 
     /** Modifiers re-mapping */
     machine_mods_mappings mods;
@@ -2821,75 +2829,90 @@ struct xkb_machine_options {
         darray(xkb_layout_index_t) targets;
     } shortcuts;
 
-    struct xkb_context *ctx;
+    enum xkb_machine_builder_flags flags;
 };
 
-#define machine_options_new(context) { \
-    .a11y_affect = XKB_A11Y_NO_FLAGS, \
-    .a11y_flags  = XKB_A11Y_NO_FLAGS, \
-    .shortcuts = {                          \
-        .mask = 0,                          \
-        .targets = darray_new(),            \
-    },                                      \
-    .ctx = (context),                       \
-}
-
-/* Default state options */
-static const struct xkb_machine_options default_machine_options =
-    machine_options_new(NULL /* unused */);
-
-struct xkb_machine_options *
-xkb_machine_options_new(struct xkb_context *context)
+struct xkb_machine_builder *
+xkb_machine_builder_new(struct xkb_keymap *keymap,
+                        enum xkb_machine_builder_flags flags)
 {
-    struct xkb_machine_options * restrict const opt = calloc(1, sizeof(*opt));
+    const enum xkb_machine_builder_flags invalid_flags
+        = flags
+        & ~(enum xkb_machine_builder_flags)XKB_MACHINE_BUILDER_FLAGS_VALUES;
+    if (invalid_flags) {
+        log_err(keymap->ctx, XKB_LOG_MESSAGE_NO_ID,
+                "%s: unrecognized keymap compilation flags: 0x%x\n",
+                __func__, invalid_flags);
+        return NULL;
+    }
+
+    struct xkb_machine_builder * const opt = calloc(1, sizeof(*opt));
     if (!opt)
         return NULL;
 
-    *opt = (struct xkb_machine_options)
-           machine_options_new(xkb_context_ref(context));
+    *opt = (struct xkb_machine_builder) {
+        .keymap = xkb_keymap_ref(keymap),
+        .flags = flags,
+        .controls = {
+            .a11y = {
+                .affect = XKB_A11Y_NO_FLAGS,
+                .flags = XKB_A11Y_NO_FLAGS,
+            },
+        },
+        .mods = darray_new(),
+        .shortcuts = {
+            .mask = 0,
+            .targets = darray_new(),
+        },
+    };
 
     return opt;
 }
 
 void
-xkb_machine_options_destroy(struct xkb_machine_options *options)
+xkb_machine_builder_destroy(struct xkb_machine_builder *builder)
 {
-    if (options == NULL)
+    if (builder == NULL)
         return;
 
-    darray_free(options->shortcuts.targets);
-    darray_free(options->mods);
-    xkb_context_unref(options->ctx);
-    free(options);
+    darray_free(builder->shortcuts.targets);
+    darray_free(builder->mods);
+    xkb_keymap_unref(builder->keymap);
+    free(builder);
 }
 
 enum xkb_error_code
-xkb_machine_options_update_a11y_flags(
-    struct xkb_machine_options *options,
+xkb_machine_builder_update_a11y_flags(
+    struct xkb_machine_builder *builder,
     enum xkb_a11y_flags affect,
     enum xkb_a11y_flags flags)
 {
-    static const enum xkb_a11y_flags XKB_A11Y_FLAGS
-        = XKB_A11Y_LATCH_TO_LOCK
-        | XKB_A11Y_LATCH_SIMULTANEOUS_KEYS;
+    const enum xkb_a11y_flags invalid_flags =
+        ~(enum xkb_a11y_flags)XKB_A11Y_FLAGS_VALUES;
 
-    if (affect & ~XKB_A11Y_FLAGS) {
-        log_err_func(options->ctx, XKB_LOG_MESSAGE_NO_ID,
-                     "unrecognized state flags: %#x\n",
-                     (flags & ~XKB_A11Y_FLAGS));
+    if (affect & invalid_flags) {
+        log_err_func(builder->keymap->ctx, XKB_LOG_MESSAGE_NO_ID,
+                     "%s: unrecognized A11Y affected flags: %#x\n",
+                     __func__, affect & invalid_flags);
+        return XKB_ERROR_UNSUPPORTED_A11Y_FLAGS;
+    }
+    if (flags & invalid_flags) {
+        log_err_func(builder->keymap->ctx, XKB_LOG_MESSAGE_NO_ID,
+                     "%s: unrecognized A11Y flags: %#x\n",
+                     __func__, flags & invalid_flags);
         return XKB_ERROR_UNSUPPORTED_A11Y_FLAGS;
     }
 
-    options->a11y_affect |= affect;
-    options->a11y_flags &= ~affect;
-    options->a11y_flags |= (flags & affect);
+    builder->controls.a11y.affect |= affect;
+    builder->controls.a11y.flags &= ~affect;
+    builder->controls.a11y.flags |= (flags & affect);
 
     return XKB_SUCCESS;
 }
 
 enum xkb_error_code
-xkb_machine_options_remap_mods(
-    struct xkb_machine_options *options,
+xkb_machine_builder_remap_mods(
+    struct xkb_machine_builder *builder,
     xkb_mod_mask_t source,
     xkb_mod_mask_t target
 )
@@ -2897,20 +2920,35 @@ xkb_machine_options_remap_mods(
     if (!source) {
         if (!target) {
             /* Reset mappings */
-            darray_resize(options->mods, 0);
+            darray_resize(builder->mods, 0);
             return XKB_SUCCESS;
         } else {
             return XKB_ERROR_UNSUPPORTED_MODIFIER_MASK;
         }
     }
 
+    /* Check the modifiers against the keymap */
+    const xkb_mod_mask_t invalid = ~builder->keymap->canonical_state_mask;
+    if ((source & invalid)) {
+        log_err(builder->keymap->ctx, XKB_ERROR_UNSUPPORTED_MODIFIER_MASK,
+                "%s: Invalid source modifiers: 0x%"PRIx32"\n",
+                __func__, source);
+        return XKB_ERROR_UNSUPPORTED_MODIFIER_MASK;
+    }
+    if ((target & invalid)) {
+        log_err(builder->keymap->ctx, XKB_ERROR_UNSUPPORTED_MODIFIER_MASK,
+                "%s: Invalid target modifiers: 0x%"PRIx32"\n",
+                __func__, target);
+        return XKB_ERROR_UNSUPPORTED_MODIFIER_MASK;
+    }
+
     struct machine_mods_mapping *mapping = NULL;
     darray_size_t m = 0;
-    darray_enumerate(m, mapping, options->mods) {
+    darray_enumerate(m, mapping, builder->mods) {
         if (mapping->source == source) {
             if (!target) {
                 /* Remove mapping */
-                darray_remove(options->mods, m);
+                darray_remove(builder->mods, m);
             } else {
                 /* Update mapping */
                 mapping->target = target;
@@ -2922,7 +2960,7 @@ xkb_machine_options_remap_mods(
     if (target) {
         /* Append new mapping */
         darray_append(
-            options->mods,
+            builder->mods,
             (struct machine_mods_mapping) {
                 .source = source,
                 .target = target
@@ -2936,37 +2974,58 @@ xkb_machine_options_remap_mods(
 }
 
 enum xkb_error_code
-xkb_machine_options_update_shortcut_mods(struct xkb_machine_options *options,
+xkb_machine_builder_update_shortcut_mods(struct xkb_machine_builder *builder,
                                          xkb_mod_mask_t affect,
                                          xkb_mod_mask_t mask)
 {
-    options->shortcuts.mask &= ~affect;
-    options->shortcuts.mask |= (mask & affect);
+    /* Check the modifiers against the keymap */
+    const xkb_mod_mask_t invalid = ~builder->keymap->canonical_state_mask;
+    if ((affect & invalid)) {
+        log_err(builder->keymap->ctx, XKB_ERROR_UNSUPPORTED_MODIFIER_MASK,
+                "%s: Invalid affected modifiers: 0x%"PRIx32"\n",
+                __func__, affect);
+        return XKB_ERROR_UNSUPPORTED_MODIFIER_MASK;
+    }
+    if ((mask & invalid)) {
+        log_err(builder->keymap->ctx, XKB_ERROR_UNSUPPORTED_MODIFIER_MASK,
+                "%s: Invalid modifiers: 0x%"PRIx32"\n",
+                __func__, mask);
+        return XKB_ERROR_UNSUPPORTED_MODIFIER_MASK;
+    }
+
+    builder->shortcuts.mask &= ~affect;
+    builder->shortcuts.mask |= (mask & affect);
     return XKB_SUCCESS;
 }
 
 enum xkb_error_code
-xkb_machine_options_remap_shortcut_layout(struct xkb_machine_options *options,
+xkb_machine_builder_remap_shortcut_layout(struct xkb_machine_builder *builder,
                                           xkb_layout_index_t source,
                                           xkb_layout_index_t target)
 {
-    if (source >= XKB_MAX_GROUPS || target >= XKB_MAX_GROUPS)
+    if (source >= builder->keymap->num_groups) {
+        log_err(builder->keymap->ctx, XKB_ERROR_UNSUPPORTED_LAYOUT_INDEX,
+                "%s: Invalid source layout: %"PRIu32"\n", __func__, source);
         return XKB_ERROR_UNSUPPORTED_LAYOUT_INDEX;
-
-    if (target == source) {
-        /* Skip default setting */
-        return XKB_SUCCESS;
+    }
+    if (target >= builder->keymap->num_groups) {
+        log_err(builder->keymap->ctx, XKB_ERROR_UNSUPPORTED_LAYOUT_INDEX,
+                "%s: Invalid target layout: %"PRIu32"\n", __func__, target);
+        return XKB_ERROR_UNSUPPORTED_LAYOUT_INDEX;
     }
 
-    struct xkb_shortcuts_config_options * restrict config = &options->shortcuts;
+    struct xkb_shortcuts_config_options * const config = &builder->shortcuts;
 
     /* Resize array & initialize new entries, if relevant */
     if (source >= darray_size(config->targets)) {
+        if (target == source) {
+            /* Skip default setting */
+            return XKB_SUCCESS;
+        }
         xkb_layout_index_t new = darray_size(config->targets);
         darray_resize(config->targets, source + 1);
         for (; new < source; new++)
-            darray_item(config->targets, new) =
-                XKB_LAYOUT_INVALID;
+            darray_item(config->targets, new) = XKB_LAYOUT_INVALID;
     }
 
     darray_item(config->targets, source) = (source == target)
@@ -3031,7 +3090,7 @@ machine_set_mods(struct xkb_machine *sm,
          * For other type of overlaps, see the sorting function.
          */
         qsort(darray_items(mappings), darray_size(mappings),
-            sizeof(*darray_items(mappings)), &cmp_mod_masks);
+              sizeof(*darray_items(mappings)), &cmp_mod_masks);
 
         darray_steal(
             mappings,
@@ -3051,8 +3110,8 @@ machine_set_mods(struct xkb_machine *sm,
 }
 
 static bool
-machine_set_shortcuts(struct xkb_machine *sm,
-                      const struct xkb_shortcuts_config_options *options)
+machine_set_shortcuts(struct xkb_machine * restrict sm,
+                      const struct xkb_shortcuts_config_options * restrict options)
 {
     if (darray_empty(options->targets)) {
         sm->config.shortcuts = (struct machine_shortcuts_config) {
@@ -3062,7 +3121,7 @@ machine_set_shortcuts(struct xkb_machine *sm,
         return true;
     }
 
-    struct xkb_keymap * const restrict keymap = sm->base.base.keymap;
+    struct xkb_keymap * const keymap = sm->base.base.keymap;
 
     /* Consider only defined layouts */
     xkb_layout_index_t count = MIN(
@@ -3081,13 +3140,8 @@ machine_set_shortcuts(struct xkb_machine *sm,
         return true;
 
     xkb_mod_mask_t mask = options->mask;
-    if (mask) {
-        /* Sanitize mask */
-        mask &= (xkb_mod_mask_t)
-                ((UINT64_C(1) << xkb_keymap_num_mods(keymap)) - 1);
-    } else {
-        /* No default mask */
-    }
+    /* Sanitize mask */
+    mask &= sm->base.base.keymap->canonical_state_mask;
     if (!mask)
         return true;
 
@@ -3115,21 +3169,18 @@ machine_set_shortcuts(struct xkb_machine *sm,
 }
 
 struct xkb_machine *
-xkb_machine_new(struct xkb_keymap *keymap,
-                const struct xkb_machine_options *options)
+xkb_machine_new(const struct xkb_machine_builder *builder)
 {
     struct xkb_machine * const machine = calloc(1, sizeof(*machine));
     if (!machine)
         return NULL;
 
-    if (!options)
-        options = &default_machine_options;
+    xkb_server_state_init(&machine->base, builder->keymap, SERVER_STATE,
+                          builder->controls.a11y.affect,
+                          builder->controls.a11y.flags);
 
-    xkb_server_state_init(&machine->base, keymap, SERVER_STATE,
-                          options->a11y_affect, options->a11y_flags);
-
-    if (!machine_set_mods(machine, &options->mods) ||
-        !machine_set_shortcuts(machine, &options->shortcuts))
+    if (!machine_set_mods(machine, &builder->mods) ||
+        !machine_set_shortcuts(machine, &builder->shortcuts))
         goto error;
 
     darray_init(machine->overlays.keys);
@@ -3247,7 +3298,7 @@ xkb_machine_process_synthetic(struct xkb_machine *sm,
     }
 
     if (update->components) {
-        const struct xkb_state_components_update * restrict const components =
+        const struct xkb_state_components_update * const components =
             update->components;
         /* Update boolean controls first */
         state_update_enabled_controls(state,
@@ -3281,10 +3332,10 @@ xkb_machine_process_synthetic(struct xkb_machine *sm,
 }
 
 static ssize_t
-do_remap_modifiers(const struct machine_modifiers_config *mappings,
-                   struct xkb_state *state,
-                   struct xkb_events *events,
-                   const struct xkb_key *key)
+do_remap_modifiers(const struct machine_modifiers_config * restrict mappings,
+                   struct xkb_state * restrict state,
+                   struct xkb_events * restrict events,
+                   const struct xkb_key * restrict key)
 {
     if (!(mappings->mask & state->components.mods))
         return -1;
@@ -3293,12 +3344,11 @@ do_remap_modifiers(const struct machine_modifiers_config *mappings,
     if (layout >= key->num_groups)
         return -1;
 
-    const struct xkb_key_type * restrict const type =
-        key->groups[layout].type;
+    const struct xkb_key_type * const type = key->groups[layout].type;
     xkb_mod_mask_t affect = 0;
     xkb_mod_mask_t mods = 0;
     for (darray_size_t m = 0; m < mappings->mappings_num; m++) {
-        const struct machine_mods_mapping * restrict const mapping =
+        const struct machine_mods_mapping * const mapping =
             &mappings->mappings[m];
         if (/* Skip not matching active mods */
             (mapping->source & state->components.mods) == mapping->source &&

--- a/test/features.c
+++ b/test/features.c
@@ -53,6 +53,7 @@ test_libxkbcommon_enums(void)
         ENUM(XKB_FEATURE_ENUM_STATE_MODE, xkb_state_mode_values, ENUM_NONE),
         ENUM(XKB_FEATURE_ENUM_STATE_MATCH, xkb_state_match_values, ENUM_FLAG),
         ENUM(XKB_FEATURE_ENUM_CONSUMED_MODE, xkb_consumed_mode_values, ENUM_NONE),
+        ENUM(XKB_FEATURE_ENUM_MACHINE_BUILDER_FLAGS, xkb_machine_builder_flags_values, ENUM_FLAG),
         ENUM(XKB_FEATURE_ENUM_EVENT_TYPE, xkb_event_type_values, ENUM_NONE),
         ENUM(XKB_FEATURE_ENUM_KEY_DIRECTION, xkb_key_direction_values, ENUM_NONE),
         ENUM(XKB_FEATURE_ENUM_EVENTS_FLAGS, xkb_events_flags_values, ENUM_FLAG),

--- a/test/server-state.c
+++ b/test/server-state.c
@@ -168,32 +168,37 @@ xkb_machine_update_latched_locked(struct xkb_machine *machine,
 }
 
 static void
-test_machine_options(struct xkb_context *ctx)
+test_machine_builder(struct xkb_context *ctx)
 {
-    struct xkb_machine_options *options = xkb_machine_options_new(ctx);
-    assert(options);
-
-    /* Invalid flags */
-    assert(xkb_machine_options_update_a11y_flags(options, -1000, 0) ==
-           XKB_ERROR_UNSUPPORTED_A11Y_FLAGS);
-    assert(xkb_machine_options_update_a11y_flags(options, 1000, 0) ==
-           XKB_ERROR_UNSUPPORTED_A11Y_FLAGS);
-
-    /* Valid flags */
-    static_assert(XKB_A11Y_NO_FLAGS == 0, "default flags");
-    assert(xkb_machine_options_update_a11y_flags(
-            options, XKB_A11Y_NO_FLAGS, 1000) == 0);
-
     struct xkb_keymap *keymap =
         xkb_keymap_new_from_names(ctx, NULL, TEST_KEYMAP_COMPILE_FLAGS);
     assert(keymap);
 
-    struct xkb_machine *sm = xkb_machine_new(keymap, options);
+    struct xkb_machine_builder *builder =
+        xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
+    assert(builder);
+
+    /* Valid flags */
+    static_assert(XKB_A11Y_NO_FLAGS == 0, "default flags");
+    assert(xkb_machine_builder_update_a11y_flags(
+            builder, XKB_A11Y_NO_FLAGS, XKB_A11Y_NO_FLAGS) == 0);
+
+    /* Invalid flags */
+    assert(xkb_machine_builder_update_a11y_flags(builder, -1000, 0) ==
+           XKB_ERROR_UNSUPPORTED_A11Y_FLAGS);
+    assert(xkb_machine_builder_update_a11y_flags(builder, 0, -1000) ==
+           XKB_ERROR_UNSUPPORTED_A11Y_FLAGS);
+    assert(xkb_machine_builder_update_a11y_flags(builder, 1000, 0) ==
+           XKB_ERROR_UNSUPPORTED_A11Y_FLAGS);
+    assert(xkb_machine_builder_update_a11y_flags(builder, 0, 1000) ==
+           XKB_ERROR_UNSUPPORTED_A11Y_FLAGS);
+
+    struct xkb_machine *sm = xkb_machine_new(builder);
     assert(sm);
 
     xkb_machine_unref(sm);
+    xkb_machine_builder_destroy(builder);
     xkb_keymap_unref(keymap);
-    xkb_machine_options_destroy(options);
 }
 
 /* Check that derived state is correctly initialized */
@@ -206,12 +211,18 @@ test_initial_derived_values(struct xkb_context *ctx)
     );
     assert(keymap);
 
-    struct xkb_machine * const sm = xkb_machine_new(keymap, NULL);
+    struct xkb_machine_builder *builder =
+        xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
+    assert(builder);
+
+    struct xkb_machine * const sm = xkb_machine_new(builder);
     assert(sm);
+
     struct xkb_state * const state = xkb_machine_get_state(sm);
     assert(xkb_state_led_name_is_active(state, XKB_LED_NAME_SCROLL));
 
     xkb_machine_unref(sm);
+    xkb_machine_builder_destroy(builder);
     xkb_keymap_unref(keymap);
 }
 
@@ -227,8 +238,11 @@ test_state_update(struct xkb_context *ctx)
 
     struct xkb_state * const state = xkb_state_new(keymap);
     assert(state);
-    struct xkb_machine * const sm = xkb_machine_new(keymap, NULL);
+    struct xkb_machine_builder *builder =
+        xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
+    struct xkb_machine * const sm = xkb_machine_new(builder);
     assert(sm);
+    xkb_machine_builder_destroy(builder);
     struct xkb_events * const events = xkb_events_new_batch(ctx,
                                                             XKB_EVENTS_NO_FLAGS);
     assert(events);
@@ -522,8 +536,14 @@ test_group_wrap(struct xkb_context *ctx)
     const xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(keymap);
     assert(num_layouts == 4);
 
-    struct xkb_machine * const sm = xkb_machine_new(keymap, NULL);
+    struct xkb_machine_builder *builder =
+        xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
+    assert(builder);
+
+    struct xkb_machine * const sm = xkb_machine_new(builder);
     assert(sm);
+    xkb_machine_builder_destroy(builder);
+
     struct xkb_state * const state = xkb_state_new(keymap);
     assert(state);
 
@@ -626,8 +646,12 @@ test_sticky_keys(struct xkb_context *ctx)
     );
     assert(keymap);
 
-    struct xkb_machine *sm = xkb_machine_new(keymap, NULL);
+    struct xkb_machine_builder *builder =
+        xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
+    assert(builder);
+    struct xkb_machine *sm = xkb_machine_new(builder);
     assert(sm);
+    xkb_machine_builder_destroy(builder);
     struct xkb_events *events = xkb_events_new_batch(ctx, XKB_EVENTS_NO_FLAGS);
     assert(events);
     struct xkb_state *state = xkb_state_new(keymap);
@@ -880,15 +904,16 @@ test_sticky_keys(struct xkb_context *ctx)
      * Test latch-to-lock
      */
 
-    struct xkb_machine_options * const sm_options = xkb_machine_options_new(ctx);
-    assert(sm_options);
-    assert(xkb_machine_options_update_a11y_flags(
-                sm_options,
+    struct xkb_machine_builder * const sm_builder =
+        xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
+    assert(sm_builder);
+    assert(xkb_machine_builder_update_a11y_flags(
+                sm_builder,
                 XKB_A11Y_LATCH_TO_LOCK,
                 XKB_A11Y_LATCH_TO_LOCK) == 0);
-    sm = xkb_machine_new(keymap, sm_options);
+    sm = xkb_machine_new(sm_builder);
     assert(sm);
-    xkb_machine_options_destroy(sm_options);
+    xkb_machine_builder_destroy(sm_builder);
     events = xkb_events_new_batch(ctx, XKB_EVENTS_NO_FLAGS);
     assert(events);
     state = xkb_state_new(keymap);
@@ -954,8 +979,13 @@ test_redirect_key(struct xkb_context *ctx)
     );
     assert(keymap);
 
-    struct xkb_machine *sm = xkb_machine_new(keymap, NULL);
+    struct xkb_machine_builder *builder =
+        xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
+    assert(builder);
+
+    struct xkb_machine *sm = xkb_machine_new(builder);
     assert(sm);
+    xkb_machine_builder_destroy(builder);
 
     static const xkb_mod_mask_t shift = UINT32_C(1) << XKB_MOD_INDEX_SHIFT;
     static const xkb_mod_mask_t ctrl = UINT32_C(1) << XKB_MOD_INDEX_CTRL;
@@ -1164,15 +1194,16 @@ test_shortcuts_tweak(struct xkb_context *context)
     const xkb_mod_mask_t level3 = _xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_LEVEL3);
     const xkb_mod_mask_t level5 = _xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_LEVEL5);
 
-    struct xkb_machine_options * const options = xkb_machine_options_new(context);
-    assert(options);
+    struct xkb_machine_builder *builder =
+        xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
+    assert(builder);
 
-    assert(xkb_machine_options_update_shortcut_mods(options, ctrl, ctrl)
+    assert(xkb_machine_builder_update_shortcut_mods(builder, ctrl, ctrl)
            == 0);
-    assert(xkb_machine_options_remap_shortcut_layout(options, 1, 2) == 0);
-    assert(xkb_machine_options_remap_shortcut_layout(options, 3, 0) == 0);
+    assert(xkb_machine_builder_remap_shortcut_layout(builder, 1, 2) == 0);
+    assert(xkb_machine_builder_remap_shortcut_layout(builder, 3, 0) == 0);
 
-    struct xkb_machine * sm = xkb_machine_new(keymap, options);
+    struct xkb_machine * sm = xkb_machine_new(builder);
     assert(sm);
 
     struct xkb_events * const events = xkb_events_new_batch(context,
@@ -2093,10 +2124,10 @@ test_shortcuts_tweak(struct xkb_context *context)
      * Use modifiers tweak in addition to the shortcuts tweak
      */
 
-    assert(!xkb_machine_options_remap_mods(options,
-                                          ctrl | alt, level3));
+    assert(!xkb_machine_builder_remap_mods(builder,
+                                           ctrl | alt, level3));
 
-    sm = xkb_machine_new(keymap, options);
+    sm = xkb_machine_new(builder);
     assert(sm);
 
     assert(xkb_machine_update_latched_locked(sm, events,
@@ -2387,7 +2418,7 @@ test_shortcuts_tweak(struct xkb_context *context)
 
     xkb_machine_unref(sm);
     xkb_events_destroy(events);
-    xkb_machine_options_destroy(options);
+    xkb_machine_builder_destroy(builder);
     xkb_keymap_unref(keymap);
 }
 
@@ -2424,8 +2455,12 @@ test_overlays(struct xkb_context *context)
         GOLDEN_TESTS_OUTPUTS "overlays-v2-2.xkb");
     assert(keymap);
 
-    struct xkb_machine * const sm = xkb_machine_new(keymap, NULL);
+    struct xkb_machine_builder *builder =
+        xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
+    assert(builder);
+    struct xkb_machine * const sm = xkb_machine_new(builder);
     assert(sm);
+    xkb_machine_builder_destroy(builder);
     struct xkb_events * events = xkb_events_new_batch(context,
                                                       XKB_EVENTS_NO_FLAGS);
     assert(events);
@@ -2563,23 +2598,24 @@ test_modifiers_tweak(struct xkb_context *context)
     const xkb_mod_mask_t level5 = _xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_LEVEL5);
     const xkb_mod_mask_t num = _xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_NUM);
 
-    struct xkb_machine_options * const options = xkb_machine_options_new(context);
-    assert(options);
+    struct xkb_machine_builder *builder =
+        xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
+    assert(builder);
 
-    assert(!xkb_machine_options_remap_mods(options, 0, 0));
-    assert(xkb_machine_options_remap_mods(options, 0, level3) ==
+    assert(!xkb_machine_builder_remap_mods(builder, 0, 0));
+    assert(xkb_machine_builder_remap_mods(builder, 0, level3) ==
            XKB_ERROR_UNSUPPORTED_MODIFIER_MASK);
-    assert(!xkb_machine_options_remap_mods(options, scroll, alt));
-    assert(!xkb_machine_options_remap_mods(options, super, level3));
-    assert(!xkb_machine_options_remap_mods(options, alt, level5));
-    assert(!xkb_machine_options_remap_mods(options, ctrl | alt, level3));
+    assert(!xkb_machine_builder_remap_mods(builder, scroll, alt));
+    assert(!xkb_machine_builder_remap_mods(builder, super, level3));
+    assert(!xkb_machine_builder_remap_mods(builder, alt, level5));
+    assert(!xkb_machine_builder_remap_mods(builder, ctrl | alt, level3));
 
-    assert(!xkb_machine_options_remap_mods(options, ctrl, shift));
-    assert(!xkb_machine_options_remap_mods(options, ctrl, 0));
+    assert(!xkb_machine_builder_remap_mods(builder, ctrl, shift));
+    assert(!xkb_machine_builder_remap_mods(builder, ctrl, 0));
 
-    struct xkb_machine * const sm = xkb_machine_new(keymap, options);
+    struct xkb_machine * const sm = xkb_machine_new(builder);
     assert(sm);
-    xkb_machine_options_destroy(options);
+    xkb_machine_builder_destroy(builder);
 
     struct xkb_events * const events = xkb_events_new_batch(context,
                                                             XKB_EVENTS_NO_FLAGS);
@@ -3261,10 +3297,10 @@ main(void)
     xkb_keymap_unref(NULL);
     xkb_state_unref(NULL);
     xkb_machine_unref(NULL);
-    xkb_machine_options_destroy(NULL);
+    xkb_machine_builder_destroy(NULL);
     xkb_events_destroy(NULL);
 
-    test_machine_options(context);
+    test_machine_builder(context);
     test_initial_derived_values(context);
 
     assert(!xkb_events_new_batch(context, -1));

--- a/test/server-state.c
+++ b/test/server-state.c
@@ -44,7 +44,7 @@ xkb_state_update_enabled_controls(struct xkb_state *state,
     };
     enum xkb_state_component changed = 0;
     /* Note: no error handling */
-    xkb_state_update_synthetic(state, &update, &changed);
+    assert(xkb_state_update_synthetic(state, &update, &changed) == XKB_SUCCESS);
     return changed;
 }
 
@@ -71,7 +71,7 @@ xkb_state_update_enabled_controls(struct xkb_state *state,
  *
  * [global keyboard controls]: @ref xkb_keyboard_control_flags
  */
-static int
+static enum xkb_error_code
 xkb_machine_update_enabled_controls(struct xkb_machine *machine,
                                     struct xkb_events *events,
                                     enum xkb_keyboard_control_flags affect,
@@ -133,7 +133,7 @@ xkb_machine_update_enabled_controls(struct xkb_machine *machine,
  *
  * @memberof xkb_machine
  */
-static int
+static enum xkb_error_code
 xkb_machine_update_latched_locked(struct xkb_machine *machine,
                                   struct xkb_events *events,
                                   xkb_mod_mask_t affect_latched_mods,
@@ -181,7 +181,7 @@ test_machine_builder(struct xkb_context *ctx)
     /* Valid flags */
     static_assert(XKB_A11Y_NO_FLAGS == 0, "default flags");
     assert(xkb_machine_builder_update_a11y_flags(
-            builder, XKB_A11Y_NO_FLAGS, XKB_A11Y_NO_FLAGS) == 0);
+            builder, XKB_A11Y_NO_FLAGS, XKB_A11Y_NO_FLAGS) == XKB_SUCCESS);
 
     /* Invalid flags */
     assert(xkb_machine_builder_update_a11y_flags(builder, -1000, 0) ==
@@ -505,8 +505,8 @@ update_controls(struct xkb_machine *sm,
 {
     if (use_machine) {
         assert(xkb_machine_update_enabled_controls(sm, events,
-                                                        affect, controls)
-               == 0);
+                                                   affect, controls)
+               == XKB_SUCCESS);
         const struct xkb_event *event;
         enum xkb_state_component changed = 0;
         while ((event = xkb_events_next(events))) {
@@ -623,7 +623,7 @@ test_group_wrap(struct xkb_context *ctx)
             .layout_policy = &layout_policy,
             .components = &components,
         };
-        assert(!xkb_machine_process_synthetic(sm, &req, events));
+        assert(xkb_machine_process_synthetic(sm, &req, events) == XKB_SUCCESS);
         while ((event = xkb_events_next(events)))
             xkb_state_update_event(state, event);
         assert_eq("unexpected effective group", tests[t].expected_group,
@@ -910,7 +910,7 @@ test_sticky_keys(struct xkb_context *ctx)
     assert(xkb_machine_builder_update_a11y_flags(
                 sm_builder,
                 XKB_A11Y_LATCH_TO_LOCK,
-                XKB_A11Y_LATCH_TO_LOCK) == 0);
+                XKB_A11Y_LATCH_TO_LOCK) == XKB_SUCCESS);
     sm = xkb_machine_new(sm_builder);
     assert(sm);
     xkb_machine_builder_destroy(sm_builder);
@@ -1154,12 +1154,12 @@ test_redirect_key(struct xkb_context *ctx)
                 __func__, t, tests[t].keycode);
         assert(xkb_keymap_key_repeats(keymap, tests[t].keycode) ==
                tests[t].repeats);
-        assert(!xkb_machine_process_key(sm, tests[t].keycode,
-                                        XKB_KEY_DOWN, events));
+        assert(xkb_machine_process_key(sm, tests[t].keycode,
+                                       XKB_KEY_DOWN, events) == XKB_SUCCESS);
         assert(check_events(events, tests[t].down.events,
                             tests[t].down.events_count));
-        assert(!xkb_machine_process_key(sm, tests[t].keycode,
-                                        XKB_KEY_REPEATED, events));
+        assert(xkb_machine_process_key(sm, tests[t].keycode,
+                                       XKB_KEY_REPEATED, events) == XKB_SUCCESS);
         if (tests[t].repeats) {
             struct xkb_event ref[ARRAY_SIZE(tests->down.events)] = {0};
             memcpy(ref, tests[t].down.events, sizeof(tests->down.events));
@@ -1169,8 +1169,8 @@ test_redirect_key(struct xkb_context *ctx)
         } else {
             assert(check_events(events, NULL, 0));
         }
-        assert(!xkb_machine_process_key(sm, tests[t].keycode,
-                                        XKB_KEY_UP, events));
+        assert(xkb_machine_process_key(sm, tests[t].keycode,
+                                       XKB_KEY_UP, events) == XKB_SUCCESS);
         assert(check_events(events, tests[t].up.events,
                             tests[t].up.events_count));
     }
@@ -1198,10 +1198,9 @@ test_shortcuts_tweak(struct xkb_context *context)
         xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
     assert(builder);
 
-    assert(xkb_machine_builder_update_shortcut_mods(builder, ctrl, ctrl)
-           == 0);
-    assert(xkb_machine_builder_remap_shortcut_layout(builder, 1, 2) == 0);
-    assert(xkb_machine_builder_remap_shortcut_layout(builder, 3, 0) == 0);
+    assert(xkb_machine_builder_update_shortcut_mods(builder, ctrl, ctrl) == XKB_SUCCESS);
+    assert(xkb_machine_builder_remap_shortcut_layout(builder, 1, 2) == XKB_SUCCESS);
+    assert(xkb_machine_builder_remap_shortcut_layout(builder, 3, 0) == XKB_SUCCESS);
 
     struct xkb_machine * sm = xkb_machine_new(builder);
     assert(sm);
@@ -1696,7 +1695,7 @@ test_shortcuts_tweak(struct xkb_context *context)
     /* Layout 1 locked, Ctrl latched */
     assert(xkb_machine_update_latched_locked(sm, events,
                                              ctrl, ctrl, false, 0,
-                                             0, 0, true, 1) == 0);
+                                             0, 0, true, 1) == XKB_SUCCESS);
     check_events_(
         events,
         {
@@ -1720,7 +1719,7 @@ test_shortcuts_tweak(struct xkb_context *context)
     /* Layout 1 locked, Ctrl locked */
     assert(xkb_machine_update_latched_locked(sm, events,
                                              ctrl, 0, false, 0,
-                                             ctrl, ctrl, false, 0) == 0);
+                                             ctrl, ctrl, false, 0) == XKB_SUCCESS);
     check_events_(
         events,
         {
@@ -1876,7 +1875,7 @@ test_shortcuts_tweak(struct xkb_context *context)
     /* Layout 1 latched, layout 2 locked, Ctrl locked */
     assert(xkb_machine_update_latched_locked(sm, events,
                                              0, 0, true, 1,
-                                             0, 0, true, 2) == 0);
+                                             0, 0, true, 2) == XKB_SUCCESS);
     check_events_(
         events,
         {
@@ -1901,7 +1900,7 @@ test_shortcuts_tweak(struct xkb_context *context)
     /* Layout 1 latched, layout 2 locked, Ctrl disabled */
     assert(xkb_machine_update_latched_locked(sm, events,
                                              0, 0, false, 0,
-                                             ctrl, 0, false, 0) == 0);
+                                             ctrl, 0, false, 0) == XKB_SUCCESS);
     check_events_(
         events,
         {
@@ -1925,7 +1924,7 @@ test_shortcuts_tweak(struct xkb_context *context)
     /* Layout 1 latched, layout 2 locked, Ctrl latched */
     assert(xkb_machine_update_latched_locked(sm, events,
                                              ctrl, ctrl, false, 0,
-                                             0, 0, false, 0) == 0);
+                                             0, 0, false, 0) == XKB_SUCCESS);
     check_events_(
         events,
         {
@@ -1954,11 +1953,13 @@ test_shortcuts_tweak(struct xkb_context *context)
         XKB_KEYBOARD_CONTROL_A11Y_STICKY_KEYS;
 
     /* Disable already disabled sticky keys: no change */
-    assert(xkb_machine_update_enabled_controls(sm, events, controls, 0) == 0);
+    assert(xkb_machine_update_enabled_controls(sm, events, controls, 0)
+           == XKB_SUCCESS);
     check_events_(events, { .type = XKB_EVENT_TYPE_NONE });
 
     /* Enable disabled sticky keys: no change */
-    assert(xkb_machine_update_enabled_controls(sm, events, controls, controls) == 0);
+    assert(xkb_machine_update_enabled_controls(sm, events, controls, controls)
+           == XKB_SUCCESS);
     check_events_(
         events,
         {
@@ -1981,11 +1982,13 @@ test_shortcuts_tweak(struct xkb_context *context)
     );
 
     /* Enable already enabled sticky keys: no change */
-    assert(xkb_machine_update_enabled_controls(sm, events, controls, controls) == 0);
+    assert(xkb_machine_update_enabled_controls(sm, events, controls, controls)
+           == XKB_SUCCESS);
     check_events_(events, { .type = XKB_EVENT_TYPE_NONE });
 
     /* Disable sticky keys: clear latches & locks */
-    assert(xkb_machine_update_enabled_controls(sm, events, controls, 0) == 0);
+    assert(xkb_machine_update_enabled_controls(sm, events, controls, 0)
+           == XKB_SUCCESS);
     check_events_(
         events,
         {
@@ -2010,7 +2013,8 @@ test_shortcuts_tweak(struct xkb_context *context)
         }
     );
 
-    assert(xkb_machine_update_enabled_controls(sm, events, controls, 0) == 0);
+    assert(xkb_machine_update_enabled_controls(sm, events, controls, 0)
+           == XKB_SUCCESS);
 
     /*
      * Check RedirectKey()
@@ -2019,7 +2023,7 @@ test_shortcuts_tweak(struct xkb_context *context)
     /* Layout 4 locked, Ctrl locked */
     assert(xkb_machine_update_latched_locked(sm, events,
                                              0, 0, false, 0,
-                                             ctrl, ctrl, true, 3) == 0);
+                                             ctrl, ctrl, true, 3) == XKB_SUCCESS);
     check_events_(
         events,
         {
@@ -2124,15 +2128,15 @@ test_shortcuts_tweak(struct xkb_context *context)
      * Use modifiers tweak in addition to the shortcuts tweak
      */
 
-    assert(!xkb_machine_builder_remap_mods(builder,
-                                           ctrl | alt, level3));
+    assert(xkb_machine_builder_remap_mods(builder, ctrl | alt, level3) ==
+           XKB_SUCCESS);
 
     sm = xkb_machine_new(builder);
     assert(sm);
 
     assert(xkb_machine_update_latched_locked(sm, events,
                                              0, 0, false, 0,
-                                             ctrl, ctrl, true, 3) == 0);
+                                             ctrl, ctrl, true, 3) == XKB_SUCCESS);
 
     assert(xkb_machine_process_key(sm, KEY_Q + EVDEV_OFFSET,
                                    XKB_KEY_DOWN, events) == 0);
@@ -2256,7 +2260,7 @@ test_shortcuts_tweak(struct xkb_context *context)
 
     assert(xkb_machine_update_latched_locked(sm, events,
                                              0, 0, false, 0,
-                                             alt, alt, false, 0) == 0);
+                                             alt, alt, false, 0) == XKB_SUCCESS);
 
     check_events_(
         events,
@@ -2326,7 +2330,7 @@ test_shortcuts_tweak(struct xkb_context *context)
 
     assert(xkb_machine_update_latched_locked(sm, events,
                                              0, 0, false, 0,
-                                             0, 0, true, 0) == 0);
+                                             0, 0, true, 0) == XKB_SUCCESS);
 
     assert(xkb_machine_process_key(sm, KEY_Q + EVDEV_OFFSET,
                                    XKB_KEY_DOWN, events) == 0);
@@ -2550,16 +2554,16 @@ test_overlays(struct xkb_context *context)
 
     for (size_t t = 0; t < ARRAY_SIZE(keycode_tests); t++) {
         fprintf(stderr, "------\n*** %s: keycodes #%zu ***\n", __func__, t);
-        assert(!xkb_machine_update_enabled_controls(
+        assert(xkb_machine_update_enabled_controls(
                 sm, events, 0xffff, keycode_tests[t].controls
-        ));
+        ) == XKB_SUCCESS);
 
         if (!keycode_tests[t].kc)
             continue;
 
-        assert(!xkb_machine_process_key(
+        assert(xkb_machine_process_key(
             sm, EVDEV_OFFSET + KEY_J, keycode_tests[t].direction, events
-        ));
+        ) == XKB_SUCCESS);
         const struct xkb_event *event;
         while ((event = xkb_events_next(events))) {
             switch (xkb_event_get_type(event)) {
@@ -2602,16 +2606,16 @@ test_modifiers_tweak(struct xkb_context *context)
         xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
     assert(builder);
 
-    assert(!xkb_machine_builder_remap_mods(builder, 0, 0));
+    assert(xkb_machine_builder_remap_mods(builder, 0, 0) == XKB_SUCCESS);
     assert(xkb_machine_builder_remap_mods(builder, 0, level3) ==
            XKB_ERROR_UNSUPPORTED_MODIFIER_MASK);
-    assert(!xkb_machine_builder_remap_mods(builder, scroll, alt));
-    assert(!xkb_machine_builder_remap_mods(builder, super, level3));
-    assert(!xkb_machine_builder_remap_mods(builder, alt, level5));
-    assert(!xkb_machine_builder_remap_mods(builder, ctrl | alt, level3));
+    assert(xkb_machine_builder_remap_mods(builder, scroll, alt) == XKB_SUCCESS);
+    assert(xkb_machine_builder_remap_mods(builder, super, level3) == XKB_SUCCESS);
+    assert(xkb_machine_builder_remap_mods(builder, alt, level5) == XKB_SUCCESS);
+    assert(xkb_machine_builder_remap_mods(builder, ctrl | alt, level3) == XKB_SUCCESS);
 
-    assert(!xkb_machine_builder_remap_mods(builder, ctrl, shift));
-    assert(!xkb_machine_builder_remap_mods(builder, ctrl, 0));
+    assert(xkb_machine_builder_remap_mods(builder, ctrl, shift) == XKB_SUCCESS);
+    assert(xkb_machine_builder_remap_mods(builder, ctrl, 0) == XKB_SUCCESS);
 
     struct xkb_machine * const sm = xkb_machine_new(builder);
     assert(sm);
@@ -2823,7 +2827,7 @@ test_modifiers_tweak(struct xkb_context *context)
     assert(xkb_machine_update_latched_locked(sm, events,
                                              0, 0, false, 0,
                                              ctrl | num, ctrl | num,
-                                             false, 0) == 0);
+                                             false, 0) == XKB_SUCCESS);
     check_events_(
         events,
         {
@@ -2992,7 +2996,7 @@ test_modifiers_tweak(struct xkb_context *context)
     assert(xkb_machine_update_latched_locked(sm, events,
                                              0, 0, false, 0,
                                              ctrl | scroll, scroll,
-                                             false, 0) == 0);
+                                             false, 0) == XKB_SUCCESS);
     check_events_(
         events,
         {
@@ -3071,7 +3075,7 @@ test_modifiers_tweak(struct xkb_context *context)
     assert(xkb_machine_update_latched_locked(sm, events,
                                              0, 0, false, 0,
                                              ctrl | alt | scroll, ctrl | alt,
-                                             false, 0) == 0);
+                                             false, 0) == XKB_SUCCESS);
 
     /* Key redirect */
     assert(xkb_machine_process_key(sm, KEY_C + EVDEV_OFFSET, XKB_KEY_DOWN,

--- a/test/state.c
+++ b/test/state.c
@@ -765,7 +765,12 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
 {
     struct xkb_state *state = xkb_state_new(keymap);
     assert(state);
-    struct xkb_machine *sm = xkb_machine_new(keymap, NULL);
+    struct xkb_machine_builder *builder =
+        xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
+    assert(builder);
+    struct xkb_machine *sm = xkb_machine_new(builder);
+    assert(sm);
+    xkb_machine_builder_destroy(builder);
     struct xkb_events *events = xkb_events_new_batch(ctx, XKB_EVENTS_NO_FLAGS);
     assert(events);
     const xkb_keysym_t *syms;

--- a/tools/interactive-evdev.c
+++ b/tools/interactive-evdev.c
@@ -89,9 +89,8 @@ is_keyboard(int fd)
 static int
 keyboard_new(struct dirent *ent,
              struct xkb_context *ctx, struct xkb_keymap *keymap,
+             const struct xkb_machine_builder *builder,
              const struct xkb_machine_options *options,
-             enum xkb_keyboard_control_flags kbd_controls_affect,
-             enum xkb_keyboard_control_flags kbd_controls_values,
              struct xkb_compose_table *compose_table, struct keyboard **out)
 {
     int ret;
@@ -120,7 +119,7 @@ keyboard_new(struct dirent *ent,
     }
 
     if (use_events_api) {
-        machine = xkb_machine_new(keymap, options);
+        machine = xkb_machine_new(builder);
         if (!machine) {
             fprintf(stderr, "Couldn't create xkb state machine for %s\n", path);
             ret = -EFAULT;
@@ -145,8 +144,8 @@ keyboard_new(struct dirent *ent,
     const struct xkb_state_components_update components = {
         .size = sizeof(components),
         .components = XKB_STATE_CONTROLS,
-        .affect_controls = kbd_controls_affect,
-        .controls = kbd_controls_values,
+        .affect_controls = options->controls.boolean.affect,
+        .controls = options->controls.boolean.flags,
     };
     const struct xkb_state_update update = {
         .size = sizeof(update),
@@ -228,9 +227,8 @@ filter_device_name(const struct dirent *ent)
 
 static struct keyboard *
 get_keyboards(struct xkb_context *ctx, struct xkb_keymap *keymap,
+              const struct xkb_machine_builder *builder,
               const struct xkb_machine_options *options,
-              enum xkb_keyboard_control_flags kbd_controls_affect,
-              enum xkb_keyboard_control_flags kbd_controls_values,
               struct xkb_compose_table *compose_table)
 {
     int ret, i, nents;
@@ -244,8 +242,8 @@ get_keyboards(struct xkb_context *ctx, struct xkb_keymap *keymap,
     }
 
     for (i = 0; i < nents; i++) {
-        ret = keyboard_new(ents[i], ctx, keymap, options, kbd_controls_values,
-                           kbd_controls_affect, compose_table, &kbd);
+        ret = keyboard_new(ents[i], ctx, keymap, builder, options,
+                           compose_table, &kbd);
         if (ret) {
             if (ret == -EACCES) {
                 fprintf(stderr, "Couldn't open /dev/input/%s: %s. "
@@ -455,7 +453,7 @@ usage(FILE *fp, char *progname)
             " --legacy-state-api[=true|false]\n"
             "    Use legacy state API instead of event API\n"
             " --controls\n"
-            "    Sticky-keys, latch-to-lock, latch-simultaneous, overlay{1-8}\n"
+            "    Keyboard controls: sticky-keys, latch-to-lock, latch-simultaneous, overlay{1-8}\n"
             " --modifiers-mapping <MAPPING>\n"
             "    Remap the modifiers\n"
             " --shortcuts-mask <MASK>\n"
@@ -484,6 +482,7 @@ main(int argc, char *argv[])
     struct xkb_context *ctx = NULL;
     struct xkb_keymap *keymap = NULL;
     struct xkb_compose_table *compose_table = NULL;
+    struct xkb_machine_builder *machine_builder = NULL;
     const char *includes[64];
     size_t num_includes = 0;
     bool use_env_names = false;
@@ -560,17 +559,8 @@ main(int argc, char *argv[])
 
     bool has_rmlvo_options = false;
 
-    /* Initialize state options */
-    ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS); /* Only used for state options */
-    struct xkb_machine_options * const machine_options = xkb_machine_options_new(ctx);
-    if (!machine_options)
-        goto error_machine_options;
-    xkb_context_unref(ctx);
-    ctx = NULL;
-    enum xkb_keyboard_control_flags kbd_controls_affect = XKB_KEYBOARD_CONTROL_NO_FLAGS;
-    enum xkb_keyboard_control_flags kbd_controls_values = XKB_KEYBOARD_CONTROL_NO_FLAGS;
-    const char *raw_modifiers_mapping = NULL;
-    const char *raw_shortcuts_mask = NULL;
+    /* Initialize machine options */
+    struct xkb_machine_options machine_options = xkb_machine_options_new();
 
     /* Ensure synced with usage() and man page */
     assert(consumed_mode == XKB_CONSUMED_MODE_XKB);
@@ -697,9 +687,7 @@ main(int argc, char *argv[])
             break;
         }
         case OPT_CONTROLS:
-            if (!tools_parse_controls(optarg, machine_options,
-                                      &kbd_controls_affect,
-                                      &kbd_controls_values)) {
+            if (!tools_parse_controls(optarg, &machine_options)) {
                 usage(stderr, argv[0]);
                 ret = EXIT_INVALID_USAGE;
                 goto error_parse_args;
@@ -708,17 +696,25 @@ main(int argc, char *argv[])
             use_events_api = true;
             break;
         case OPT_MODIFIERS_TWEAK_MAPPING:
-            raw_modifiers_mapping = optarg;
+            if (!tools_parse_modifiers_mappings(optarg, &machine_options)) {
+                usage(stderr, argv[0]);
+                ret = EXIT_INVALID_USAGE;
+                goto error_parse_args;
+            }
             /* --legacy-state-api=false is implied */
             use_events_api = true;
             break;
         case OPT_SHORTCUTS_TWEAK_MASK:
-            raw_shortcuts_mask = optarg;
+            if (!tools_parse_shortcuts_mask(optarg, &machine_options)) {
+                usage(stderr, argv[0]);
+                ret = EXIT_INVALID_USAGE;
+                goto error_parse_args;
+            }
             /* --legacy-state-api=false is implied */
             use_events_api = true;
             break;
         case OPT_SHORTCUTS_TWEAK_MAPPING:
-            if (!tools_parse_shortcuts_mappings(optarg, machine_options)) {
+            if (!tools_parse_shortcuts_mappings(optarg, &machine_options)) {
                 usage(stderr, argv[0]);
                 ret = EXIT_INVALID_USAGE;
                 goto error_parse_args;
@@ -834,19 +830,12 @@ too_much_arguments:
         goto out;
     }
 
-    if (raw_modifiers_mapping &&
-        !tools_parse_modifiers_mappings(raw_modifiers_mapping, keymap,
-                                        machine_options)) {
-        fprintf(stderr,
-                "ERROR: Failed to parse modifiers mapping: \"%s\"\n",
-                raw_modifiers_mapping);
-    }
-
-    if (raw_shortcuts_mask &&
-        !tools_parse_shortcuts_mask(raw_shortcuts_mask, keymap, machine_options)) {
-        fprintf(stderr,
-                "ERROR: Failed to parse shortcuts mask: \"%s\"\n",
-                raw_shortcuts_mask);
+    machine_builder = xkb_machine_builder_new_from_options(keymap,
+                                                           &machine_options);
+    if (!machine_builder) {
+        fprintf(stderr, "ERROR: Failed to create state machine builder\n");
+        ret = EXIT_FAILURE;
+        goto out;
     }
 
     if (with_compose) {
@@ -860,8 +849,8 @@ too_much_arguments:
         }
     }
 
-    kbds = get_keyboards(ctx, keymap, machine_options, kbd_controls_affect,
-                         kbd_controls_values, compose_table);
+    kbds = get_keyboards(ctx, keymap, machine_builder, &machine_options,
+                         compose_table);
     if (!kbds) {
         goto out;
     }
@@ -888,10 +877,10 @@ too_much_arguments:
     free_keyboards(kbds);
 out:
     xkb_compose_table_unref(compose_table);
+    xkb_machine_builder_destroy(machine_builder);
     xkb_keymap_unref(keymap);
 error_parse_args:
-error_machine_options:
-    xkb_machine_options_destroy(machine_options);
+    xkb_machine_options_free(&machine_options);
     xkb_context_unref(ctx);
 
     return ret;
@@ -899,12 +888,12 @@ error_machine_options:
 too_many_includes:
     fprintf(stderr, "ERROR: too many includes (max: %zu)\n",
             ARRAY_SIZE(includes));
-    xkb_machine_options_destroy(machine_options);
+    xkb_machine_options_free(&machine_options);
     exit(EXIT_INVALID_USAGE);
 
 input_format_error:
     fprintf(stderr, "ERROR: Cannot use RMLVO options with keymap input\n");
     usage(stderr, argv[0]);
-    xkb_machine_options_destroy(machine_options);
+    xkb_machine_options_free(&machine_options);
     exit(EXIT_INVALID_USAGE);
 }

--- a/tools/interactive-wayland.c
+++ b/tools/interactive-wayland.c
@@ -93,11 +93,7 @@ static enum xkb_consumed_mode consumed_mode = XKB_CONSUMED_MODE_XKB;
 static enum print_state_options print_options = DEFAULT_PRINT_OPTIONS;
 static bool report_state_changes = true;
 static bool use_local_state = false;
-static struct xkb_machine_options * machine_options = NULL;
-static enum xkb_keyboard_control_flags kbd_controls_affect = XKB_KEYBOARD_CONTROL_NO_FLAGS;
-static enum xkb_keyboard_control_flags kbd_controls_values = XKB_KEYBOARD_CONTROL_NO_FLAGS;
-static const char *raw_modifiers_mapping = NULL;
-static const char *raw_shortcuts_mask = NULL;
+static struct xkb_machine_options machine_options = xkb_machine_options_new();
 static struct xkb_keymap *custom_keymap = NULL;
 #endif
 
@@ -476,8 +472,8 @@ kbd_keymap(void *data, struct wl_keyboard *wl_kbd, uint32_t format,
             const struct xkb_state_components_update components = {
                 .size = sizeof(components),
                 .components = XKB_STATE_CONTROLS,
-                .affect_controls = kbd_controls_affect,
-                .controls = kbd_controls_values,
+                .affect_controls = machine_options.controls.boolean.affect,
+                .controls = machine_options.controls.boolean.flags,
             };
             const struct xkb_state_update update = {
                 .size = sizeof(update),
@@ -489,31 +485,15 @@ kbd_keymap(void *data, struct wl_keyboard *wl_kbd, uint32_t format,
     }
     if (use_local_state && use_events_api) {
         if (!seat->machine) {
-            if (raw_modifiers_mapping) {
-                /* No race condition when using wl_display_dispatch() */
-                xkb_machine_options_remap_mods(machine_options, 0, 0);
-                if (!tools_parse_modifiers_mappings(raw_modifiers_mapping,
-                                                    seat->keymap,
-                                                    machine_options)) {
-                    fprintf(stderr,
-                            "%s: ERROR: Failed to parse modifiers mapping: \"%s\"\n",
-                            seat->name_str, raw_modifiers_mapping);
-                }
-            }
-            if (raw_shortcuts_mask) {
-                /* No race condition when using wl_display_dispatch() */
-                xkb_machine_options_update_shortcut_mods(
-                    machine_options, XKB_MOD_ALL, 0
-                );
-                if (!tools_parse_shortcuts_mask(raw_shortcuts_mask, seat->keymap,
-                                                machine_options)) {
-                    fprintf(stderr,
-                            "%s: ERROR: Failed to parse shortcuts mask: \"%s\"\n",
-                            seat->name_str, raw_shortcuts_mask);
-                }
+            struct xkb_machine_builder * machine_builder =
+                xkb_machine_builder_new_from_options(seat->keymap, &machine_options);
+            if (!machine_builder) {
+                fprintf(stderr, "ERROR: Couldn't create xkb state machine builder\n");
+                return;
             }
 
-            seat->machine = xkb_machine_new(seat->keymap, machine_options);
+            seat->machine = xkb_machine_new(machine_builder);
+            xkb_machine_builder_destroy(machine_builder);
             if (!seat->machine)
                 fprintf(stderr, "%s: ERROR: Failed to create local XKB state!\n",
                         seat->name_str);
@@ -526,8 +506,8 @@ kbd_keymap(void *data, struct wl_keyboard *wl_kbd, uint32_t format,
                 const struct xkb_state_components_update components = {
                     .size = sizeof(components),
                     .components = XKB_STATE_CONTROLS,
-                    .affect_controls = kbd_controls_affect,
-                    .controls = kbd_controls_values,
+                    .affect_controls = machine_options.controls.boolean.affect,
+                    .controls = machine_options.controls.boolean.flags,
                 };
                 const struct xkb_state_update update = {
                     .size = sizeof(update),
@@ -1029,23 +1009,6 @@ main(int argc, char *argv[])
 #ifndef KEYMAP_DUMP
     bool with_keymap_file = false;
     const char *keymap_path = NULL;
-
-    /* Only used for state options */
-    inter.ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-    if (!inter.ctx) {
-        ret = -1;
-        fprintf(stderr, "ERROR: Couldn't create xkb context\n");
-        goto err_out;
-    }
-    machine_options = xkb_machine_options_new(inter.ctx);
-    xkb_context_unref(inter.ctx);
-    inter.ctx = NULL;
-    if (!machine_options) {
-        ret = -1;
-        fprintf(stderr, "ERROR: Couldn't create xkb state machine options\n");
-        goto err_out;
-    }
-
     bool with_compose = false;
     struct xkb_compose_table *compose_table = NULL;
 #endif
@@ -1198,26 +1161,25 @@ local_state:
             break;
         }
         case OPT_CONTROLS:
-            if (!tools_parse_controls(optarg, machine_options,
-                                      &kbd_controls_affect,
-                                      &kbd_controls_values)) {
+            if (!tools_parse_controls(optarg, &machine_options))
                 goto invalid_usage;
-            }
             /* --local-state and --legacy-state-api=false are implied */
             use_events_api = true;
             goto local_state;
         case OPT_MODIFIERS_TWEAK_MAPPING:
-            raw_modifiers_mapping = optarg;
+            if (!tools_parse_modifiers_mappings(optarg, &machine_options))
+                goto invalid_usage;
             /* --local-state and --legacy-state-api=false are implied */
             use_events_api = true;
             goto local_state;
         case OPT_SHORTCUTS_TWEAK_MASK:
-            raw_shortcuts_mask = optarg;
+            if (!tools_parse_shortcuts_mask(optarg, &machine_options))
+                goto invalid_usage;
             /* --local-state and --legacy-state-api=false are implied */
             use_events_api = true;
             goto local_state;
         case OPT_SHORTCUTS_TWEAK_MAPPING:
-            if (!tools_parse_shortcuts_mappings(optarg, machine_options))
+            if (!tools_parse_shortcuts_mappings(optarg, &machine_options))
                 goto invalid_usage;
             /* --local-state and --legacy-state-api=false are implied */
             use_events_api = true;
@@ -1389,7 +1351,7 @@ err_out:
     ret = (ret >= 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 error_parse_args:
 #ifndef KEYMAP_DUMP
-    xkb_machine_options_destroy(machine_options);
+    xkb_machine_options_free(&machine_options);
 #endif
     exit(ret);
 }

--- a/tools/interactive-x11.c
+++ b/tools/interactive-x11.c
@@ -71,11 +71,7 @@ static enum xkb_consumed_mode consumed_mode = XKB_CONSUMED_MODE_XKB;
 static enum print_state_options print_options = DEFAULT_PRINT_OPTIONS;
 static bool report_state_changes = true;
 static bool use_local_state = false;
-static struct xkb_machine_options * machine_options = NULL;
-static enum xkb_keyboard_control_flags kbd_controls_affect = XKB_KEYBOARD_CONTROL_NO_FLAGS;
-static enum xkb_keyboard_control_flags kbd_controls_values = XKB_KEYBOARD_CONTROL_NO_FLAGS;
-static const char *raw_modifiers_mapping = NULL;
-static const char *raw_shortcuts_mask = NULL;
+static struct xkb_machine_options machine_options = xkb_machine_options_new();
 static struct xkb_keymap *custom_keymap = NULL;
 #endif
 
@@ -178,8 +174,8 @@ update_keymap(struct keyboard *kbd)
         const struct xkb_state_components_update components_update = {
             .size = sizeof(components_update),
             .components = XKB_STATE_CONTROLS,
-            .affect_controls = kbd_controls_affect,
-            .controls = kbd_controls_values,
+            .affect_controls = machine_options.controls.boolean.affect,
+            .controls = machine_options.controls.boolean.flags,
         };
         const struct xkb_state_update update = {
             .size = sizeof(update),
@@ -187,30 +183,15 @@ update_keymap(struct keyboard *kbd)
         };
         if (use_events_api) {
             if (!kbd->machine) {
-                if (raw_modifiers_mapping) {
-                    xkb_machine_options_remap_mods(machine_options, 0, 0);
-                    if (!tools_parse_modifiers_mappings(raw_modifiers_mapping,
-                                                        kbd->keymap,
-                                                        machine_options)) {
-                        fprintf(stderr,
-                                "ERROR: Failed to parse modifiers mapping: \"%s\"\n",
-                                raw_modifiers_mapping);
-                    }
-                }
-                if (raw_shortcuts_mask) {
-                    xkb_machine_options_update_shortcut_mods(
-                        machine_options, XKB_MOD_ALL, 0
-                    );
-                    if (!tools_parse_shortcuts_mask(raw_shortcuts_mask, kbd->keymap,
-                                                    machine_options)) {
-                        fprintf(stderr,
-                                "ERROR: Failed to parse shortcuts mask: \"%s\"\n",
-                                raw_shortcuts_mask);
-                    }
+                struct xkb_machine_builder * machine_builder =
+                    xkb_machine_builder_new_from_options(kbd->keymap, &machine_options);
+                if (!machine_builder) {
+                    fprintf(stderr, "ERROR: Couldn't create xkb state machine builder\n");
+                    return - 1;
                 }
 
-                kbd->machine =
-                    xkb_machine_new(kbd->keymap, machine_options);
+                kbd->machine = xkb_machine_new(machine_builder);
+                xkb_machine_builder_destroy(machine_builder);
                 if (!kbd->machine)
                     return -1;
             }
@@ -221,8 +202,7 @@ update_keymap(struct keyboard *kbd)
                     return -1;
             }
             const int ret = xkb_machine_process_synthetic(kbd->machine,
-                                                             &update,
-                                                             kbd->events);
+                                                          &update, kbd->events);
             if (ret)
                 return ret;
             const struct xkb_event *event;
@@ -622,23 +602,6 @@ main(int argc, char *argv[])
     bool with_keymap_file = false;
     enum xkb_keymap_format keymap_format = DEFAULT_INPUT_KEYMAP_FORMAT;
     const char *keymap_path = NULL;
-
-    /* Only used for state options */
-    core_kbd.ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-    if (!core_kbd.ctx) {
-        ret = -1;
-        fprintf(stderr, "Couldn't create xkb context\n");
-        goto err_out;
-    }
-    machine_options = xkb_machine_options_new(core_kbd.ctx);
-    xkb_context_unref(core_kbd.ctx);
-    core_kbd.ctx = NULL;
-    if (!machine_options) {
-        ret = -1;
-        fprintf(stderr, "Couldn't create xkb state machine options\n");
-        goto err_out;
-    }
-
     bool with_compose = false;
     const char *locale;
 #endif
@@ -752,26 +715,25 @@ local_state:
             break;
         }
         case OPT_CONTROLS:
-            if (!tools_parse_controls(optarg, machine_options,
-                                      &kbd_controls_affect,
-                                      &kbd_controls_values)) {
+            if (!tools_parse_controls(optarg, &machine_options))
                 goto invalid_usage;
-            }
             /* --local-state and --legacy-state-api=false are implied */
             use_events_api = true;
             goto local_state;
         case OPT_MODIFIERS_TWEAK_MAPPING:
-            raw_modifiers_mapping = optarg;
+            if (!tools_parse_modifiers_mappings(optarg, &machine_options))
+                goto invalid_usage;
             /* --local-state and --legacy-state-api=false are implied */
             use_events_api = true;
             goto local_state;
         case OPT_SHORTCUTS_TWEAK_MASK:
-            raw_shortcuts_mask = optarg;
+            if (!tools_parse_shortcuts_mask(optarg, &machine_options))
+                goto invalid_usage;
             /* --local-state and --legacy-state-api=false are implied */
             use_events_api = true;
             goto local_state;
         case OPT_SHORTCUTS_TWEAK_MAPPING:
-            if (!tools_parse_shortcuts_mappings(optarg, machine_options))
+            if (!tools_parse_shortcuts_mappings(optarg, &machine_options))
                 goto invalid_usage;
             /* --local-state and --legacy-state-api=false are implied */
             use_events_api = true;
@@ -989,7 +951,7 @@ err_out:
     ret = (ret >= 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 error_parse_args:
 #ifndef KEYMAP_DUMP
-    xkb_machine_options_destroy(machine_options);
+    xkb_machine_options_free(&machine_options);
 #endif
     exit(ret);
 }

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -10,6 +10,7 @@
  */
 
 #include "config.h"
+#include "darray.h"
 
 #include <assert.h>
 #include <errno.h>
@@ -952,10 +953,60 @@ tools_parse_bool(const char *s, enum tools_arg_optionality optional, bool *out)
     }
 }
 
+static void
+xkb_raw_modifiers_free(struct xkb_raw_mod_mask *raw_mods)
+{
+    darray_free(raw_mods->names);
+    darray_free(raw_mods->indices);
+}
+
+static void
+xkb_machine_mods_raw_mapping_free(struct xkb_machine_mods_raw_mapping *mapping)
+{
+    xkb_raw_modifiers_free(&mapping->source);
+    xkb_raw_modifiers_free(&mapping->target);
+}
+
+void
+xkb_machine_options_free(struct xkb_machine_options *options)
+{
+    xkb_raw_modifiers_free(&options->shortcuts.mask);
+    darray_free(options->shortcuts.mappings);
+
+    struct xkb_machine_mods_raw_mapping *mapping;
+    darray_foreach(mapping, options->modifiers)
+        xkb_machine_mods_raw_mapping_free(mapping);
+    darray_free(options->modifiers);
+}
+
+static bool
+xkb_machine_options_update_boolean_ctrls(struct xkb_machine_options *options,
+                                         enum xkb_keyboard_control_flags flags,
+                                         bool disable)
+{
+    if (disable)
+        options->controls.boolean.flags &= ~flags;
+    else
+        options->controls.boolean.flags |= flags;
+    options->controls.boolean.affect |= flags;
+    return true;
+}
+
+static bool
+xkb_machine_options_update_a11y_flags(struct xkb_machine_options *options,
+                                      enum xkb_a11y_flags flags,
+                                      bool disable)
+{
+    if (disable)
+        options->controls.a11y.flags &= ~flags;
+    else
+        options->controls.a11y.flags |= flags;
+    options->controls.a11y.affect |= flags;
+    return true;
+}
+
 bool
-tools_parse_controls(const char *raw, struct xkb_machine_options *options,
-                     enum xkb_keyboard_control_flags *controls_affect,
-                     enum xkb_keyboard_control_flags *controls_values)
+tools_parse_controls(const char *raw, struct xkb_machine_options *options)
 {
     if (isempty(raw))
         return true;
@@ -992,7 +1043,7 @@ tools_parse_controls(const char *raw, struct xkb_machine_options *options,
     const char *start = raw;
     const char *s = start;
 
-    bool ok = true;
+    bool ret = true;
 
     /* Parse comma-separated list of options */
     while (true) {
@@ -1017,67 +1068,71 @@ tools_parse_controls(const char *raw, struct xkb_machine_options *options,
             }
         }
 
-        ok = false;
+        bool ok = false;
         for (enum control_field type = 0;
              type < (enum control_field) ARRAY_SIZE(fields);
              type++) {
             if (strncmp(start, fields[type], len) != 0 ||
-                fields[type][len] != '\0')
+                fields[type][len] != '\0') {
                 continue;
+            }
 
             ok = true;
 
             switch (type) {
             case CONTROL_FIELD_OVERLAY1:
-            case CONTROL_FIELD_OVERLAY2: {
-                static_assert(CONTROL_FIELD_OVERLAY1 == 0, "");
-                static_assert(XKB_KEYBOARD_CONTROL_OVERLAY2 ==
-                              (XKB_KEYBOARD_CONTROL_OVERLAY1 << 1), "");
-                const enum xkb_keyboard_control_flags flag =
-                    XKB_KEYBOARD_CONTROL_OVERLAY1 << type;
-                if (disable)
-                    *controls_values &= ~flag;
-                else
-                    *controls_values |= flag;
-                *controls_affect |= flag;
-                break;
-            }
+            case CONTROL_FIELD_OVERLAY2:
             case CONTROL_FIELD_OVERLAY3:
             case CONTROL_FIELD_OVERLAY4:
             case CONTROL_FIELD_OVERLAY5:
             case CONTROL_FIELD_OVERLAY6:
             case CONTROL_FIELD_OVERLAY7:
             case CONTROL_FIELD_OVERLAY8: {
+                static_assert(CONTROL_FIELD_OVERLAY1 == 0, "");
+                static_assert(
+                    XKB_KEYBOARD_CONTROL_OVERLAY1 ==
+                    (XKB_KEYBOARD_CONTROL_OVERLAY1 << CONTROL_FIELD_OVERLAY1),
+                    ""
+                );
+                static_assert(CONTROL_FIELD_OVERLAY2 == 1, "");
+                static_assert(
+                    XKB_KEYBOARD_CONTROL_OVERLAY2 ==
+                    (XKB_KEYBOARD_CONTROL_OVERLAY1 << CONTROL_FIELD_OVERLAY2),
+                    ""
+                );
                 static_assert(CONTROL_FIELD_OVERLAY3 == 2, "");
-                static_assert(XKB_KEYBOARD_CONTROL_OVERLAY4 ==
-                              (XKB_KEYBOARD_CONTROL_OVERLAY3 << 1), "");
+                static_assert(
+                    XKB_KEYBOARD_CONTROL_OVERLAY3 ==
+                    (XKB_KEYBOARD_CONTROL_OVERLAY1 << CONTROL_FIELD_OVERLAY3),
+                    ""
+                );
+                static_assert(CONTROL_FIELD_OVERLAY8 == 7, "");
+                static_assert(
+                    XKB_KEYBOARD_CONTROL_OVERLAY8 ==
+                    (XKB_KEYBOARD_CONTROL_OVERLAY1 << CONTROL_FIELD_OVERLAY8),
+                    ""
+                );
                 const enum xkb_keyboard_control_flags flag =
-                    XKB_KEYBOARD_CONTROL_OVERLAY3 << (type - CONTROL_FIELD_OVERLAY3);
-                if (disable)
-                    *controls_values &= ~flag;
-                else
-                    *controls_values |= flag;
-                *controls_affect |= flag;
+                    XKB_KEYBOARD_CONTROL_OVERLAY1 << type;
+                ok = xkb_machine_options_update_boolean_ctrls(
+                    options, flag, disable
+                );
                 break;
             }
             case CONTROL_FIELD_STICKY_KEYS:
-                if (disable)
-                    *controls_values &= ~XKB_KEYBOARD_CONTROL_A11Y_STICKY_KEYS;
-                else
-                    *controls_values |= XKB_KEYBOARD_CONTROL_A11Y_STICKY_KEYS;
-                *controls_affect |= XKB_KEYBOARD_CONTROL_A11Y_STICKY_KEYS;
+                ok = xkb_machine_options_update_boolean_ctrls(
+                    options, XKB_KEYBOARD_CONTROL_A11Y_STICKY_KEYS, disable
+                );
                 break;
             case CONTROL_FIELD_LATCH_TO_LOCK:
                 ok = xkb_machine_options_update_a11y_flags(
-                    options, XKB_A11Y_LATCH_TO_LOCK,
-                    (disable ? 0 : XKB_A11Y_LATCH_TO_LOCK)
-                ) == 0;
+                    options, XKB_A11Y_LATCH_TO_LOCK, disable
+                );
                 break;
             case CONTROL_FIELD_LATCH_SIMULTANEOUS:
                 ok = xkb_machine_options_update_a11y_flags(
-                    options, XKB_A11Y_LATCH_SIMULTANEOUS_KEYS,
-                    (disable ? 0 : XKB_A11Y_LATCH_SIMULTANEOUS_KEYS)
-                ) == 0;
+                    options, XKB_A11Y_LATCH_SIMULTANEOUS_KEYS, disable
+                );
                 break;
             default:
                 {} /* Label followed by declaration requires C23 */
@@ -1086,12 +1141,14 @@ tools_parse_controls(const char *raw, struct xkb_machine_options *options,
                     CONTROL_FIELD_LATCH_SIMULTANEOUS + 1 == _NUM_CONTROL_FIELDS,
                     "missing case"
                 );
+                ret = false;
             }
         }
 
         if (!ok) {
             fprintf(stderr, "ERROR: cannot parse control entry: \"%.*s\"\n",
                     (unsigned int) len, start);
+            ret = false;
             break;
         }
 
@@ -1103,12 +1160,12 @@ next:
         start = s;
     }
 
-    return ok;
+    return ret;
 }
 
 static size_t
-tools_parse_mod_mask(const char *raw, size_t length, struct xkb_keymap *keymap,
-                     xkb_mod_mask_t *out)
+tools_parse_raw_mod_mask(const char *raw, size_t length,
+                         struct xkb_raw_mod_mask *raw_mask)
 {
     const char *start = raw;
     const char *s = start;
@@ -1134,15 +1191,10 @@ tools_parse_mod_mask(const char *raw, size_t length, struct xkb_keymap *keymap,
 
         if (len >= ARRAY_SIZE(buf) || !memcpy(buf, start, len))
             return 0;
-        buf[len] = '\0';
-
-        const xkb_mod_index_t idx = xkb_keymap_mod_get_index(keymap, buf);
-        if (idx == XKB_MOD_INVALID) {
-            fprintf(stderr, "ERROR: cannot parse modifier: \"%s\"\n", buf);
-            return 0;
-        }
-
-        *out |= xkb_keymap_mod_get_mask2(keymap, idx);
+        const darray_size_t idx = darray_size(raw_mask->names);
+        darray_append_items(raw_mask->names, buf, len);
+        darray_append(raw_mask->names, '\0');
+        darray_append(raw_mask->indices, idx);
 
 next:
         if (count >= length || s[0] == '\0')
@@ -1156,8 +1208,32 @@ next:
     return count;
 }
 
+static bool
+tools_parse_mod_mask(struct xkb_keymap *keymap,
+                     const struct xkb_raw_mod_mask *raw_mask, const char *field,
+                     xkb_mod_mask_t *out)
+{
+    bool ret = true;
+    darray_size_t *name_idx;
+
+    darray_foreach(name_idx, raw_mask->indices) {
+        const char *name = &darray_item(raw_mask->names, *name_idx);
+        const xkb_mod_index_t idx = xkb_keymap_mod_get_index(keymap, name);
+        if (idx == XKB_MOD_INVALID) {
+            fprintf(stderr,
+                    "ERROR: unknown modifier in %s: \"%s\"\n",
+                    field, name);
+            ret = false;
+        } else {
+            *out |= xkb_keymap_mod_get_mask2(keymap, idx);
+        }
+    }
+
+    return ret;
+}
+
 bool
-tools_parse_modifiers_mappings(const char *raw, struct xkb_keymap *keymap,
+tools_parse_modifiers_mappings(const char *raw,
                                struct xkb_machine_options *options)
 {
     const char *start = raw;
@@ -1184,36 +1260,35 @@ tools_parse_modifiers_mappings(const char *raw, struct xkb_keymap *keymap,
         while (source_len < len && start[source_len] != mods_sep)
             source_len++;
 
-        xkb_mod_mask_t source = 0;
-        size_t consumed = tools_parse_mod_mask(start, source_len, keymap, &source);
+        struct xkb_machine_mods_raw_mapping mapping = {0};
+        size_t consumed = tools_parse_raw_mod_mask(start, source_len,
+                                                   &mapping.source);
         if (consumed != source_len) {
             fprintf(stderr, "ERROR: invalid modifiers mapping source\n");
+            xkb_machine_mods_raw_mapping_free(&mapping);
             return false;
         }
 
         if (start[consumed] != mods_sep) {
             fprintf(stderr, "ERROR: invalid modifiers mapping: \"%s\"\n",
                     start);
+            xkb_machine_mods_raw_mapping_free(&mapping);
             return false;
         }
 
         start += consumed + 1;
         len -= consumed + 1;
 
-        xkb_mod_mask_t target = 0;
-        consumed = tools_parse_mod_mask(start, len, keymap, &target);
+        consumed = tools_parse_raw_mod_mask(start, len, &mapping.target);
         if (consumed != len) {
             fprintf(stderr, "ERROR: invalid modifiers mapping target: \"%s\"\n",
                     start);
+            xkb_machine_mods_raw_mapping_free(&mapping);
             return false;
         }
 
-        if (xkb_machine_options_remap_mods(options, source, target)) {
-            fprintf(stderr,
-                    "ERROR: cannot add modifiers mapping: "
-                    "0x%"PRIx32" -> 0x%"PRIx32"\n", source, target);
-            return false;
-        }
+        /* Steal */
+        darray_append(options->modifiers, mapping);
 
 next:
         if (s[0] == '\0')
@@ -1226,13 +1301,73 @@ next:
     return true;
 }
 
-bool
-tools_parse_shortcuts_mask(const char *raw, struct xkb_keymap *keymap,
-                           struct xkb_machine_options *options)
+static bool
+tools_set_modifiers_mappings(const struct xkb_machine_options *options,
+                             struct xkb_machine_builder *builder)
 {
+    bool ret = true;
+    struct xkb_keymap *keymap = xkb_machine_builder_get_keymap(builder);
+
+    struct xkb_machine_mods_raw_mapping *mapping;
+    darray_foreach(mapping, options->modifiers) {
+        bool ok;
+
+        xkb_mod_mask_t source = 0;
+        ok = tools_parse_mod_mask(keymap, &mapping->source,
+                                  "mapping source", &source);
+
+        xkb_mod_mask_t target = 0;
+        ok = tools_parse_mod_mask(keymap, &mapping->target,
+                                  "mapping target", &target) && ok;
+
+        if (!ok) {
+            ret = false;
+            continue;
+        }
+
+        if (xkb_machine_builder_remap_mods(builder, source, target) !=
+            XKB_SUCCESS) {
+            fprintf(stderr,
+                    "ERROR: cannot add modifiers mapping: "
+                    "0x%"PRIx32" -> 0x%"PRIx32"\n", source, target);
+            ret = false;
+        }
+    }
+
+    return ret;
+}
+
+bool
+tools_parse_shortcuts_mask(const char *raw, struct xkb_machine_options *options)
+{
+    const size_t len = strlen_safe(raw);
+
+    struct xkb_raw_mod_mask raw_mask = {0};
+    const size_t consumed = tools_parse_raw_mod_mask(raw, len, &raw_mask);
+
+    if (consumed != len) {
+        fprintf(stderr, "ERROR: invalid shortcut modifiers mask: %s\n", raw);
+        xkb_raw_modifiers_free(&raw_mask);
+        return false;
+    }
+
+    /* Steal */
+    options->shortcuts.mask = raw_mask;
+    return true;
+}
+
+static bool
+tools_set_shortcuts_mask(const struct xkb_machine_options *options,
+                         struct xkb_machine_builder *builder)
+{
+    struct xkb_keymap *keymap = xkb_machine_builder_get_keymap(builder);
     xkb_mod_mask_t mask = 0;
-    return tools_parse_mod_mask(raw, SIZE_MAX, keymap, &mask) &&
-           !xkb_machine_options_update_shortcut_mods(options, mask, mask);
+
+    return (
+        tools_parse_mod_mask(keymap, &options->shortcuts.mask,
+                             "shortcut modifier mask", &mask) &&
+        !xkb_machine_builder_update_shortcut_mods(builder, mask, mask)
+    );
 }
 
 static int
@@ -1242,7 +1377,7 @@ tools_parse_layout_index1(const char *raw, size_t len, xkb_layout_index_t *out)
     if (consumed > 0 && *out == 0) {
         consumed = -1;
     }
-    if (consumed < 0) {
+    if (consumed < 0 || *out == 0 || *out > XKB_MAX_GROUPS) {
         fprintf(stderr, "ERROR: invalid layout index: \"%.*s\"\n",
                 (unsigned int) len, raw);
     } else {
@@ -1300,12 +1435,19 @@ tools_parse_shortcuts_mappings(const char *raw,
             return false;
         }
 
-        if (xkb_machine_options_remap_shortcut_layout(options, source, target)) {
-            fprintf(stderr,
-                    "ERROR: cannot add shortcuts layout mapping: "
-                    "%"PRIu32" -> %"PRIu32"\n", source, target);
-            return false;
+        if (source >= darray_size(options->shortcuts.mappings)) {
+            if (target == source) {
+                /* Skip default setting */
+                goto next;
+            }
+            xkb_layout_index_t new =
+                (xkb_layout_index_t)darray_size(options->shortcuts.mappings);
+            darray_resize(options->shortcuts.mappings, source + 1);
+            for (; new < source; new++)
+                darray_item(options->shortcuts.mappings, new) = XKB_LAYOUT_INVALID;
         }
+
+        darray_item(options->shortcuts.mappings, source) = target;
 
 next:
         if (s[0] == '\0')
@@ -1316,4 +1458,49 @@ next:
     }
 
     return true;
+}
+
+static bool
+tools_set_shortcuts_mappings(const struct xkb_machine_options *options,
+                             struct xkb_machine_builder *builder)
+{
+    bool ret = true;
+    xkb_layout_index_t source;
+    xkb_layout_index_t *target;
+    darray_enumerate(source, target, options->shortcuts.mappings) {
+        if (*target == XKB_LAYOUT_INVALID)
+            continue;
+        const enum xkb_error_code error =
+            xkb_machine_builder_remap_shortcut_layout(builder, source, *target);
+        if (error != XKB_SUCCESS) {
+            fprintf(stderr,
+                    "ERROR %d: cannot add shortcuts layout mapping: "
+                    "%"PRIu32" -> %"PRIu32"\n", error, source, *target);
+            ret = false;
+        }
+    }
+
+    return ret;
+}
+
+struct xkb_machine_builder *
+xkb_machine_builder_new_from_options(struct xkb_keymap *keymap,
+                                     const struct xkb_machine_options *options)
+{
+    struct xkb_machine_builder * const builder =
+        xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
+    if (!builder)
+        return NULL;
+
+    if ((unsigned)(xkb_machine_builder_update_a11y_flags(
+            builder, options->controls.a11y.affect, options->controls.a11y.flags
+        ) != XKB_SUCCESS) |
+        (unsigned)!tools_set_modifiers_mappings(options, builder) |
+        (unsigned)!tools_set_shortcuts_mask(options, builder) |
+        (unsigned)!tools_set_shortcuts_mappings(options, builder)) {
+            xkb_machine_builder_destroy(builder);
+            return NULL;
+    }
+
+    return builder;
 }

--- a/tools/tools-common.h
+++ b/tools/tools-common.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "config.h"
+#include "darray.h"
 
 #include <assert.h>
 #include <stdbool.h>
@@ -105,25 +106,74 @@ enum tools_arg_optionality {
 bool
 tools_parse_bool(const char *s, enum tools_arg_optionality optional, bool *out);
 
-bool
-tools_parse_controls(const char *s, struct xkb_machine_options *options,
-                     enum xkb_keyboard_control_flags *controls_affect,
-                     enum xkb_keyboard_control_flags *controls_values);
+/** Raw modifier masks: plus-separated list of modifier names */
+struct xkb_raw_mod_mask {
+    darray_char names;
+    darray(darray_size_t) indices;
+};
+
+#define xkb_raw_mod_mask_new() { \
+    .names = darray_new(),       \
+    .indices = darray_new(),     \
+}
+
+/** Raw modifier mapping */
+struct xkb_machine_mods_raw_mapping {
+    struct xkb_raw_mod_mask source;
+    struct xkb_raw_mod_mask target;
+};
+
+/** Precursor of xkb_machine_builder, to handle tools args parsing */
+struct xkb_machine_options {
+    struct {
+        struct {
+            enum xkb_keyboard_control_flags affect;
+            enum xkb_keyboard_control_flags flags;
+        } boolean; /**< Initial boolean controls */
+        struct {
+            enum xkb_a11y_flags affect;
+            enum xkb_a11y_flags flags;
+        } a11y; /**< Initial A11Y flags */
+    } controls;
+
+    struct {
+        struct xkb_raw_mod_mask mask;
+        darray(xkb_layout_index_t) mappings;
+    } shortcuts; /**< Shortcut tweak */
+
+    /** Modifiers tweak */
+    darray(struct xkb_machine_mods_raw_mapping) modifiers;
+};
+
+#define xkb_machine_options_new() {     \
+    .controls = {0},                    \
+    .shortcuts = {                      \
+        .mask = xkb_raw_mod_mask_new(), \
+        .mappings = darray_new(),       \
+    },                                  \
+    .modifiers = darray_new(),          \
+}
 
 void
-tools_reset_modifiers_mappings(struct xkb_machine_options *options);
+xkb_machine_options_free(struct xkb_machine_options *options);
 
 bool
-tools_parse_modifiers_mappings(const char *raw, struct xkb_keymap *keymap,
+tools_parse_controls(const char *s, struct xkb_machine_options *options);
+
+bool
+tools_parse_modifiers_mappings(const char *raw,
                                struct xkb_machine_options *options);
 
 bool
-tools_parse_shortcuts_mask(const char *raw, struct xkb_keymap *keymap,
-                           struct xkb_machine_options *options);
+tools_parse_shortcuts_mask(const char *raw, struct xkb_machine_options *options);
 
 bool
 tools_parse_shortcuts_mappings(const char *raw,
                                struct xkb_machine_options *options);
+
+struct xkb_machine_builder *
+xkb_machine_builder_new_from_options(struct xkb_keymap *keymap,
+                                     const struct xkb_machine_options *options);
 
 #ifdef _WIN32
 #define setenv(varname, value, overwrite) _putenv_s((varname), (value))

--- a/xkbcommon.map
+++ b/xkbcommon.map
@@ -158,12 +158,12 @@ global:
     xkb_state_update_event;
     xkb_state_update_synthetic;
     xkb_state_serialize_enabled_controls;
-    xkb_machine_options_new;
-    xkb_machine_options_destroy;
-    xkb_machine_options_update_a11y_flags;
-    xkb_machine_options_remap_mods;
-    xkb_machine_options_update_shortcut_mods;
-    xkb_machine_options_remap_shortcut_layout;
+    xkb_machine_builder_new;
+    xkb_machine_builder_destroy;
+    xkb_machine_builder_update_a11y_flags;
+    xkb_machine_builder_remap_mods;
+    xkb_machine_builder_update_shortcut_mods;
+    xkb_machine_builder_remap_shortcut_layout;
     xkb_machine_new;
     xkb_machine_ref;
     xkb_machine_unref;

--- a/xkbcommon.map
+++ b/xkbcommon.map
@@ -160,6 +160,7 @@ global:
     xkb_state_serialize_enabled_controls;
     xkb_machine_builder_new;
     xkb_machine_builder_destroy;
+    xkb_machine_builder_get_keymap;
     xkb_machine_builder_update_a11y_flags;
     xkb_machine_builder_remap_mods;
     xkb_machine_builder_update_shortcut_mods;


### PR DESCRIPTION
Before this commit, `xkb_machine_options` did not depend on a keymap, postponing various checks to the call of `xkb_machine_new()`.
    
The issue is that non-trivial errors of `xkb_machine_options_*()` functions are not triggered at call site.
    
- Refactored `xkb_machine_options` into `xkb_machine_builder` with an explicit dependency on the corresponding keymap.