### PR TITLE
state: Document ABI versioning of `xkb_state_update`

### DIFF
--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -3118,6 +3118,33 @@ xkb_machine_process_key(struct xkb_machine *machine,
  * - `::XKB_STATE_LAYOUT_LOCKED`  → `locked_layout`
  * - `::XKB_STATE_CONTROLS`       → `affect_controls`, `controls`
  *
+ * @note This struct uses a **size-based versioning** scheme to allow
+ * forward and compatibility between callers and the library:
+ * <dl>
+ * <dt>Older callers (smaller struct)</dt>
+ * <dd>
+ *   Trailing fields unknown to the caller default to zero in the library.
+ * </dd>
+ * <dt>Newer callers (larger struct)</dt>
+ * <dd>
+ *   Accepted only if all trailing bytes unknown to the library are zero.
+ * </dd>
+ * </dl>
+ *
+ * @pre The struct MUST be initialized with `memset()` before setting any
+ * fields:
+ * ```c
+ * struct xkb_state_components_update update;
+ * memset(&update, 0, sizeof(update));
+ * update.size = sizeof(update);
+ * update.components = …;
+ * ```
+ *
+ * @invariant #size MUST be explicitly set to
+ * `sizeof(struct xkb_state_components_update)`.
+ * @invariant All bytes of the struct, including padding, MUST remain zero
+ * except for *explicitly* assigned fields.
+ *
  * @since 1.14.0
  *
  * @sa `xkb_state_update`
@@ -3126,9 +3153,9 @@ struct xkb_state_components_update {
     /**
      * Size of this structure, for forward-compatibility.
      *
-     * Must be set to `sizeof(struct xkb_state_components_update)`.
-     * If the caller’s size exceeds the library’s (e.g. version mismatch),
-     * an error is returned unless all extra bytes are zero.
+     * @sa `::XKB_ERROR_ABI_INVALID_STRUCT_SIZE`
+     * @sa `::XKB_ERROR_ABI_BACKWARD_COMPAT`
+     * @sa `::XKB_ERROR_ABI_FORWARD_COMPAT`
      */
     size_t size;
     /**
@@ -3213,6 +3240,11 @@ struct xkb_state_components_update {
      * @sa `xkb_keyboard_control_flags`
      */
     enum xkb_keyboard_control_flags controls;
+
+#if SIZE_MAX > UINT32_MAX
+    /** @private Reserved for ABI alignment. Must be zero. */
+    uint32_t _reserved;
+#endif
 };
 
 /**
@@ -3250,6 +3282,33 @@ enum xkb_layout_out_of_range_policy {
  * If `policy` is `::XKB_LAYOUT_OUT_OF_RANGE_REDIRECT`, `redirect` specifies
  * the target layout index; otherwise `redirect` is ignored.
  *
+ * @note This struct uses a **size-based versioning** scheme to allow
+ * forward and backward compatibility between callers and the library:
+ * <dl>
+ * <dt>Older callers (smaller struct)</dt>
+ * <dd>
+ *   Trailing fields unknown to the caller default to zero in the library.
+ * </dd>
+ * <dt>Newer callers (larger struct)</dt>
+ * <dd>
+ *   Accepted only if all trailing bytes unknown to the library are zero.
+ * </dd>
+ * </dl>
+ *
+ * @pre The struct MUST be initialized with `memset()` before setting any
+ * fields:
+ * ```c
+ * struct xkb_layout_policy_update update;
+ * memset(&update, 0, sizeof(update));
+ * update.size = sizeof(update);
+ * update.policy = …;
+ * ```
+ *
+ * @invariant #size MUST be explicitly set to
+ * `sizeof(struct xkb_layout_policy_update)`.
+ * @invariant All bytes of the struct, including padding, MUST remain zero
+ * except for *explicitly* assigned fields.
+ *
  * @since 1.14.0
  *
  * @sa `xkb_layout_out_of_range_policy`
@@ -3259,9 +3318,9 @@ struct xkb_layout_policy_update {
     /**
      * Size of this structure, for forward-compatibility.
      *
-     * Must be set to `sizeof(struct xkb_layout_policy_update)`.
-     * If the caller’s size exceeds the library’s (e.g. version mismatch),
-     * an error is returned unless all extra bytes are zero.
+     * @sa `::XKB_ERROR_ABI_INVALID_STRUCT_SIZE`
+     * @sa `::XKB_ERROR_ABI_BACKWARD_COMPAT`
+     * @sa `::XKB_ERROR_ABI_FORWARD_COMPAT`
      */
     size_t size;
     /**
@@ -3291,6 +3350,32 @@ struct xkb_layout_policy_update {
  *
  * A `NULL` pointer means “not set / no change”.
  *
+ * @note This struct uses a **size-based versioning** scheme to allow
+ * forward and backward compatibility between callers and the library:
+ * <dl>
+ * <dt>Older callers (smaller struct)</dt>
+ * <dd>
+ *   Trailing fields unknown to the caller default to zero in the library.
+ * </dd>
+ * <dt>Newer callers (larger struct)</dt>
+ * <dd>
+ *   Accepted only if all trailing bytes unknown to the library are zero.
+ * </dd>
+ * </dl>
+ *
+ * @pre The struct MUST be initialized with `memset()` before setting any
+ * fields:
+ * ```c
+ * struct xkb_state_update update;
+ * memset(&update, 0, sizeof(update));
+ * update.size = sizeof(update);
+ * update.components = …;
+ * ```
+ *
+ * @invariant #size MUST be explicitly set to `sizeof(struct xkb_state_update)`.
+ * @invariant All bytes of the struct, including padding, MUST remain zero
+ * except for *explicitly* assigned fields.
+ *
  * @since 1.14.0
  *
  * @sa `xkb_state::xkb_state_update_synthetic()`
@@ -3302,9 +3387,9 @@ struct xkb_state_update {
     /**
      * Size of this structure, for forward-compatibility.
      *
-     * Must be set to `sizeof(struct xkb_state_update)`.
-     * If the caller’s size exceeds the library’s (e.g. version mismatch),
-     * an error is returned unless all extra bytes are zero.
+     * @sa `::XKB_ERROR_ABI_INVALID_STRUCT_SIZE`
+     * @sa `::XKB_ERROR_ABI_BACKWARD_COMPAT`
+     * @sa `::XKB_ERROR_ABI_FORWARD_COMPAT`
      */
     size_t size;
     /**

--- a/src/state-priv.h
+++ b/src/state-priv.h
@@ -54,7 +54,29 @@ struct xkb_state_components_update_v1 {
     int32_t locked_layout;
     enum xkb_keyboard_control_flags affect_controls;
     enum xkb_keyboard_control_flags controls;
+
+#if SIZE_MAX > UINT32_MAX
+    /* Reserved for ABI alignment. Must be zero. */
+    uint32_t _reserved;
+#endif
 };
+
+/* Ensure there is no implicit padding */
+static_assert(sizeof(struct xkb_state_components_update_v1) ==
+              sizeof(size_t)                          /* size                */
+            + sizeof(enum xkb_state_component)        /* components          */
+            + sizeof(xkb_mod_mask_t)                  /* affect_latched_mods */
+            + sizeof(xkb_mod_mask_t)                  /* latched_mods        */
+            + sizeof(xkb_mod_mask_t)                  /* affect_locked_mods  */
+            + sizeof(xkb_mod_mask_t)                  /* locked_mods         */
+            + sizeof(int32_t)                         /* latched_layout      */
+            + sizeof(int32_t)                         /* locked_layout       */
+            + sizeof(enum xkb_keyboard_control_flags) /* affect_controls     */
+            + sizeof(enum xkb_keyboard_control_flags) /* controls            */
+#if SIZE_MAX > UINT32_MAX
+            + sizeof(uint32_t)                        /* _reserved           */
+#endif
+            , "struct xkb_state_components_update_v1 has implicit padding");
 
 /* Current version is 1 */
 static_assert(sizeof(struct xkb_state_components_update) ==
@@ -71,6 +93,13 @@ struct xkb_layout_policy_update_v1 {
     xkb_layout_index_t redirect;
 };
 
+/* Ensure there is no implicit padding */
+static_assert(sizeof(struct xkb_layout_policy_update_v1) ==
+              sizeof(size_t)                               /* size     */
+            + sizeof(enum xkb_layout_out_of_range_policy)  /* policy   */
+            + sizeof(xkb_layout_index_t),                  /* redirect */
+              "struct xkb_layout_policy_update_v1 has implicit padding");
+
 /* Current version is 1 */
 static_assert(sizeof(struct xkb_layout_policy_update) ==
               sizeof(struct xkb_layout_policy_update_v1), "");
@@ -85,6 +114,13 @@ struct xkb_state_update_v1 {
     const struct xkb_state_components_update_v1 *components;
     const struct xkb_layout_policy_update_v1 *layout_policy;
 };
+
+/* Ensure there is no implicit padding */
+static_assert(sizeof(struct xkb_state_update_v1) ==
+              sizeof(size_t)                          /* size          */
+            + sizeof((void *)0)                       /* components    */
+            + sizeof((void *)0),                      /* layout_policy */
+              "struct xkb_state_update_v1 has implicit padding");
 
 /* Current version is 1 */
 static_assert(sizeof(struct xkb_state_update) ==


### PR DESCRIPTION
Mention in the public API that possible padding bytes MUST be set to 0 with `memset()`.

Ensure there is no *implicit* padding so that we can avoid using `memset()` internally.