### PR TITLE
registry: Add DTD error logging for libxml2 < 2.14

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,7 +34,7 @@ jobs:
         shell: cmd
         run: |
           :: Jinja2 is needed for merge-modes tests
-          python -m pip install --upgrade meson Jinja2
+          python -m pip install --upgrade "meson!=1.11.0" Jinja2
           choco install -y winflexbison3
       - name: Setup
         shell: cmd

--- a/meson.build
+++ b/meson.build
@@ -585,6 +585,7 @@ if get_option('enable-xkbregistry')
         'libxml/parser.h',
         'xmlCtxtSetErrorHandler',
         prefix: system_ext_define,
+        dependencies: dep_libxml,
     )
         configh_data.set10('HAVE_XML_CTXT_SET_ERRORHANDLER', true)
     endif
@@ -593,6 +594,7 @@ if get_option('enable-xkbregistry')
         'libxml/parser.h',
         'xmlCtxtParseDtd',
         prefix: system_ext_define,
+        dependencies: dep_libxml,
     )
         configh_data.set10('HAVE_XML_CTXT_PARSE_DTD', true)
     endif

--- a/src/registry.c
+++ b/src/registry.c
@@ -1423,6 +1423,9 @@ validate(struct rxkb_context *ctx, xmlDoc *doc)
     xmlParserCtxtPtr xmlCtxt = xmlNewParserCtxt();
     if (!xmlCtxt)
         return false;
+    static_assert(HAVE_XML_CTXT_SET_ERRORHANDLER,
+                  "xmlCtxtSetErrorHandler (2.13) introduced before "
+                  "xmlCtxtParseDtd (2.14)");
     xmlCtxtSetErrorHandler(xmlCtxt, xml_structured_error_func, ctx);
     xmlCtxtSetOptions(xmlCtxt, _XML_OPTIONS | XML_PARSE_DTDLOAD);
 
@@ -1453,11 +1456,17 @@ validate(struct rxkb_context *ctx, xmlDoc *doc)
     success = xmlCtxtValidateDtd(xmlCtxt, doc, dtd);
 #else
     xmlValidCtxt *dtdvalid = xmlNewValidCtxt();
+    if (!dtdvalid) {
+        success = false;
+        goto ctx_error;
+    }
+    dtdvalid->error = &xml_error_func;
+    dtdvalid->userData = ctx;
     success = xmlValidateDtd(dtdvalid, doc, dtd);
-    if (dtdvalid)
-        xmlFreeValidCtxt(dtdvalid);
-#endif
+    xmlFreeValidCtxt(dtdvalid);
 
+ctx_error:
+#endif
     xmlFreeDtd(dtd);
 
 dtd_error:


### PR DESCRIPTION
Fixed missing logging of libxml2 errors when validating the DTD for libxml2 < 2.14.

Relates-to: https://bugs.kde.org/show_bug.cgi?id=518963

@ariasuni