### PR TITLE
xkbcomp: Fix default section tag detection

### DIFF
--- a/changes/api/+include-default-section.bugfix.md
+++ b/changes/api/+include-default-section.bugfix.md
@@ -1,0 +1,1 @@
+Fixed include statement of default section, possibly broken in some custom configurations.

--- a/src/xkbcomp/include.c
+++ b/src/xkbcomp/include.c
@@ -452,7 +452,7 @@ ProcessIncludeFile(struct xkb_context *ctx, const IncludeStmt *stmt,
                         xkb_file_type_to_string(xkb_file->file_type), stmt->file);
                 FreeXkbFile(xkb_file);
                 xkb_file = NULL;
-            } else if (stmt->map || (xkb_file->flags && MAP_IS_DEFAULT)) {
+            } else if (stmt->map || (xkb_file->flags & MAP_IS_DEFAULT)) {
                 /*
                  * Exact match: explicit map name or explicit default map.
                  * Lookup stops here.

--- a/test/data/extra/symbols/capslock
+++ b/test/data/extra/symbols/capslock
@@ -1,3 +1,3 @@
-xkb_symbols "custom" {
+partial xkb_symbols "custom" {
 	key <CAPS> { [ XF86Fn ] };
 };


### PR DESCRIPTION
Before this commit, detection of the `default` tag of XKB section was broken: it wrongly matched the first section with at least one tag, independently of the tag value. This resulted in possibly including the wrong section when the include statement does not use an explicit section name, e.g. `include "fr"` instead of `include "fr(basic)"`.

Thanksfully, xkeyboard-config has always the `default` section at the top of the files, so only custom configurations could be affected.

- Fixed typo: `&&` → `&` introduced by 9b0b8c6863a9f2f4d1b3e67ab23d16e12710936b.
- Added corresponding test.