### PR TITLE
Add `xkb_keymap_serialize()`

### DIFF
--- a/changes/api/+xkb_keymap_serialize.feature.md
+++ b/changes/api/+xkb_keymap_serialize.feature.md
@@ -1,0 +1,8 @@
+Added `xkb_keymap::xkb_keymap_serialize()`,  `struct xkb_keymap_serialize_config` and
+`struct xkb_serialize_result` to enable more control on serializing or its result.
+
+In particular, it enables to serialize a keymap with more than 4 layouts into
+an <strong>X11</strong>-compatible keymap, suitable to use in the [Wayland] protocol
+(see: [`wl_keyboard::keymap_format::xkb_v1`](https://wayland.app/protocols/wayland#wl_keyboard:enum:keymap_format:entry:xkb_v1)).
+
+[Wayland]: https://wayland.freedesktop.org/

--- a/changes/tools/+compile-keymap-layout-mask.feature.md
+++ b/changes/tools/+compile-keymap-layout-mask.feature.md
@@ -1,0 +1,1 @@
+`xkbcli compile-keymap`: Added `--layouts-mask` to select the layouts indices to serialize.

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -666,3 +666,57 @@ if (xkb_keymap_num_layouts_for_key(keymap, keycode))
 ```
 </dd>
 </dl>
+
+### Layouts
+
+#### How to handle more than 4 layouts?
+
+##### Parsing
+
+Creating a keymap with more than 4 layouts requires using the [keymap format v2].
+
+[keymap format v2]: @ref xkb_keymap_format::XKB_KEYMAP_FORMAT_TEXT_V2
+
+##### Serialiazing
+
+Serialiazing a keymap with more than 4 layouts may be achieved by:
+
+<dl>
+<dt>*Lossless* serialization</dt>
+<dd>Serialize all the layouts using the [keymap format v2].</dd>
+<dt>*Lossy* serialization</dt>
+<dd>
+Serialize a *subset* of the layouts using `xkb_keymap::xkb_keymap_serialize()`.
+The target keymap format depends on the use case.
+
+@figure
+@figcaption
+Example of an X11-compatible serialization of a **8**-layout keymap:
+only layouts indices **3 to 6** are serialized.
+@endfigcaption
+
+```c
+const struct xkb_keymap_serialize_config config = {
+    .size = sizeof(config),
+    /* X11 compatibility */
+    .format = XKB_KEYMAP_FORMAT_TEXT_V1,
+    /* X11 compatibility: 4 layouts (max supported by X11), indices 3-6 (0-indexed) */
+    .layouts = 0x78
+};
+
+struct xkb_keymap_serialize_result result = { .size = sizeof(result) };
+
+const xkb_error_code ret = xkb_keymap_serialize(keymap, &config, &result);
+if (ret == XKB_SUCCESS) {
+    // send result.serialized
+    …
+} else {
+    // handle error
+    …
+}
+
+free(result.serialized);
+```
+@endfigure
+</dd>
+</dl>

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -1381,6 +1381,10 @@ enum xkb_keymap_format {
      * advised to use this format as well for serializing, in order to ensure
      * maximum compatibility for interchange.
      *
+     * @note In case serializing a keymap with *more than 4 layouts*, use
+     * `xkb_keymap::xkb_keymap_serialize()` and select the layouts to serialize
+     * using `xkb_keymap_serialize_config::layouts`.
+     *
      * [xkb_v1]: https://wayland.freedesktop.org/docs/html/apa.html#protocol-spec-wl_keyboard-enum-keymap_format
      */
     XKB_KEYMAP_FORMAT_TEXT_V1 = 1,
@@ -1641,6 +1645,170 @@ enum xkb_keymap_serialize_flags {
 };
 
 /**
+ * @struct xkb_keymap_serialize_config
+ *
+ * Serialization configuration for `xkb_keymap::xkb_keymap_serialize()`.
+ *
+ * @sa `::xkb_keymap_serialize_result`
+ * @since 1.14.0
+ */
+struct xkb_keymap_serialize_config {
+    /**
+     * Size of this structure, for forward-compatibility.
+     *
+     * @sa `::XKB_ERROR_ABI_INVALID_STRUCT_SIZE`
+     * @sa `::XKB_ERROR_ABI_BACKWARD_COMPAT`
+     * @sa `::XKB_ERROR_ABI_FORWARD_COMPAT`
+     *
+     * @since 1.14.0
+     */
+    size_t size;
+    /**
+     * Mask of [serialization flags].
+     *
+     * @sa `xkb_keymap_serialize_flags`
+     *
+     * @since 1.14.0
+     *
+     * [serialization flags]: @ref xkb_keymap_serialize_flags
+     */
+    uint32_t flags;
+    /**
+     * Target [keymap format].
+     *
+     * @sa `xkb_keymap_format`
+     *
+     * @since 1.14.0
+     *
+     * [keymap format]: @ref xkb_keymap_format
+     */
+    uint32_t format;
+    /**
+     * Mask of layouts to serialize.
+     *
+     * If `0`, then all the keymap layouts are serialized.
+     *
+     * @since 1.14.0
+     */
+    xkb_layout_mask_t layouts;
+    /**
+     * @private
+     *
+     * Reserved for future extensions.
+     *
+     * @pre Must be set to `0` by the caller.
+     */
+    uint32_t reserved;
+};
+
+/**
+ * @struct xkb_keymap_serialize_result
+ *
+ * Result of `xkb_keymap::xkb_keymap_serialize()`
+ *
+ * @sa `::xkb_keymap_serialize_config`
+ * @since 1.14.0
+ */
+struct xkb_keymap_serialize_result {
+    /**
+     * Size of this structure, for forward-compatibility.
+     *
+     * @sa `::XKB_ERROR_ABI_INVALID_STRUCT_SIZE`
+     * @sa `::XKB_ERROR_ABI_BACKWARD_COMPAT`
+     * @sa `::XKB_ERROR_ABI_FORWARD_COMPAT`
+     *
+     * @since 1.14.0
+     */
+    size_t size;
+    /**
+     * A newly *allocated* keymap serialization, or `NULL` on failure.
+     *
+     * The caller of `xkb_keymap::xkb_keymap_serialize()` must free it.
+     *
+     * @since 1.14.0
+     */
+    char *serialized;
+    /**
+     * Length of #serialized, in bytes, including any terminating `NUL` byte.
+     *
+     * Valid only if the function returns `::XKB_SUCCESS`; otherwise unspecified.
+     *
+     * @since 1.14.0
+     */
+    size_t length;
+    /**
+     * Mask of the original layouts actually included in #serialized.
+     *
+     * Valid only if the function returns `::XKB_SUCCESS`; otherwise unspecified.
+     *
+     * @sa `xkb_keymap_serialize_config::layouts`
+     *
+     * @since 1.14.0
+     */
+    xkb_layout_mask_t layouts;
+    /**
+     * @private
+     *
+     * Reserved for future extensions.
+     *
+     * @pre Must be set to `0` by the caller.
+     */
+    uint32_t reserved;
+};
+
+/**
+ * Serialize a compiled keymap to a string.
+ *
+ * On success, returns a newly *allocated* serialized keymap in
+ * [`result->serialized`][serialized], together with additional metadata.
+ * It is suitable to use with `xkb_keymap_new_from_string2()`.
+ *
+ * Use this function instead of `xkb_keymap_get_as_string()` or
+ * `xkb_keymap_get_as_string2()` when more control on serializing
+ * or its result is required.
+ *
+ * @note This function enables to serialize an X11-<em>incompatible</em> keymap
+ * with more than 4 layouts to an X11-<em>compatible</em> keymap with up to 4
+ * layouts:
+ * - set [`config->format`][format] to `::XKB_KEYMAP_FORMAT_TEXT_V1`,
+ * - set up to 4 bits in [`config->layouts`][layouts] to select a subset of
+ *   layouts to serialized.
+ *
+ * @param[in]     keymap   The keymap to serialize.
+ * @param[in]     config   Configuration guiding the serialization.
+ * @param[in,out] result   Result of the serialization.
+ *
+ * @pre @p config must point to a zero-initialized struct with
+ * [`size`](@ref xkb_keymap_serialize_config::size) set to `sizeof(*config)`.
+ *
+ * @pre @p result must point to a zero-initialized struct with
+ * [`size`](@ref xkb_keymap_serialize_result::size) set to `sizeof(*result)`.
+ *
+ * @invariant The library writes only to fields of @p result that fall
+ * within `result->size`.
+ *
+ * @post If the return value is `::XKB_SUCCESS`, the caller is responsible
+ * for freeing [`result->serialized`][serialized].
+ *
+ * @post Otherwise, [`result->serialized`][serialized] is set to `NULL` and
+ * all fields of @p result beyond it are left unspecified.
+ *
+ * @returns `::XKB_SUCCESS` on success; otherwise an
+ * [error code](@ref xkb_error_code).
+ *
+ * @since 1.14.0
+ * @memberof xkb_keymap
+ *
+ * [format]: @ref xkb_keymap_serialize_config::format
+ * [layouts]: @ref xkb_keymap_serialize_config::layouts
+ * [serialized]: @ref xkb_keymap_serialize_result::serialized
+ */
+XKB_EXPORT enum xkb_error_code
+xkb_keymap_serialize(const struct xkb_keymap *keymap,
+                     const struct xkb_keymap_serialize_config *config,
+                     struct xkb_keymap_serialize_result *result);
+
+/**
  * Get the compiled keymap as a string.
  *
  * Same as `xkb_keymap::xkb_keymap_get_as_string2()` using
@@ -1649,6 +1817,7 @@ enum xkb_keymap_serialize_flags {
  * @since 1.12.0: Drop unused types and compatibility entries and do not
  * pretty-print.
  *
+ * @sa `xkb_keymap::xkb_keymap_serialize()`
  * @sa `xkb_keymap::xkb_keymap_get_as_string2()`
  * @memberof xkb_keymap
  */
@@ -1676,6 +1845,7 @@ xkb_keymap_get_as_string(struct xkb_keymap *keymap,
  *
  * @since 1.12.0
  *
+ * @sa `xkb_keymap_serialize()`
  * @sa `xkb_keymap_get_as_string()`
  * @sa `xkb_keymap_new_from_string()`
  * @memberof xkb_keymap

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -1292,6 +1292,15 @@ enum xkb_keymap_compile_flags {
     XKB_KEYMAP_COMPILE_STRICT_MODE = (1 << 0)
 };
 
+/** @} */
+
+/**
+ * @defgroup xkb_keymap_format_enum Keymap formats
+ * @ingroup keymap keymap-serialization
+ * @brief Keymap formats for parsing and serializing keymaps
+ * <!-- this group enable to display keymap formats in multiple groups -->
+ */
+
 /**
  * @enum xkb_keymap_format
  * The possible keymap formats.
@@ -1367,6 +1376,8 @@ enum xkb_keymap_compile_flags {
  * </tbody>
  * </table>
  *
+ * @ingroup xkb_keymap_format_enum
+ *
  * [xkb_v1]: https://wayland.freedesktop.org/docs/html/apa.html#protocol-spec-wl_keyboard-enum-keymap_format
  * [xkeyboard-config]: https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config
  */
@@ -1410,6 +1421,11 @@ enum xkb_keymap_format {
      */
     XKB_KEYMAP_FORMAT_TEXT_V2 = 2
 };
+
+/**
+ * @addtogroup keymap
+ * @{
+ */
 
 /**
  * Create a keymap from a [RMLVO] builder.
@@ -1569,6 +1585,15 @@ xkb_keymap_ref(struct xkb_keymap *keymap);
  */
 XKB_EXPORT void
 xkb_keymap_unref(struct xkb_keymap *keymap);
+
+/** @} */
+
+/**
+ * @defgroup keymap-serialization Keymap Serialization
+ * Serializing keymaps.
+ *
+ * @{
+ */
 
 /**
  * Get the keymap as a string in the format from which it was created.

--- a/src/keymap-priv.h
+++ b/src/keymap-priv.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2026 Pierre Le Marre <dev@wismill.eu>
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include "config.h"
+
+#include <assert.h>
+#include <stddef.h>
+
+#include "xkbcommon/xkbcommon.h"
+#include "abi-check.h"
+
+/******************************************************************************
+ * xkb_keymap_serialize_config
+ *****************************************************************************/
+
+/**
+ * Version 1 of `xkb_keymap_serialize_config`, used for ABI check only
+ *
+ * @since 1.14.0
+ */
+struct xkb_keymap_serialize_config_v1 {
+    size_t size;
+    uint32_t flags;
+    uint32_t format;
+    xkb_layout_mask_t layouts;
+    uint32_t reserved;
+};
+
+/* Ensure there is no implicit padding */
+static_assert(sizeof(struct xkb_keymap_serialize_config) ==
+              sizeof(size_t)                          /* size        */
+            + sizeof(uint32_t)                        /* flags       */
+            + sizeof(uint32_t)                        /* format      */
+            + sizeof(xkb_layout_mask_t)               /* layouts     */
+            + sizeof(uint32_t),                       /* reserved    */
+              "struct xkb_keymap_serialize_config_v1 has implicit padding");
+
+static_assert(offsetof(struct xkb_keymap_serialize_config, reserved) +
+              sizeof(((struct xkb_keymap_serialize_config *)0)->reserved) ==
+              sizeof(struct xkb_keymap_serialize_config),
+              "`reserved` is not the explicit trailing padding");
+
+/* Current version is 1 */
+static_assert(sizeof(struct xkb_keymap_serialize_config) ==
+              sizeof(struct xkb_keymap_serialize_config_v1), "");
+
+/* Ensure reasonable margin to the upper size limit */
+static_assert(sizeof(struct xkb_keymap_serialize_config) * 30 <=
+              (size_t)XKB_ABI_MAX_SIZE, "");
+
+/******************************************************************************
+ * xkb_keymap_serialize_result
+ *****************************************************************************/
+
+/**
+ * Version 1 of `xkb_keymap_serialize_result`, used for ABI check only
+ *
+ * @since 1.14.0
+ */
+struct xkb_keymap_serialize_result_v1 {
+    size_t size;
+    char *serialized;
+    size_t length;
+    xkb_layout_mask_t layouts;
+    uint32_t reserved;
+};
+
+/* Ensure there is no implicit padding */
+static_assert(sizeof(struct xkb_keymap_serialize_result) ==
+              sizeof(size_t)                          /* size        */
+            + sizeof((void *)0)                       /* serialized  */
+            + sizeof(size_t)                          /* length      */
+            + sizeof(xkb_layout_mask_t)               /* layouts     */
+            + sizeof(uint32_t),                       /* reserved    */
+              "struct xkb_keymap_serialize_result_v1 has implicit padding");
+
+static_assert(offsetof(struct xkb_keymap_serialize_result, reserved) +
+              sizeof(((struct xkb_keymap_serialize_result *)0)->reserved) ==
+              sizeof(struct xkb_keymap_serialize_result),
+              "`reserved` is not the explicit trailing padding");
+
+/* Current version is 1 */
+static_assert(sizeof(struct xkb_keymap_serialize_result) ==
+              sizeof(struct xkb_keymap_serialize_result_v1), "");
+
+/* Ensure reasonable margin to the upper size limit */
+static_assert(sizeof(struct xkb_keymap_serialize_result) * 30 <=
+              (size_t)XKB_ABI_MAX_SIZE, "");
+
+/******************************************************************************
+ * Utils
+ *****************************************************************************/
+
+/** Size of the *first version* of the struct */
+#define xkb_versioned_struct_size_v1(x) _Generic(      \
+    (x),                                               \
+    const struct xkb_keymap_serialize_config *:        \
+        sizeof(struct xkb_keymap_serialize_config_v1), \
+    const struct xkb_keymap_serialize_result *:        \
+        sizeof(struct xkb_keymap_serialize_result_v1)  \
+)
+
+/** Minimal *current* valid size of the struct */
+#define xkb_versioned_struct_size_min(x) _Generic(     \
+    (x),                                               \
+    const struct xkb_keymap_serialize_config *:        \
+        sizeof(struct xkb_keymap_serialize_config_v1), \
+    const struct xkb_keymap_serialize_result *:        \
+        sizeof(struct xkb_keymap_serialize_result_v1)  \
+)
+
+/** Offset of the last meaningful field of the current struct */
+#define xkb_versioned_struct_reserved_offset(x) _Generic(      \
+    (x),                                                       \
+    const struct xkb_keymap_serialize_config *:                \
+        offsetof(struct xkb_keymap_serialize_config, reserved),\
+    const struct xkb_keymap_serialize_result *:                \
+        offsetof(struct xkb_keymap_serialize_result, reserved) \
+)
+
+/* V1 is the smallest struct version */
+static_assert(
+    xkb_versioned_struct_size_v1(((const struct xkb_keymap_serialize_config *)NULL)) <=
+    xkb_versioned_struct_size_min(((const struct xkb_keymap_serialize_config *)NULL)),
+    ""
+);
+
+/* Minimal size is lower or equal to the current size */
+static_assert(
+    xkb_versioned_struct_size_min(((const struct xkb_keymap_serialize_config *)NULL)) <=
+    sizeof(const struct xkb_keymap_serialize_config),
+    ""
+);
+
+#define xkb_check_keymap_serialize_struct_size(x) xkb_check_versioned_struct_size( \
+    xkb_versioned_struct_size_v1(x),                                               \
+    xkb_versioned_struct_size_min(x),                                              \
+    xkb_versioned_struct_reserved_offset(x),                                       \
+    (x)                                                                            \
+)

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -16,10 +16,13 @@
 #include <assert.h>
 #include <stdint.h>
 
+#include "utils-numbers.h"
 #include "xkbcommon/xkbcommon.h"
+#include "abi-check.h"
 #include "atom.h"
 #include "features/enums.h"
 #include "keymap.h"
+#include "keymap-priv.h"
 #include "messages-codes.h"
 #include "text.h"
 
@@ -252,34 +255,130 @@ xkb_keymap_new_from_file(struct xkb_context *ctx,
     return keymap;
 }
 
+/* Check ABI compatibility */
+static enum xkb_error_code
+check_keymap_serialize_abi(
+    struct xkb_context * restrict ctx,
+    const char * restrict func,
+    const struct xkb_keymap_serialize_config * restrict config,
+    const struct xkb_keymap_serialize_result * restrict result
+)
+{
+    enum xkb_error_code error;
+    if ((error = xkb_check_keymap_serialize_struct_size(config)) ||
+        (error = xkb_check_keymap_serialize_struct_size(result))) {
+        xkb_log_abi_error(ctx, func, error);
+    }
+    return error;
+}
+
+enum xkb_error_code
+xkb_keymap_serialize(const struct xkb_keymap *keymap,
+                     const struct xkb_keymap_serialize_config *config,
+                     struct xkb_keymap_serialize_result *result)
+{
+    /* Check ABI compatibility */
+    enum xkb_error_code error =
+        check_keymap_serialize_abi(keymap->ctx, __func__, config, result);
+    if (error)
+        return error;
+
+    struct xkb_keymap_serialize_config new_config = *config;
+
+    static const enum xkb_keymap_serialize_flags XKB_KEYMAP_SERIALIZE_FLAGS
+        = (enum xkb_keymap_serialize_flags) XKB_KEYMAP_SERIALIZE_FLAGS_VALUES;
+
+    if (new_config.flags & ~XKB_KEYMAP_SERIALIZE_FLAGS) {
+        log_err_func(keymap->ctx,
+                     XKB_ERROR_UNSUPPORTED_KEYMAP_SERIALIZATION_FLAGS_,
+                     "unrecognized serialization flags: %#x\n",
+                     (new_config.flags & ~XKB_KEYMAP_SERIALIZE_FLAGS));
+        return XKB_ERROR_UNSUPPORTED_KEYMAP_SERIALIZATION_FLAGS;
+    }
+
+    if (new_config.format == XKB_KEYMAP_USE_ORIGINAL_FORMAT)
+        new_config.format = keymap->format;
+
+    const struct xkb_keymap_format_ops * const ops =
+        get_keymap_format_ops(new_config.format);
+    if (!ops || !ops->keymap_serialize) {
+        log_err_func(keymap->ctx, XKB_ERROR_UNSUPPORTED_KEYMAP_FORMAT_,
+                     "unsupported keymap format: %d\n", new_config.format);
+        return XKB_ERROR_UNSUPPORTED_KEYMAP_FORMAT;
+    }
+
+    const xkb_layout_mask_t all_layouts =
+        (xkb_layout_mask_t)((UINT64_C(1) << keymap->num_groups) - 1);
+    if (!new_config.layouts) {
+        new_config.layouts = all_layouts;
+    }
+
+    if (new_config.layouts & ~all_layouts) {
+        log_err_func(keymap->ctx, XKB_ERROR_UNSUPPORTED_LAYOUT_INDEX_,
+                     "unsupported layout mask: "
+                     "expected subset of 0x%08"PRIx32", got: 0x%08"PRIx32"\n",
+                     all_layouts, new_config.layouts);
+        return XKB_ERROR_UNSUPPORTED_LAYOUT_INDEX;
+    }
+
+    const xkb_layout_index_t max_groups = format_max_groups(config->format);
+    const xkb_layout_index_t num_groups =
+        (xkb_layout_index_t)popcount32(new_config.layouts);
+
+    if (num_groups > max_groups) {
+        const bool strict =
+            (new_config.flags & XKB_KEYMAP_SERIALIZE_STRICT_MODE);
+        xkb_log_with_code(
+            keymap->ctx,
+            (strict ? XKB_LOG_LEVEL_ERROR : XKB_LOG_LEVEL_WARNING),
+            XKB_LOG_VERBOSITY_MINIMAL,
+            XKB_ERROR_LAYOUT_COUNT_LIMIT_EXCEEDED_,
+            "Cannot serialize %"PRIu32" groups in keymap format %d: "
+            "maximum is %"PRIu32"%s\n",
+            num_groups, config->format, max_groups,
+            (strict ? "" : "; discarding unsupported groups")
+        );
+        if (strict) {
+            return XKB_ERROR_LAYOUT_COUNT_LIMIT_EXCEEDED;
+        } else {
+            new_config.layouts =
+                keep_lowest_n_set_bits(new_config.layouts, max_groups);
+        }
+    }
+
+    log_dbg(keymap->ctx, XKB_LOG_MESSAGE_NO_ID,
+            "Serializing group mask 0x%"PRIx32" (total: %"PRIu32")\n",
+            new_config.layouts, num_groups);
+
+    if (new_config.layouts != all_layouts) {
+        /*
+         * If some layouts are discarded, then interprets may not trigger
+         * properly. Avoid this by requiring explicit values.
+         */
+        new_config.flags |= (XKB_KEYMAP_SERIALIZE_EXPLICIT_KEY_VALUES |
+                             XKB_KEYMAP_SERIALIZE_EXPLICIT_VMODS);
+    }
+
+    return ops->keymap_serialize(keymap, &new_config, result);
+}
+
 char *
 xkb_keymap_get_as_string2(struct xkb_keymap *keymap,
                           enum xkb_keymap_format format,
                           enum xkb_keymap_serialize_flags flags)
 {
-    static const enum xkb_keymap_serialize_flags XKB_KEYMAP_SERIALIZE_FLAGS
-        = (enum xkb_keymap_serialize_flags) XKB_KEYMAP_SERIALIZE_FLAGS_VALUES;
+    const struct xkb_keymap_serialize_config config = {
+        .size = sizeof(config),
+        .flags = flags,
+        .format = format,
+        .layouts = 0,
+    };
 
-    if (flags & ~XKB_KEYMAP_SERIALIZE_FLAGS) {
-        log_err_func(keymap->ctx,
-                     XKB_ERROR_UNSUPPORTED_KEYMAP_SERIALIZATION_FLAGS,
-                     "unrecognized serialization flags: %#x\n",
-                     (flags & ~XKB_KEYMAP_SERIALIZE_FLAGS));
-        return NULL;
-    }
+    struct xkb_keymap_serialize_result result = { .size = sizeof(result) };
 
-    if (format == XKB_KEYMAP_USE_ORIGINAL_FORMAT)
-        format = keymap->format;
-
-    const struct xkb_keymap_format_ops * const ops =
-        get_keymap_format_ops(format);
-    if (!ops || !ops->keymap_get_as_string) {
-        log_err_func(keymap->ctx, XKB_ERROR_UNSUPPORTED_KEYMAP_FORMAT,
-                     "unsupported keymap format: %d\n", format);
-        return NULL;
-    }
-
-    return ops->keymap_get_as_string(keymap, format, flags);
+    return (xkb_keymap_serialize(keymap, &config, &result) == XKB_SUCCESS)
+        ? result.serialized
+        : NULL;
 }
 
 char *

--- a/src/keymap.h
+++ b/src/keymap.h
@@ -982,9 +982,11 @@ struct xkb_keymap_format_ops {
     bool (*keymap_new_from_string)(struct xkb_keymap *keymap,
                                    const char *string, size_t length);
     bool (*keymap_new_from_file)(struct xkb_keymap *keymap, FILE *file);
-    char *(*keymap_get_as_string)(struct xkb_keymap *keymap,
-                                  enum xkb_keymap_format format,
-                                  enum xkb_keymap_serialize_flags flags);
+    enum xkb_error_code (*keymap_serialize)(
+        const struct xkb_keymap *keymap,
+        const struct xkb_keymap_serialize_config *config,
+        struct xkb_keymap_serialize_result *result
+    );
 };
 
 extern const struct xkb_keymap_format_ops text_v1_keymap_format_ops;

--- a/src/utils-numbers.h
+++ b/src/utils-numbers.h
@@ -10,6 +10,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#if defined(_MSC_VER)
+# include <intrin.h>
+#endif
+
 #include "utils.h"
 
 /*
@@ -115,6 +119,8 @@ MAKE_PARSE_HEX_TO(uint32_t, UINT32_MAX)
  */
 MAKE_PARSE_HEX_TO(uint64_t, UINT64_MAX)
 
+#undef MAKE_PARSE_HEX_TO
+
 static inline unsigned int
 popcount32(uint32_t x)
 {
@@ -130,6 +136,33 @@ popcount32(uint32_t x)
         count++;
     }
     return count;
+#endif
+}
+
+static inline unsigned int
+ctz32(uint32_t x)
+{
+    if (x == 0)
+        return 32;
+
+#if defined(__GNUC__) || defined(__clang__)
+    return _Generic(
+        x,
+        unsigned int: (unsigned int)__builtin_ctz(x),
+        unsigned long: (unsigned int)__builtin_ctzl(x),
+        unsigned long long: (unsigned int)__builtin_ctzll(x)
+    );
+#elif defined(_MSC_VER)
+    unsigned long index;
+    _BitScanForward(&index, x);
+    return (unsigned int)index;
+#else
+    /* Fallback: De Bruijn sequence algorithm for 32-bit integers */
+    static const unsigned int debruijn32[32] = {
+        0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8,
+        31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9
+    };
+    return debruijn32[((x & -x) * UINT32_C(0x077cb531)) >> 27];
 #endif
 }
 
@@ -179,4 +212,13 @@ next_pow2(unsigned int x)
 #endif
 }
 
-#undef MAKE_PARSE_HEX_TO
+static inline uint32_t
+keep_lowest_n_set_bits(uint32_t mask, unsigned int n) {
+    const uint32_t original = mask;
+
+    /* Clear the lowest set bit n times */
+    while (n-- && mask)
+        mask &= (mask - 1);
+
+    return original ^ mask;
+}

--- a/src/xkbcomp/keymap-dump.c
+++ b/src/xkbcomp/keymap-dump.c
@@ -13,14 +13,16 @@
 #include "config.h"
 
 #include <assert.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "context.h"
+#include "xkbcommon/xkbcommon-errors.h"
 #include "xkbcommon/xkbcommon-keysyms.h"
 #include "xkbcommon/xkbcommon.h"
 #include "atom.h"
 #include "action.h"
+#include "context.h"
 #include "darray.h"
 #include "keymap.h"
 #include "messages-codes.h"
@@ -750,6 +752,11 @@ write_action(const struct xkb_keymap *keymap, enum xkb_keymap_format format,
                       suffix);
         } else {
             /* Unsupported group index: degrade to VoidAction() */
+            log_warn(keymap->ctx, XKB_LOG_MESSAGE_NO_ID,
+                     "Unsupported group index %"PRIu32" for action %s()\n",
+                      (action->group.group +
+                       !!(action->group.flags & ACTION_ABSOLUTE_SWITCH)),
+                     type);
             goto void_action;
         }
         break;
@@ -1302,7 +1309,8 @@ write_keysyms(const struct xkb_keymap *keymap,
 }
 
 static bool
-write_key(const struct xkb_keymap *keymap, enum xkb_keymap_format format,
+write_key(const struct xkb_keymap *keymap,
+          const struct xkb_keymap_serialize_config *config,
           const key_name_substitutions *substitutions,
           xkb_layout_index_t max_groups, bool some_interprets,
           bool drop_interprets, bool explicit, bool pretty,
@@ -1310,7 +1318,24 @@ write_key(const struct xkb_keymap *keymap, enum xkb_keymap_format format,
 {
     bool simple = true;
 
-    const xkb_layout_index_t num_groups = MIN(key->num_groups, max_groups);
+    xkb_layout_mask_t layouts = config->layouts;
+    if (popcount32(layouts) != keymap->num_groups) {
+        /* Subset of layouts: use out-of-range key policy */
+        xkb_layout_index_t l = 0;
+        for (xkb_layout_mask_t ls = layouts; ls; ls >>= 1, l++) {
+            if (ls & 0x1) {
+                /* Replace target layout with its effective layout, if valid */
+                layouts &= ~(UINT32_C(1) << l);
+                const xkb_layout_index_t effective =
+                    xkb_keymap_key_effective_layout(key, l);
+                if (effective != XKB_LAYOUT_INVALID)
+                    layouts |= (UINT32_C(1) << effective);
+            }
+        }
+    } else {
+        layouts &= ((UINT64_C(1) << key->num_groups) - 1);
+    }
+    const xkb_layout_index_t groups_count = popcount32(layouts);
 
     const xkb_atom_t name = (substitutions == NULL)
         ? key->name
@@ -1327,7 +1352,10 @@ write_key(const struct xkb_keymap *keymap, enum xkb_keymap_format format,
         bool multi_type = explicit;
         /* Check for distinct key types only if not requiring explicit values */
         if (!explicit) {
-            for (xkb_layout_index_t group = 1; group < num_groups; group++) {
+            for (xkb_layout_index_t group = 1; group < key->num_groups; group++) {
+                if (!((UINT32_C(1) << group) & layouts))
+                    continue;
+
                 if (key->groups[group].type != key->groups[0].type) {
                     multi_type = true;
                     break;
@@ -1336,12 +1364,18 @@ write_key(const struct xkb_keymap *keymap, enum xkb_keymap_format format,
         }
 
         if (multi_type) {
-            for (xkb_layout_index_t group = 0; group < num_groups; group++) {
+            xkb_layout_index_t new_group = (xkb_layout_index_t)-1;
+            for (xkb_layout_index_t group = 0; group < key->num_groups; group++) {
+                if (!((UINT32_C(1) << group) & layouts))
+                    continue;
+
+                new_group++;
+
                 if (!key->groups[group].explicit_type && !explicit)
                     continue;
 
                 const struct xkb_key_type * const type = key->groups[group].type;
-                write_buf(buf, "\n\t\ttype[%"PRIu32"]= ", group + 1);
+                write_buf(buf, "\n\t\ttype[%"PRIu32"]= ", new_group + 1);
                 write_buf_string_literal(
                   buf, xkb_atom_text(keymap->ctx, type->name));
                 copy_to_buf(buf, ",");
@@ -1418,14 +1452,34 @@ write_key(const struct xkb_keymap *keymap, enum xkb_keymap_format format,
         simple = false;
         break;
 
-    case XKB_LAYOUT_OUT_OF_RANGE_REDIRECT:
-        if (key->out_of_range_group_number < num_groups) {
-            /* TODO: Fallback or warning if condition fails? */
-            write_buf(buf, "\n\t\tgroupsRedirect= %"PRIu32",",
-                      key->out_of_range_group_number + 1);
-            simple = false;
+    case XKB_LAYOUT_OUT_OF_RANGE_REDIRECT: {
+        if (!groups_count) {
+            /* No layout to redirect to: skip */
+            break;
         }
+
+        xkb_layout_mask_t layout_mask =
+            (UINT32_C(1) << key->out_of_range_group_number);
+        if (!(layouts & layout_mask)) {
+            /*
+             * Layout is not included: default to first layout
+             * See: XkbWrapGroupIntoRange
+             */
+            log_warn(keymap->ctx, XKB_LOG_MESSAGE_NO_ID,
+                     "key %s: groupsRedirect=%"PRIu32" converted to "
+                     "groupsRedirect=1\n",
+                     KeyNameText(keymap->ctx, name),
+                     key->out_of_range_group_number + 1);
+            layout_mask = 0x1;
+        }
+
+        /* In case some lower layouts were discarded, update the group index */
+        const xkb_layout_mask_t low = (layouts & (layout_mask - 1));
+        const xkb_layout_index_t new = popcount32(low);
+        write_buf(buf, "\n\t\tgroupsRedirect= %"PRIu32",", new + 1);
+        simple = false;
         break;
+    }
 
     case XKB_LAYOUT_OUT_OF_RANGE_WRAP:
     default:
@@ -1435,7 +1489,8 @@ write_key(const struct xkb_keymap *keymap, enum xkb_keymap_format format,
     if (key->overlays) {
         xkb_overlay_mask_t remaining = key->overlays;
 
-        const xkb_overlay_index_t overlay_max = format_max_overlays(format);
+        const xkb_overlay_index_t overlay_max =
+            format_max_overlays(config->format);
         static_assert(XKB_OVERLAY_MAX == 8, "invalid right shift");
         const xkb_overlay_mask_t valid =
             (xkb_overlay_mask_t)((1u << overlay_max) - 1u);
@@ -1450,7 +1505,7 @@ write_key(const struct xkb_keymap *keymap, enum xkb_keymap_format format,
         }
 
         if (remaining && !key->overlays_inline &&
-            !areOverlappingOverlaysSupported(format)) {
+            !areOverlappingOverlaysSupported(config->format)) {
             /* isolate lowest set bit */
             const xkb_overlay_mask_t lsb = (xkb_overlay_mask_t)(
                 remaining &
@@ -1497,24 +1552,35 @@ write_key(const struct xkb_keymap *keymap, enum xkb_keymap_format format,
         }
     }
 
-    if (num_groups > 1 || explicit_actions || explicit)
+    if (groups_count > 1 || explicit_actions || explicit)
         simple = false;
 
     if (simple) {
-        if (num_groups == 0) {
+        if (groups_count == 0) {
             /* Remove trailing comma */
+            delete_last_char(buf, ',');
             if (buf->buf[buf->size - 1] == ',')
                 buf->size--;
         } else {
             copy_to_buf(buf, "\t[ ");
-            if (!write_keysyms(keymap, buf, buf2, key, 0, pretty, false))
+            /* Get the single group index */
+            xkb_mod_index_t group = ctz32(layouts);
+            /* The group may not be defined for this key if it is not the first one */
+            group = xkb_keymap_key_effective_layout(key, group);
+            if (!write_keysyms(keymap, buf, buf2, key, group, pretty, false))
                 return false;
             copy_to_buf(buf, " ]");
         }
         copy_to_buf(buf, " };\n");
     }
     else {
-        for (xkb_layout_index_t group = 0; group < num_groups; group++) {
+        xkb_layout_index_t new_group = (xkb_layout_index_t)-1;
+        for (xkb_layout_index_t group = 0; group < key->num_groups; group++) {
+            if (!((UINT32_C(1) << group) & layouts))
+                continue;
+
+            new_group++;
+
             const bool print_actions =
                 /* Group has explicit actions */
                 key->groups[group].explicit_actions ||
@@ -1529,23 +1595,23 @@ write_key(const struct xkb_keymap *keymap, enum xkb_keymap_format format,
                  * the actions must be made explicit */
                 (key->groups[group].implicit_actions && !some_interprets);
 
-            if (group != 0)
+            if (new_group != 0)
                 copy_to_buf(buf, ",");
-            write_buf(buf, "\n\t\tsymbols[%"PRIu32"]= [ ", group + 1);
+            write_buf(buf, "\n\t\tsymbols[%"PRIu32"]= [ ", new_group + 1);
 
             if (!write_keysyms(keymap, buf, buf2, key, group,
                                pretty, print_actions))
                 return false;
             copy_to_buf(buf, " ]");
             if (print_actions) {
-                write_buf(buf, ",\n\t\tactions[%"PRIu32"]= [ ", group + 1);
-                if (!write_actions(keymap, format, max_groups,
+                write_buf(buf, ",\n\t\tactions[%"PRIu32"]= [ ", new_group + 1);
+                if (!write_actions(keymap, config->format, max_groups,
                                    buf, buf2, key, group))
                     return false;
                 copy_to_buf(buf, " ]");
             }
         }
-        if (!num_groups)
+        if (!groups_count)
             delete_last_char(buf, ',');
         copy_to_buf(buf, "\n\t};\n");
     }
@@ -1766,18 +1832,18 @@ exit:
 }
 
 static bool
-write_symbols(const struct xkb_keymap *keymap, enum xkb_keymap_format format,
+write_symbols(const struct xkb_keymap *keymap,
+              const struct xkb_keymap_serialize_config *config,
               const key_name_substitutions *substitutions,
-              xkb_layout_index_t max_groups,
-              enum xkb_keymap_serialize_flags flags, bool some_interp,
+              xkb_layout_index_t max_groups, bool some_interp,
               struct buf *buf)
 {
-    const bool pretty = (flags & XKB_KEYMAP_SERIALIZE_PRETTY);
+    const bool pretty = (config->flags & XKB_KEYMAP_SERIALIZE_PRETTY);
     const bool defaults =
-        (flags & XKB_KEYMAP_SERIALIZE_EXPLICIT_DEFAULT_VALUES);
+        (config->flags & XKB_KEYMAP_SERIALIZE_EXPLICIT_DEFAULT_VALUES);
     const bool explicit_key_values =
-        (flags & XKB_KEYMAP_SERIALIZE_EXPLICIT_KEY_VALUES);
-    const bool drop_unused = !(flags & XKB_KEYMAP_SERIALIZE_KEEP_UNUSED);
+        (config->flags & XKB_KEYMAP_SERIALIZE_EXPLICIT_KEY_VALUES);
+    const bool drop_unused = !(config->flags & XKB_KEYMAP_SERIALIZE_KEEP_UNUSED);
     const bool drop_interprets = (explicit_key_values && drop_unused);
     /* TODO: print all default values if explicit flag is set */
 
@@ -1786,21 +1852,26 @@ write_symbols(const struct xkb_keymap *keymap, enum xkb_keymap_format format,
     else
         copy_to_buf(buf, "xkb_symbols {\n");
 
-    const xkb_layout_index_t num_group_names = MIN(keymap->num_group_names,
-                                                   max_groups);
     bool has_group_names = false;
-    for (xkb_layout_index_t group = 0; group < num_group_names; group++)
+    xkb_layout_index_t new_group = (xkb_layout_index_t)-1;
+    for (xkb_layout_index_t group = 0; group < keymap->num_group_names; group++) {
+        if (!((UINT32_C(1) << group) & config->layouts))
+            continue;
+
+        new_group++;
+
         if (keymap->group_names[group]) {
-            write_buf(buf, "\tname[%"PRIu32"]=", group + 1);
+            write_buf(buf, "\tname[%"PRIu32"]=", new_group + 1);
             write_buf_string_literal(
                 buf, xkb_atom_text(keymap->ctx, keymap->group_names[group]));
             copy_to_buf(buf, ";\n");
             has_group_names = true;
         }
+    }
     if (has_group_names)
         copy_to_buf(buf, "\n");
 
-    if (defaults && !write_actions_defaults(keymap, format, buf))
+    if (defaults && !write_actions_defaults(keymap, config->format, buf))
         return false;
 
     struct buf buf2 = { NULL, 0, 0 };
@@ -1808,7 +1879,7 @@ write_symbols(const struct xkb_keymap *keymap, enum xkb_keymap_format format,
     xkb_keys_foreach(key, keymap) {
         /* Skip keys with no explicit values */
         if (key->explicit) {
-            if (!write_key(keymap, format, substitutions, max_groups,
+            if (!write_key(keymap, config, substitutions, max_groups,
                            some_interp, drop_interprets, explicit_key_values,
                            pretty, buf, &buf2, key)) {
                 free(buf2.buf);
@@ -1818,8 +1889,7 @@ write_symbols(const struct xkb_keymap *keymap, enum xkb_keymap_format format,
     }
     free(buf2.buf);
 
-
-    if (!write_modmaps(keymap, format, substitutions,
+    if (!write_modmaps(keymap, config->format, substitutions,
                        pretty, drop_interprets, buf))
         return false;
 
@@ -1827,64 +1897,57 @@ write_symbols(const struct xkb_keymap *keymap, enum xkb_keymap_format format,
     return true;
 }
 
-static bool
-write_keymap(const struct xkb_keymap *keymap, enum xkb_keymap_format format,
-             enum xkb_keymap_serialize_flags flags, struct buf *buf)
+static enum xkb_error_code
+write_keymap(const struct xkb_keymap *keymap,
+             const struct xkb_keymap_serialize_config *config,
+             struct buf *buf, struct xkb_keymap_serialize_result *result)
 {
-    const xkb_layout_index_t max_groups = format_max_groups(format);
-    if (keymap->num_groups > max_groups) {
-        const bool strict = (flags & XKB_KEYMAP_SERIALIZE_STRICT_MODE);
-        xkb_log_with_code(
-            keymap->ctx,
-            (strict ? XKB_LOG_LEVEL_ERROR : XKB_LOG_LEVEL_WARNING),
-            XKB_LOG_VERBOSITY_MINIMAL,
-            XKB_ERROR_LAYOUT_COUNT_LIMIT_EXCEEDED,
-            "Cannot serialize %"PRIu32" groups in keymap format %d: "
-            "maximum is %"PRIu32"%s\n",
-            keymap->num_groups, format, max_groups,
-            (strict ? "" : "; discarding unsupported groups")
-        );
-        if (strict) {
-            return false;
-        } else {
-            /* discard excessive groups */
-        }
-    }
-
     key_name_substitutions substitutions = darray_new();
-    if (format == XKB_KEYMAP_FORMAT_TEXT_V1) {
+    if (config->format == XKB_KEYMAP_FORMAT_TEXT_V1) {
         if (!rename_long_keys(keymap, &substitutions))
             return false;
     }
     const key_name_substitutions * const substitutions_ptr =
         (darray_empty(substitutions)) ? NULL : &substitutions;
 
+    const xkb_layout_index_t max_groups = format_max_groups(config->format);
+
     bool some_interp = false;
     const bool ok = (
         check_write_buf(buf, "xkb_keymap {\n") &&
-        write_keycodes(keymap, substitutions_ptr, flags, buf) &&
-        write_types(keymap, format, flags, buf) &&
-        write_compat(keymap, format, max_groups, flags, &some_interp, buf) &&
-        write_symbols(keymap, format, substitutions_ptr, max_groups,
-                      flags, some_interp, buf) &&
+        write_keycodes(keymap, substitutions_ptr, config->flags, buf) &&
+        write_types(keymap, config->format, config->flags, buf) &&
+        write_compat(keymap, config->format, max_groups, config->flags,
+                     &some_interp, buf) &&
+        write_symbols(keymap, config, substitutions_ptr, max_groups,
+                      some_interp, buf) &&
         check_write_buf(buf, "};\n")
     );
 
     darray_free(substitutions);
-    return ok;
+    return ok ? XKB_SUCCESS : -1;
 }
 
-char *
-text_v1_keymap_get_as_string(struct xkb_keymap *keymap,
-                             enum xkb_keymap_format format,
-                             enum xkb_keymap_serialize_flags flags)
+enum xkb_error_code
+text_v1_keymap_serialize(
+        const struct xkb_keymap *keymap,
+        const struct xkb_keymap_serialize_config *config,
+        struct xkb_keymap_serialize_result *result
+)
 {
     struct buf buf = { NULL, 0, 0 };
 
-    if (!write_keymap(keymap, format, flags, &buf)) {
+    const enum xkb_error_code error =
+        write_keymap(keymap, config, &buf, result);
+    if (error != XKB_SUCCESS) {
         free(buf.buf);
-        return NULL;
+        result->serialized = NULL;
+        return error;
     }
 
-    return buf.buf;
+    result->serialized = buf.buf;
+    result->length = buf.size + 1;
+    result->layouts = config->layouts;
+
+    return XKB_SUCCESS;
 }

--- a/src/xkbcomp/xkbcomp-priv.h
+++ b/src/xkbcomp/xkbcomp-priv.h
@@ -127,10 +127,12 @@ struct xkb_keymap_info {
     pending_computation_array *pending_computations;
 };
 
-char *
-text_v1_keymap_get_as_string(struct xkb_keymap *keymap,
-                             enum xkb_keymap_format format,
-                             enum xkb_keymap_serialize_flags flags);
+enum xkb_error_code
+text_v1_keymap_serialize(
+        const struct xkb_keymap *keymap,
+        const struct xkb_keymap_serialize_config *config,
+        struct xkb_keymap_serialize_result *result
+);
 
 XkbFile *
 XkbParseFile(struct xkb_context *ctx,

--- a/src/xkbcomp/xkbcomp.c
+++ b/src/xkbcomp/xkbcomp.c
@@ -246,5 +246,5 @@ const struct xkb_keymap_format_ops text_v1_keymap_format_ops = {
     .keymap_new_from_names = text_v1_keymap_new_from_names,
     .keymap_new_from_string = text_v1_keymap_new_from_string,
     .keymap_new_from_file = text_v1_keymap_new_from_file,
-    .keymap_get_as_string = text_v1_keymap_get_as_string,
+    .keymap_serialize = text_v1_keymap_serialize,
 };

--- a/test/data/keymaps/extended-layout-indices-v1.xkb
+++ b/test/data/keymaps/extended-layout-indices-v1.xkb
@@ -29,13 +29,28 @@ xkb_symbols {
 	name[1]="G1";
 
 	key <a>                  {
-		symbols[1]= [               a ],
-		symbols[2]= [               a ],
-		symbols[3]= [               a ],
-		symbols[4]= [               a ]
+		type[1]= "ONE_LEVEL",
+		type[2]= "ONE_LEVEL",
+		type[3]= "ONE_LEVEL",
+		type[4]= "ONE_LEVEL",
+		repeat= No,
+		virtualMods= none,
+		symbols[1]= [                              a ],
+		actions[1]= [ LockControls(controls=none,affect=neither) ],
+		symbols[2]= [                              a ],
+		actions[2]= [ LockControls(controls=none,affect=neither) ],
+		symbols[3]= [                              a ],
+		actions[3]= [ LockControls(controls=none,affect=neither) ],
+		symbols[4]= [                              a ],
+		actions[4]= [ LockControls(controls=none,affect=neither) ]
 	};
 	key <b>                  {
+		type[1]= "ONE_LEVEL",
+		type[2]= "ONE_LEVEL",
+		type[3]= "ONE_LEVEL",
+		type[4]= "ONE_LEVEL",
 		repeat= No,
+		virtualMods= none,
 		symbols[1]= [                       NoSymbol ],
 		actions[1]= [ LockControls(controls=none,affect=neither) ],
 		symbols[2]= [                       NoSymbol ],
@@ -46,10 +61,20 @@ xkb_symbols {
 		actions[4]= [ LockControls(controls=none,affect=neither) ]
 	};
 	key <c>                  {
-		symbols[1]= [               1 ],
-		symbols[2]= [               2 ],
-		symbols[3]= [               3 ],
-		symbols[4]= [               4 ]
+		type[1]= "ONE_LEVEL",
+		type[2]= "ONE_LEVEL",
+		type[3]= "ONE_LEVEL",
+		type[4]= "ONE_LEVEL",
+		repeat= Yes,
+		virtualMods= none,
+		symbols[1]= [                              1 ],
+		actions[1]= [                     NoAction() ],
+		symbols[2]= [                              2 ],
+		actions[2]= [                     NoAction() ],
+		symbols[3]= [                              3 ],
+		actions[3]= [                     NoAction() ],
+		symbols[4]= [                              4 ],
+		actions[4]= [                     NoAction() ]
 	};
 };
 

--- a/test/data/keymaps/serialize-layouts-subset-2,3,4,5.xkb
+++ b/test/data/keymaps/serialize-layouts-subset-2,3,4,5.xkb
@@ -1,0 +1,77 @@
+xkb_keymap {
+xkb_keycodes {
+	minimum = 8;
+	maximum = 255;
+	<LALT>               = 64;
+	<RALT>               = 108;
+};
+
+xkb_types {
+	virtual_modifiers Alt=Mod1,LevelThree=Mod5;
+
+	type "ONE_LEVEL" {
+		modifiers= none;
+	};
+};
+
+xkb_compatibility {
+	virtual_modifiers Alt=Mod1,LevelThree=Mod5;
+
+	interpret.useModMapMods= AnyLevel;
+	interpret.repeat= False;
+	interpret Alt_L+AnyOf(all) {
+		virtualModifier= Alt;
+		action= SetMods(modifiers=modMapMods,clearLocks);
+	};
+	interpret ISO_Level3_Shift+AnyOf(all) {
+		virtualModifier= LevelThree;
+		useModMapMods=level1;
+		action= SetMods(modifiers=LevelThree,clearLocks);
+	};
+};
+
+xkb_symbols {
+	name[1]="2";
+	name[2]="3";
+	name[3]="4";
+	name[4]="5";
+
+	key <LALT>               {
+		type[1]= "ONE_LEVEL",
+		type[2]= "ONE_LEVEL",
+		type[3]= "ONE_LEVEL",
+		type[4]= "ONE_LEVEL",
+		repeat= No,
+		virtualMods= Alt,
+		groupsRedirect= 1,
+		symbols[1]= [                          Alt_L ],
+		actions[1]= [ SetMods(modifiers=modMapMods,clearLocks) ],
+		symbols[2]= [               ISO_Level3_Shift ],
+		actions[2]= [ SetMods(modifiers=LevelThree,clearLocks) ],
+		symbols[3]= [                              a ],
+		actions[3]= [                     NoAction() ],
+		symbols[4]= [                          Alt_L ],
+		actions[4]= [ SetMods(modifiers=modMapMods,clearLocks) ]
+	};
+	key <RALT>               {
+		type[1]= "ONE_LEVEL",
+		type[2]= "ONE_LEVEL",
+		type[3]= "ONE_LEVEL",
+		type[4]= "ONE_LEVEL",
+		repeat= No,
+		virtualMods= LevelThree,
+		groupsRedirect= 1,
+		symbols[1]= [               ISO_Level3_Shift ],
+		actions[1]= [ SetMods(modifiers=LevelThree,clearLocks) ],
+		symbols[2]= [                              c ],
+		actions[2]= [                     NoAction() ],
+		symbols[3]= [               ISO_Level3_Shift ],
+		actions[3]= [ SetMods(modifiers=LevelThree,clearLocks) ],
+		symbols[4]= [                              d ],
+		actions[4]= [                     NoAction() ]
+	};
+	modifier_map Mod1 { <LALT> };
+	modifier_map Mod5 { <RALT> };
+};
+
+};

--- a/test/data/keymaps/serialize-layouts-subset-3,4,5.xkb
+++ b/test/data/keymaps/serialize-layouts-subset-3,4,5.xkb
@@ -1,0 +1,70 @@
+xkb_keymap {
+xkb_keycodes {
+	minimum = 8;
+	maximum = 255;
+	<LALT>               = 64;
+	<RALT>               = 108;
+};
+
+xkb_types {
+	virtual_modifiers Alt=Mod1,LevelThree=Mod5;
+
+	type "ONE_LEVEL" {
+		modifiers= none;
+	};
+};
+
+xkb_compatibility {
+	virtual_modifiers Alt=Mod1,LevelThree=Mod5;
+
+	interpret.useModMapMods= AnyLevel;
+	interpret.repeat= False;
+	interpret Alt_L+AnyOf(all) {
+		virtualModifier= Alt;
+		action= SetMods(modifiers=modMapMods,clearLocks);
+	};
+	interpret ISO_Level3_Shift+AnyOf(all) {
+		virtualModifier= LevelThree;
+		useModMapMods=level1;
+		action= SetMods(modifiers=LevelThree,clearLocks);
+	};
+};
+
+xkb_symbols {
+	name[1]="3";
+	name[2]="4";
+	name[3]="5";
+
+	key <LALT>               {
+		type[1]= "ONE_LEVEL",
+		type[2]= "ONE_LEVEL",
+		type[3]= "ONE_LEVEL",
+		repeat= No,
+		virtualMods= Alt,
+		groupsRedirect= 1,
+		symbols[1]= [               ISO_Level3_Shift ],
+		actions[1]= [ SetMods(modifiers=LevelThree,clearLocks) ],
+		symbols[2]= [                              a ],
+		actions[2]= [                     NoAction() ],
+		symbols[3]= [                          Alt_L ],
+		actions[3]= [ SetMods(modifiers=modMapMods,clearLocks) ]
+	};
+	key <RALT>               {
+		type[1]= "ONE_LEVEL",
+		type[2]= "ONE_LEVEL",
+		type[3]= "ONE_LEVEL",
+		repeat= No,
+		virtualMods= LevelThree,
+		groupsRedirect= 1,
+		symbols[1]= [                              c ],
+		actions[1]= [                     NoAction() ],
+		symbols[2]= [               ISO_Level3_Shift ],
+		actions[2]= [ SetMods(modifiers=LevelThree,clearLocks) ],
+		symbols[3]= [                              d ],
+		actions[3]= [                     NoAction() ]
+	};
+	modifier_map Mod1 { <LALT> };
+	modifier_map Mod5 { <RALT> };
+};
+
+};

--- a/test/data/keymaps/serialize-layouts-subset-6.xkb
+++ b/test/data/keymaps/serialize-layouts-subset-6.xkb
@@ -1,0 +1,56 @@
+xkb_keymap {
+xkb_keycodes {
+	minimum = 8;
+	maximum = 255;
+	<LALT>               = 64;
+	<RALT>               = 108;
+};
+
+xkb_types {
+	virtual_modifiers Alt=Mod1,LevelThree=Mod5;
+
+	type "ONE_LEVEL" {
+		modifiers= none;
+	};
+};
+
+xkb_compatibility {
+	virtual_modifiers Alt=Mod1,LevelThree=Mod5;
+
+	interpret.useModMapMods= AnyLevel;
+	interpret.repeat= False;
+	interpret Alt_L+AnyOf(all) {
+		virtualModifier= Alt;
+		action= SetMods(modifiers=modMapMods,clearLocks);
+	};
+	interpret ISO_Level3_Shift+AnyOf(all) {
+		virtualModifier= LevelThree;
+		useModMapMods=level1;
+		action= SetMods(modifiers=LevelThree,clearLocks);
+	};
+};
+
+xkb_symbols {
+	name[1]="6";
+
+	key <LALT>               {
+		type[1]= "ONE_LEVEL",
+		repeat= No,
+		virtualMods= Alt,
+		groupsRedirect= 1,
+		symbols[1]= [                              b ],
+		actions[1]= [                     NoAction() ]
+	};
+	key <RALT>               {
+		type[1]= "ONE_LEVEL",
+		repeat= No,
+		virtualMods= LevelThree,
+		groupsRedirect= 1,
+		symbols[1]= [                              e ],
+		actions[1]= [                     NoAction() ]
+	};
+	modifier_map Mod1 { <LALT> };
+	modifier_map Mod5 { <RALT> };
+};
+
+};

--- a/test/data/keymaps/serialize-layouts-subset-all.xkb
+++ b/test/data/keymaps/serialize-layouts-subset-all.xkb
@@ -1,0 +1,63 @@
+xkb_keymap {
+xkb_keycodes {
+	minimum = 8;
+	maximum = 255;
+	<LALT>               = 64;
+	<RALT>               = 108;
+};
+
+xkb_types {
+	virtual_modifiers Alt=Mod1,LevelThree=Mod5;
+
+	type "ONE_LEVEL" {
+		modifiers= none;
+	};
+};
+
+xkb_compatibility {
+	virtual_modifiers Alt=Mod1,LevelThree=Mod5;
+
+	interpret.useModMapMods= AnyLevel;
+	interpret.repeat= False;
+	interpret Alt_L+AnyOf(all) {
+		virtualModifier= Alt;
+		action= SetMods(modifiers=modMapMods,clearLocks);
+	};
+	interpret ISO_Level3_Shift+AnyOf(all) {
+		virtualModifier= LevelThree;
+		useModMapMods=level1;
+		action= SetMods(modifiers=LevelThree,clearLocks);
+	};
+};
+
+xkb_symbols {
+	name[1]="1";
+	name[2]="2";
+	name[3]="3";
+	name[4]="4";
+	name[5]="5";
+	name[6]="6";
+
+	key <LALT>               {
+		groupsRedirect= 1,
+		symbols[1]= [           Alt_L ],
+		symbols[2]= [           Alt_L ],
+		symbols[3]= [ ISO_Level3_Shift ],
+		symbols[4]= [               a ],
+		symbols[5]= [           Alt_L ],
+		symbols[6]= [               b ]
+	};
+	key <RALT>               {
+		groupsRedirect= 2,
+		symbols[1]= [ ISO_Level3_Shift ],
+		symbols[2]= [ ISO_Level3_Shift ],
+		symbols[3]= [               c ],
+		symbols[4]= [ ISO_Level3_Shift ],
+		symbols[5]= [               d ],
+		symbols[6]= [               e ]
+	};
+	modifier_map Mod1 { <LALT> };
+	modifier_map Mod5 { <RALT> };
+};
+
+};

--- a/test/keymap.c
+++ b/test/keymap.c
@@ -11,6 +11,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "xkbcommon/xkbcommon.h"
 #include "xkbcommon/xkbcommon-keysyms.h"
@@ -23,6 +24,8 @@
 
 #define KEY_LVL3 84
 #define KEY_LVL5 195
+
+#define GOLDEN_TESTS_OUTPUTS "keymaps/"
 
 static void
 test_supported_formats(void)
@@ -893,10 +896,155 @@ test_issue_934(void)
     xkb_context_unref(context);
 }
 
+static void
+test_serialize_layouts_subset(bool update_output_files)
+{
+    struct xkb_context *context = test_get_context(CONTEXT_NO_FLAG);
+    assert(context);
+
+    /*
+     * This keymap is used to test that vmods remains unchanged, independently
+     * of the subset of layouts.
+     */
+    static const char keymap_str[] =
+        "xkb_keymap {\n"
+        "  xkb_keycodes { <LALT> = 64; <RALT> = 108; };\n"
+        "  xkb_compat {\n"
+        "    virtual_modifiers  Alt, LevelThree;\n"
+        "    interpret.repeat= False;\n"
+        "    setMods.clearLocks= True;\n"
+        "    interpret Alt_L+Any {\n"
+        "      virtualModifier= Alt;\n"
+        "      action = SetMods(modifiers=modMapMods);\n"
+        "    };\n"
+        "    interpret ISO_Level3_Shift+Any {\n"
+        "      useModMapMods= level1;\n"
+        "      virtualModifier= LevelThree;\n"
+        "      action= SetMods(modifiers=LevelThree);\n"
+        "    };\n"
+        "  };\n"
+        "  xkb_symbols {\n"
+        "    name[1] = \"1\";\n"
+        "    name[2] = \"2\";\n"
+        "    name[3] = \"3\";\n"
+        "    name[4] = \"4\";\n"
+        "    name[5] = \"5\";\n"
+        "    name[6] = \"6\";\n"
+        "    key <LALT> {\n"
+        "      groupsRedirect = 1,\n"
+        "      symbols[1] = [Alt_L],\n"
+        "      symbols[3] = [ISO_Level3_Shift],\n"
+        "      symbols[4] = [a],\n"
+        "      symbols[5] = [Alt_L],\n"
+        "      symbols[6] = [b]\n"
+        "    };\n"
+        "    key <RALT> {\n"
+        "      groupsRedirect = 2,\n"
+        "      symbols[1] = [ISO_Level3_Shift],\n"
+        "      symbols[3] = [c],\n"
+        "      symbols[4] = [ISO_Level3_Shift],\n"
+        "      symbols[5] = [d],\n"
+        "      symbols[6] = [e]\n"
+        "    };\n"
+        "    modifier_map Mod1 { <LALT> };\n"
+        "    modifier_map Mod5 { ISO_Level3_Shift };\n"
+        "  };\n"
+        "};";
+
+    struct xkb_keymap * const keymap = xkb_keymap_new_from_buffer(
+        context, keymap_str, sizeof(keymap_str),
+        XKB_KEYMAP_FORMAT_TEXT_V2, XKB_KEYMAP_COMPILE_NO_FLAGS
+    );
+    assert(keymap);
+
+    static const struct {
+        xkb_layout_mask_t layouts;
+        const char* expected;
+    } tests[] = {
+        {
+            .layouts = 0x3f,
+            .expected = GOLDEN_TESTS_OUTPUTS "serialize-layouts-subset-all.xkb"
+        },
+        {
+            .layouts = 0x1e,
+            .expected = GOLDEN_TESTS_OUTPUTS "serialize-layouts-subset-2,3,4,5.xkb"
+        },
+        {
+            .layouts = 0x1c,
+            .expected = GOLDEN_TESTS_OUTPUTS "serialize-layouts-subset-3,4,5.xkb"
+        },
+        {
+            .layouts = 0x20,
+            .expected = GOLDEN_TESTS_OUTPUTS "serialize-layouts-subset-6.xkb"
+        },
+    };
+
+    for (size_t t = 0; t < ARRAY_SIZE(tests); t++) {
+        fprintf(stderr, "------\n*** %s: #%zu ***\n", __func__, t);
+        const struct xkb_keymap_serialize_config config = {
+            .size = sizeof(config),
+            .format = XKB_KEYMAP_FORMAT_TEXT_V2,
+            .flags = TEST_KEYMAP_SERIALIZE_FLAGS |
+                     XKB_KEYMAP_SERIALIZE_EXPLICIT_VMODS,
+            .layouts = tests[t].layouts,
+        };
+        struct xkb_keymap_serialize_result result = { .size = sizeof(result) };
+        const enum xkb_error_code ret =
+            xkb_keymap_serialize(keymap, &config, &result);
+        assert(ret ^ !!result.serialized);
+        assert(ret ^ !!tests[t].expected);
+        assert(!!result.serialized == !!tests[t].expected);
+        assert_eq("layout mask", tests[t].layouts, result.layouts, "%"PRIx32);
+
+        char* const path = test_get_path(tests[t].expected);
+        assert(path);
+        if (tests[t].expected) {
+            assert(result.length == strlen(result.serialized) + 1);
+            if (update_output_files) {
+                fprintf(stderr, "Writing golden test output to: %s\n", path);
+                FILE *file = fopen(path, "wb");
+                assert(file);
+                fwrite(result.serialized, sizeof(*result.serialized),
+                       result.length - 1, file);
+                fclose(file);
+            } else {
+                fprintf(stderr, "Reading golden test output: %s\n", path);
+                char* const expected = test_read_file(tests[t].expected);
+                assert(expected);
+                if (!streq(expected, result.serialized)) {
+                    fprintf(stderr,
+                            "Failure: dumped map differs from expected.\n"
+                            "Path to expected file: %s\n"
+                            "Length: expected %zu, got: %zu\n"
+                            "Dumped map:\n%s\n",
+                            path, strlen(expected),
+                            result.length, result.serialized);
+                    assert(false);
+                }
+                free(expected);
+            }
+        }
+        free(path);
+        free(result.serialized);
+    }
+
+    xkb_keymap_unref(keymap);
+    xkb_context_unref(context);
+}
+
 int
-main(void)
+main(int argc, char *argv[])
 {
     test_init();
+
+    bool update_output_files = false;
+    int arg_index = 0;
+    while (++arg_index < argc) {
+        if (streq(argv[arg_index], "update")) {
+            /* Update files with *obtained* results */
+            update_output_files = true;
+        }
+    }
 
     test_supported_formats();
     test_garbage_key();
@@ -908,6 +1056,7 @@ main(void)
     test_keynames_atoms();
     test_key_iterator();
     test_issue_934();
+    test_serialize_layouts_subset(update_output_files);
 
     return EXIT_SUCCESS;
 }

--- a/test/tool-option-parsing.py
+++ b/test/tool-option-parsing.py
@@ -409,6 +409,7 @@ class TestXkbcli(unittest.TestCase):
             ["--explicit-vmods", "-h"],
             ["--explicit-keys", "-h"],
             ["--explicit-values", "-h"],
+            ["--layouts-mask", "0x1", "-h"],
         ):
             with self.subTest(args=args):
                 self.xkbcli_compile_keymap.run_command_success(args)

--- a/tools/compile-keymap.c
+++ b/tools/compile-keymap.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "xkbcommon/xkbcommon-errors.h"
 #include "xkbcommon/xkbcommon.h"
 #include "tools-common.h"
 #include "src/utils.h"
@@ -115,6 +116,8 @@ usage(FILE *file, const char *progname)
            "    Force serializing key values\n"
            " --explicit-values\n"
            "    Force serializing all values\n"
+           " --layouts-mask\n"
+           "    Hexadecimal mask of the layouts indices to select for serializing\n"
            " --kccgst\n"
            "    Print a keymap which only includes the KcCGST component names instead of the full keymap\n"
            " --kccgst-yaml\n"
@@ -152,6 +155,7 @@ parse_options(int argc, char **argv,
               enum xkb_keymap_format *keymap_output_format,
               enum xkb_keymap_compile_flags *compile_flags,
               enum xkb_keymap_serialize_flags *serialize_flags,
+              xkb_layout_mask_t *layout_mask,
               bool *use_env_names,
               char **path, struct xkb_rule_names *names)
 {
@@ -184,6 +188,7 @@ parse_options(int argc, char **argv,
         OPT_KEYMAP_EXPLICIT_VMODS,
         OPT_KEYMAP_EXPLICIT_KEYS,
         OPT_KEYMAP_EXPLICIT,
+        OPT_KEYMAP_LAYOUTS,
         OPT_KCCGST,
         OPT_KCCGST_YAML,
         OPT_RMLVO,
@@ -225,6 +230,7 @@ parse_options(int argc, char **argv,
         {"explicit-vmods",   no_argument,            0, OPT_KEYMAP_EXPLICIT_VMODS},
         {"explicit-keys",    no_argument,            0, OPT_KEYMAP_EXPLICIT_KEYS},
         {"explicit-values",  no_argument,            0, OPT_KEYMAP_EXPLICIT},
+        {"layouts-mask",     required_argument,      0, OPT_KEYMAP_LAYOUTS},
         {"kccgst",           no_argument,            0, OPT_KCCGST},
         {"kccgst-yaml",      no_argument,            0, OPT_KCCGST_YAML},
         {"rmlvo",            no_argument,            0, OPT_RMLVO},
@@ -341,6 +347,13 @@ parse_options(int argc, char **argv,
                               | XKB_KEYMAP_SERIALIZE_EXPLICIT_VMODS
                               | XKB_KEYMAP_SERIALIZE_EXPLICIT_KEY_VALUES;
             break;
+        case OPT_KEYMAP_LAYOUTS: {
+            uint32_t mask = 0;
+            if (!tools_parse_mask(optarg, TOOLS_ARG_REQUIRED, &mask))
+                goto invalid_usage;
+            *layout_mask = mask;
+            break;
+        }
         case OPT_RULES:
             if (input_format == INPUT_FORMAT_KEYMAP)
                 goto input_format_error;
@@ -576,8 +589,7 @@ print_keymap(struct xkb_context *ctx,
              enum xkb_keymap_compile_flags compile_flags,
              enum input_format format,
              const struct xkb_rule_names *rmlvo, const char *path,
-             enum xkb_keymap_format keymap_output_format,
-             enum xkb_keymap_serialize_flags serialize_flags)
+             const struct xkb_keymap_serialize_config *config)
 {
     int ret = EXIT_SUCCESS;
     struct xkb_keymap *keymap = load_keymap(ctx, keymap_input_format,
@@ -589,15 +601,15 @@ print_keymap(struct xkb_context *ctx,
     } else if (test) {
         fprintf(stderr, "%s\n", success_text);
     } else {
-        char* keymap_string = xkb_keymap_get_as_string2(
-            keymap, keymap_output_format, serialize_flags
-        );
-        if (!keymap_string) {
-            fprintf(stderr, "ERROR: Couldn't get the keymap string\n");
+        struct xkb_keymap_serialize_result result = { .size = sizeof(result) };
+        const enum xkb_error_code error =
+            xkb_keymap_serialize(keymap, config, &result);
+        if (error != XKB_SUCCESS) {
+            fprintf(stderr, "ERROR %d: Couldn't get the keymap string\n", error);
             ret = EXIT_FAILURE;
         } else {
-            fputs(keymap_string, stdout);
-            free(keymap_string);
+            fputs(result.serialized, stdout);
+            free(result.serialized);
         }
     }
     xkb_keymap_unref(keymap);
@@ -643,6 +655,7 @@ main(int argc, char **argv)
         (enum xkb_keymap_compile_flags) DEFAULT_KEYMAP_COMPILE_FLAGS;
     enum xkb_keymap_serialize_flags serialize_flags =
         (enum xkb_keymap_serialize_flags) DEFAULT_KEYMAP_SERIALIZE_FLAGS;
+    xkb_layout_mask_t layout_mask = 0; /* all layouts by default */
 
     setlocale(LC_ALL, "");
 
@@ -655,8 +668,8 @@ main(int argc, char **argv)
     enum output_format output_format = OUTPUT_FORMAT_KEYMAP;
     if (!parse_options(argc, argv, &input_format, &output_format,
                        &keymap_input_format, &keymap_output_format,
-                       &compile_flags, &serialize_flags, &use_env_names,
-                       &keymap_path, &names))
+                       &compile_flags, &serialize_flags, &layout_mask,
+                       &use_env_names, &keymap_path, &names))
         return EXIT_INVALID_USAGE;
 
     enum xkb_context_flags ctx_flags = XKB_CONTEXT_NO_DEFAULT_INCLUDES;
@@ -701,10 +714,16 @@ main(int argc, char **argv)
         rc = print_modmaps(ctx, keymap_input_format,
                            compile_flags, input_format, &names, keymap_path);
         break;
-    default:
+    default: {
+        struct xkb_keymap_serialize_config config = {
+            .size = sizeof(config),
+            .flags = serialize_flags,
+            .format = keymap_output_format,
+            .layouts = layout_mask,
+        };
         rc = print_keymap(ctx, keymap_input_format, compile_flags, input_format,
-                          &names, keymap_path,
-                          keymap_output_format, serialize_flags);
+                          &names, keymap_path, &config);
+    }
     }
 
     xkb_context_unref(ctx);

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -966,6 +966,32 @@ tools_parse_bool(const char *s, enum tools_arg_optionality optional, bool *out)
     }
 }
 
+bool
+tools_parse_mask(const char *s, enum tools_arg_optionality optional, uint32_t *out)
+{
+    #define HEX_PREFIX "0x"
+    if (isempty(s)) {
+        if (optional == TOOLS_ARG_REQUIRED) {
+            fprintf(stderr, "ERROR: mask value is required, but got none\n");
+            return false;
+        } else {
+            /* Keep value unchanged */
+            return true;
+        }
+    } else if (strncmp(s, HEX_PREFIX, sizeof(HEX_PREFIX) - 1) == 0) {
+        const int count =
+            parse_hex_to_uint32_t(s + sizeof(HEX_PREFIX) - 1, SIZE_MAX, out);
+        const size_t expected = strlen(s) - (sizeof(HEX_PREFIX) - 1);
+        if (count == (int)expected) {
+            return true;
+        }
+    }
+
+    fprintf(stderr, "ERROR: invalid mask value: \"%s\"\n", s);
+    return false;
+    #undef HEX_PREFIX
+}
+
 static void
 xkb_raw_modifiers_free(struct xkb_raw_mod_mask *raw_mods)
 {

--- a/tools/tools-common.h
+++ b/tools/tools-common.h
@@ -106,6 +106,9 @@ enum tools_arg_optionality {
 bool
 tools_parse_bool(const char *s, enum tools_arg_optionality optional, bool *out);
 
+bool
+tools_parse_mask(const char *s, enum tools_arg_optionality optional, uint32_t *out);
+
 /** Raw modifier masks: plus-separated list of modifier names */
 struct xkb_raw_mod_mask {
     darray_char names;

--- a/tools/xkbcli-compile-keymap.1
+++ b/tools/xkbcli-compile-keymap.1
@@ -98,6 +98,9 @@ Force serializing keys values.
 .It Fl \-explicit\-values
 Force serializing all values.
 .
+.It Fl \-layouts\-mask
+Hexadecimal mask of the layouts indices to select for serializing.
+.
 .It Fl \-keymap Oo Ar PATH Oc , Fl \-from\-xkb Oo Ar PATH Oc
 Load the XKB keymap from a file, ignore RMLVO options. If
 .Ar PATH

--- a/tools/xkbcli-zsh-completion.zsh
+++ b/tools/xkbcli-zsh-completion.zsh
@@ -198,6 +198,7 @@ _xkbcli-compile-keymap() {
 		'--explicit-vmods[force serializing virtual modifiers encodings]' \
 		'--explicit-keys[force serializing keys values]' \
 		'--explicit-values[force serializing all values]' \
+		'--layouts-mask[Hexadecimal mask of the layouts indices to select for serializing]:' \
 		'(--kccgst-yaml --rmlvo --modmaps)--kccgst[print a keymap in KcCGST format]' \
 		'(--kccgst      --rmlvo --modmaps)--kccgst-yaml[print a KcCGST keymap in YAML format]' \
 		'(--kccgst-yaml         --modmaps)--rmlvo[print the full RMLVO in YAML format]' \

--- a/xkbcommon.map
+++ b/xkbcommon.map
@@ -154,6 +154,7 @@ global:
     xkb_keymap_key_iterator_new;
     xkb_keymap_key_iterator_destroy;
     xkb_keymap_key_iterator_next;
+    xkb_keymap_serialize;
     xkb_state_new_with_mode;
     xkb_state_update_event;
     xkb_state_update_synthetic;


### PR DESCRIPTION
Enable to have more control over serializing or its result than `xkb_keymap_get_as_string()` or `xkb_keymap_get_as_string2()`. In particular, it allows to choose which layouts are serialized.

Added:
- `xkb_keymap_serialize()`
- `struct xkb_keymap_serialize_config`
- `struct xkb_keymap_serialize_result`

---

TODO:
- [x] tests
- [x] split commits?
