### PR TITLE
doc: Clarify how to modify system-wide configuration

### DIFF
--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -73,4 +73,4 @@ it is advised to try custom configurations safely with the following workflow:
 
 Happy hacking!
 
-[user-configuration locations]: @ref user-config-locations
+[user-configuration locations]: @ref xkb-data-locations

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -33,13 +33,39 @@ See [contributing to xkeyboard-config] for further information.
 
 ### Where are the system keyboard layouts located?
 
-They are usually located at `/usr/share/xkeyboard-config-2`, or
+They are usually located at `/usr/share/xkeyboard-config-<VERSION>`, or
 `/usr/share/X11/xkb` on older setups.
 
 Alternatively, use `xkbcli info` and check the `XKB_CONFIG_ROOT` entry.
 
 @note Do not modify system files! See @ref how-do-i-customize-my-layout "" for
 further instructions.
+
+### How do I customize my layout?
+
+This project does not provide any keyboard layout database:
+- If you want to modify only your *user* keyboard configuration,
+  see: [User-configuration](./user-configuration.md).
+- If you want to modify the *system-wide* keyboard configuration,
+  follow the [User-configuration](./user-configuration.md) but
+  *replace `$XDG_CONFIG_HOME` with `<sysconfdir>` (usually `/etc`) in the
+  file locations*.
+- If you want to modify the *standard keyboard layout database*, please first
+  try it *locally* (see our [debugging tools]) and then file an issue or a merge
+  request at the [xkeyboard-config] project.
+
+See also the [keymap text format][text format] documentation for the syntax and
+the [compatibility](./compatibility.md) page for the supported features.
+
+[text format]: ./keymap-text-format-v1-v2.md
+
+### How do I test my custom layout without installing it?
+
+Use our [debugging tools].
+
+### How can I create a package for my layout?
+
+See @ref packaging-keyboard-layouts.
 
 ### Why does my key combination to switch between layouts not work?
 
@@ -140,28 +166,6 @@ log, expected/got results) and file a [bug report]!
 [debugging tools]: ./debugging.md
 [xkeyboard-config]: https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config
 [bug report]: https://github.com/xkbcommon/libxkbcommon/issues/new
-
-### How do I customize my layout?
-
-This project does not provide any keyboard layout database:
-- If you want to modify only your *local* keyboard configuration,
-  see: [User-configuration](./user-configuration.md).
-- If you want to modify the standard keyboard layout database, please first try
-  it *locally* (see our [debugging tools]) and then file an issue or a merge
-  request at the [xkeyboard-config] project.
-
-See also the [keymap text format][text format] documentation for the syntax and
-the [compatibility](./compatibility.md) page for the supported features.
-
-[text format]: ./keymap-text-format-v1-v2.md
-
-### How do I test my custom layout without installing it?
-
-Use our [debugging tools].
-
-### How can I create a package for my layout?
-
-See @ref packaging-keyboard-layouts.
 
 ### How do I swap some keys?
 

--- a/doc/user-configuration.md
+++ b/doc/user-configuration.md
@@ -8,6 +8,11 @@ will be parsed by libxkbcommon.
 
 @note For *distributing* keyboard layouts, see @ref packaging-keyboard-layouts "".
 
+@note The following instructions focus on a *user-configuration*; it can be
+extended to a *system-wide* configuration by replacing `$XDG_CONFIG_HOME` with
+`<sysconfdir>` in the file locations. See @ref xkb-data-locations "" for further
+details.
+
 @warning The below requires libxkbcommon as keymap compiler and
 **does not work in _X11_** sessions, because X servers have hard-coded paths.
 
@@ -19,20 +24,68 @@ see [debugging] for further details.
 
 @tableofcontents{html:2}
 
-## Data locations {#user-config-locations}
+## XKB data locations
 
 libxkbcommon searches the following paths for XKB configuration files:
-1. `$XDG_CONFIG_HOME/xkb/`, or `$HOME/.config/xkb/` if the `$XDG_CONFIG_HOME`
-   environment variable is not defined. See the [XDG Base Directory Specification]
-   for further details.
-2. <div><!-- [HACK] Doxygen requires this extra div -->
-   @deprecated `$HOME/.xkb/` as a *legacy* alternative to the previous XDG option.
-   </div>
-3. `$XKB_CONFIG_EXTRA_PATH` if set, otherwise `<sysconfdir>/xkb` (on most
-   distributions this is `/etc/xkb`).
-4. `$XKB_CONFIG_ROOT` if set, otherwise `<datadir>/X11/xkb/` (path defined by
-   the `xkeyboard-config` package, on most distributions this is
-   `/usr/share/X11/xkb`).
+
+<table>
+<caption>XKB lookup paths</caption>
+<thead>
+<tr>
+<th>Scope</th>
+<th>Rank</th>
+<th>Name</th>
+<th>Path</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<th rowspan="2">User</th>
+<th>1</th>
+<th>*User* configuration</th>
+<td>
+`$XDG_CONFIG_HOME/xkb/`, or `$HOME/.config/xkb/` if the `$XDG_CONFIG_HOME`
+environment variable is not defined. See the [XDG Base Directory Specification]
+for further details.
+</td>
+</tr>
+<tr>
+<th>2</th>
+<th>**Legacy** *user* configuration</th>
+<td>
+@deprecated `$HOME/.xkb/` as a *legacy* alternative to the previous XDG option.
+</td>
+</tr>
+<tr>
+<th rowspan="3">System</th>
+<th>3</th>
+<th>*System*-wide configuration</th>
+<td>
+`$XKB_CONFIG_EXTRA_PATH` if set, otherwise `<sysconfdir>/xkb` (on most
+distributions this is `/etc/xkb`).
+</td>
+</tr>
+<tr>
+<th>4</th>
+<th>XKB extension packages data</th>
+<td>
+See @ref packaging-keyboard-layouts "".
+</td>
+</tr>
+<tr>
+<th>5</th>
+<th>Canonical XKB root</th>
+<td>
+`$XKB_CONFIG_ROOT` if set, otherwise `<datadir>/X11/xkb/` (path defined by
+the `xkeyboard-config` package, on most distributions this is
+`/usr/share/xkeyboard-config-<VERSION>`, or `/usr/share/X11/xkb` on older setups).
+
+@warning Do not modify the system XKB root files, because they will be
+overwritten by any update of the `xkeyboard-config`/`xkb-data` package.
+</td>
+</tr>
+</tbody>
+</table>
 
 [XDG Base Directory Specification]: https://specifications.freedesktop.org/basedir-spec/latest/
 
@@ -41,6 +94,10 @@ those paths in order until the required data is found.
 
 @note Where libxkbcommon runs in a privileged context, only the system
 (`<datadir>`) path is available.
+
+@note The rest of the page assumes configuring a *user-configuration*; it can
+be extended to a *system-wide* configuration by replacing `$XDG_CONFIG_HOME`
+with `<sysconfdir>` in the file locations (see in the table above).
 
 Each directory should have one or more of the following subdirectories:
 - `compat`

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -1043,14 +1043,29 @@ xkb_context_get_user_data(struct xkb_context *context);
  * include statement is encountered during keymap compilation.
  *
  * The default include paths are, in that lookup order:
+ *
+ * <dl>
+ * <dt>User</dt>
+ * <dd>
  * - The path `$XDG_CONFIG_HOME/xkb`, where `$XDG_CONFIG_HOME` is the value of
  *   the environment variable `XDG_CONFIG_HOME`, with the usual fallback to
  *   `$HOME/.config/` if unset.
- * - The path `$HOME/.xkb`, where `$HOME` is the value of the environment
- *   variable `HOME`.
+ *
+ *   See @ref user-configuration "" for further information.
+ * - @deprecated The *legacy* path `$HOME/.xkb`, where `$HOME` is the value of
+ *   the environment variable `HOME`.
+ *   <!-- [HACK] blank required by Doxygen -->
+ *
+ * </dd>
+ * <dt>System</dt>
+ * <dd>
  * - The `XKB_CONFIG_EXTRA_PATH` environment variable, if defined, otherwise the
  *   system configuration directory, defined at library configuration time
  *   (usually `/etc/xkb`).
+ *
+ *   One can adapt the @ref user-configuration "" instructions by replacing
+ *   `$XDG_CONFIG_HOME` with the system configuration directory in the
+ *   file locations.
  * - Each subdirectory of each XKB extensions directory (versioned, then
  *   unversioned if no corresponding versioned subdirectory), listed in
  *   lexicographic order. The extensions directories are defined by the
@@ -1059,9 +1074,20 @@ xkb_context_get_user_data(struct xkb_context *context);
  *   root extensions directories, defined at library configuration time (usually
  *   `/usr/share/xkeyboard-config-<VERSION>.d` and
  *   `/usr/share/xkeyboard-config.d`).
+ *
+ *   See @ref packaging-keyboard-layouts "" for further information.
  * - The `XKB_CONFIG_ROOT` environment variable, if defined, otherwise
  *   the system XKB root, defined at library configuration time
  *   (usually `/usr/share/xkeyboard-config-<VERSION>` or `/usr/share/X11/xkb`).
+ *
+ *   @warning Do not modify the system XKB root files, because they will be
+ *   overwritten by any update of the `xkeyboard-config`/`xkb-data` package.
+ * - Since 1.12.2: if the previous path failed, it fallbacks to the *legacy X11
+ *   path* defined at compilation time (usually `/usr/share/X11/xkb`). This
+ *   fallback is skipped is `XKB_CONFIG_ROOT` is explicitly set to an empty
+ *   string.
+ * </dd>
+ * </dl>
  *
  * @{
  */


### PR DESCRIPTION
Before this commit, only user-configuration was documented, while in fact the instructions can be applied for system-wide configuration by modifying `/etc/xkb` directory (or similar) rather than `~/.config/xkb` (or similar).