### PR TITLE
tools: Add --version

### DIFF
--- a/changes/tools/+version.feature.md
+++ b/changes/tools/+version.feature.md
@@ -1,0 +1,1 @@
+Added `--version` to all tools.

--- a/tools/compile-compose.c
+++ b/tools/compile-compose.c
@@ -20,7 +20,7 @@ static void
 usage(FILE *fp, char *progname)
 {
     fprintf(fp,
-            "Usage: %s [--help] [--verbose] [--locale LOCALE] [--test] [FILE]\n",
+            "Usage: %s [--help] [--version] [--verbose] [--locale LOCALE] [--test] [FILE]\n",
             progname);
     fprintf(fp,
             "\n"
@@ -29,6 +29,8 @@ usage(FILE *fp, char *progname)
             "Options:\n"
             " --help\n"
             "    Print this help and exit\n"
+            " --version\n"
+            "    Print version information and exit\n"
             " --verbose\n"
             "    Enable verbose debugging output\n"
             " --file FILE\n"
@@ -57,6 +59,7 @@ main(int argc, char *argv[])
     };
     static struct option opts[] = {
         {"help",    no_argument,       0, 'h'},
+        {"version", no_argument,       0, 'V'},
         {"verbose", no_argument,       0, OPT_VERBOSE},
         {"file",    required_argument, 0, OPT_FILE},
         {"locale",  required_argument, 0, OPT_LOCALE},
@@ -75,7 +78,7 @@ main(int argc, char *argv[])
         int opt;
         int option_index = 0;
 
-        opt = getopt_long(argc, argv, "h", opts, &option_index);
+        opt = getopt_long(argc, argv, "hV", opts, &option_index);
         if (opt == -1)
             break;
 
@@ -96,6 +99,9 @@ main(int argc, char *argv[])
         case 'h':
             usage(stdout, argv[0]);
             return EXIT_SUCCESS;
+        case 'V':
+            printf("%s\n", LIBXKBCOMMON_VERSION);
+            exit(EXIT_SUCCESS);
         default:
             usage(stderr, argv[0]);
             return EXIT_INVALID_USAGE;

--- a/tools/compile-keymap.c
+++ b/tools/compile-keymap.c
@@ -50,6 +50,8 @@ usage(FILE *file, const char *progname)
            "General options:\n"
            " --help\n"
            "    Print this help and exit\n"
+           " --version\n"
+           "    Print version information and exit\n"
            " --verbose\n"
            "    Enable verbose debugging output\n"
            " --test\n"
@@ -199,6 +201,7 @@ parse_options(int argc, char **argv,
          * General
          */
         {"help",             no_argument,            0, 'h'},
+        {"version",          no_argument,            0, 'V'},
         {"verbose",          no_argument,            0, OPT_VERBOSE},
         {"test",             no_argument,            0, OPT_TEST},
         /*
@@ -242,7 +245,7 @@ parse_options(int argc, char **argv,
     int option_index = 0;
     while (1) {
         option_index = 0;
-        int c = getopt_long(argc, argv, "h", opts, &option_index);
+        int c = getopt_long(argc, argv, "hV", opts, &option_index);
         if (c == -1)
             break;
 
@@ -250,7 +253,10 @@ parse_options(int argc, char **argv,
         /* General */
         case 'h':
             usage(stdout, argv[0]);
-            exit(0);
+            exit(EXIT_SUCCESS);
+        case 'V':
+            printf("%s\n", LIBXKBCOMMON_VERSION);
+            exit(EXIT_SUCCESS);
         case OPT_VERBOSE:
             verbose = true;
             break;

--- a/tools/how-to-type.c
+++ b/tools/how-to-type.c
@@ -71,7 +71,7 @@ parse_char_or_codepoint(const char *raw) {
 static void
 usage(FILE *fp, const char *argv0)
 {
-    fprintf(fp, "Usage: %s [--help] [--verbose] [--keysym] [--disable-compose] "
+    fprintf(fp, "Usage: %s [--help] [--version] [--verbose] [--keysym] [--disable-compose] "
                 "[--rules <rules>] [--model <model>] "
                 "[--layout <layout>] [--variant <variant>] "
                 "[--options <options>] [--enable-environment-names] "
@@ -95,6 +95,8 @@ usage(FILE *fp, const char *argv0)
         "Options:\n"
         " --help\n"
         "    Print this help and exit\n"
+        " --version\n"
+        "    Print version information and exit\n"
         " --verbose\n"
         "    Enable verbose debugging output\n"
         " --keysym\n"
@@ -163,6 +165,7 @@ parse_options(int argc, char **argv, bool *verbose,
     };
     static struct option opts[] = {
         {"help",                 no_argument,            0, 'h'},
+        {"version",              no_argument,            0, 'V'},
         {"verbose",              no_argument,            0, OPT_VERBOSE},
         {"keysym",               no_argument,            0, OPT_KEYSYM},
         {"disable-compose",      no_argument,            0, OPT_DISABLE_COMPOSE},
@@ -181,7 +184,7 @@ parse_options(int argc, char **argv, bool *verbose,
         int opt;
         int option_index = 0;
 
-        opt = getopt_long(argc, argv, "h", opts, &option_index);
+        opt = getopt_long(argc, argv, "hV", opts, &option_index);
         if (opt == -1)
             break;
 
@@ -246,6 +249,9 @@ parse_options(int argc, char **argv, bool *verbose,
             break;
         case 'h':
             usage(stdout, argv[0]);
+            exit(EXIT_SUCCESS);
+        case 'V':
+            printf("%s\n", LIBXKBCOMMON_VERSION);
             exit(EXIT_SUCCESS);
         default:
             goto invalid_usage;

--- a/tools/info.c
+++ b/tools/info.c
@@ -25,16 +25,18 @@ parse_options(int argc, char **argv)
 {
     enum options {
         OPT_HELP = 'h',
+        OPT_VERSION = 'V',
     };
 
     static struct option opts[] = {
         {"help",                 no_argument,            0, OPT_HELP},
+        {"version",              no_argument,            0, OPT_VERSION},
         {0, 0, 0, 0},
     };
 
     while (1) {
         int option_index = 0;
-        int opt = getopt_long(argc, argv, "h", opts, &option_index);
+        int opt = getopt_long(argc, argv, "hV", opts, &option_index);
 
         if (opt == -1)
             break;
@@ -42,6 +44,9 @@ parse_options(int argc, char **argv)
         switch (opt) {
         case OPT_HELP:
             usage(stdout, argv[0]);
+            exit(EXIT_SUCCESS);
+        case OPT_VERSION:
+            printf("%s\n", LIBXKBCOMMON_VERSION);
             exit(EXIT_SUCCESS);
         default:
 // invalid_usage:

--- a/tools/interactive-evdev.c
+++ b/tools/interactive-evdev.c
@@ -468,8 +468,10 @@ usage(FILE *fp, char *progname)
             " --without-x11-offset\n"
             "    Don't add X11 keycode offset\n"
             "Other:\n"
-            "    --help\n"
-            "    Display this help and exit\n",
+            " --help\n"
+            "    Display this help and exit\n"
+            " --version\n"
+            "    Print version information and exit\n",
             progname, progname,
             xkb_keymap_get_format_label(DEFAULT_INPUT_KEYMAP_FORMAT)
     );
@@ -528,6 +530,7 @@ main(int argc, char *argv[])
     };
     static struct option opts[] = {
         {"help",                 no_argument,            0, 'h'},
+        {"version",              no_argument,            0, 'V'},
         {"verbose",              no_argument,            0, OPT_VERBOSE},
         {"uniline",              no_argument,            0, OPT_UNILINE},
         {"multiline",            no_argument,            0, OPT_MULTILINE},
@@ -568,7 +571,7 @@ main(int argc, char *argv[])
 
     while (1) {
         int option_index = 0;
-        int opt = getopt_long(argc, argv, "*1h", opts, &option_index);
+        int opt = getopt_long(argc, argv, "*1hV", opts, &option_index);
         if (opt == -1)
             break;
 
@@ -725,6 +728,10 @@ main(int argc, char *argv[])
             break;
         case 'h':
             usage(stdout, argv[0]);
+            ret = EXIT_SUCCESS;
+            goto error_parse_args;
+        case 'V':
+            printf("%s\n", LIBXKBCOMMON_VERSION);
             ret = EXIT_SUCCESS;
             goto error_parse_args;
         default:

--- a/tools/interactive-wayland.c
+++ b/tools/interactive-wayland.c
@@ -935,7 +935,7 @@ static void
 usage(FILE *fp, char *progname)
 {
         fprintf(fp,
-                "Usage: %s [--help] [--verbose]"
+                "Usage: %s [--help] [--version] [--verbose]"
 #ifdef KEYMAP_DUMP
                 " [--no-pretty] [--drop-unused] [--raw] [--input-format] [--strict]"
                 " [--output-format] [--format] [--no-pretty] [--drop-unused]"
@@ -1001,7 +1001,8 @@ usage(FILE *fp, char *progname)
                 "    --no-state-report  do not report changes to the state\n"
 #endif
                 "    --verbose          enable verbose debugging output\n"
-                "    --help             display this help and exit\n",
+                "    --help             display this help and exit\n"
+                "    --version          print version information and exit\n",
                 xkb_keymap_get_format_label(DEFAULT_INPUT_KEYMAP_FORMAT)
         );
 }
@@ -1045,6 +1046,7 @@ main(int argc, char *argv[])
     };
     static struct option opts[] = {
         {"help",                 no_argument,            0, 'h'},
+        {"version",              no_argument,            0, 'V'},
         {"verbose",              no_argument,            0, OPT_VERBOSE},
         {"strict",               no_argument,            0, OPT_KEYMAP_STRICT_PARSER},
 #ifdef KEYMAP_DUMP
@@ -1084,7 +1086,7 @@ main(int argc, char *argv[])
         int opt;
         int option_index = 0;
 
-        opt = getopt_long(argc, argv, "*1h", opts, &option_index);
+        opt = getopt_long(argc, argv, "*1hV", opts, &option_index);
         if (opt == -1)
             break;
 
@@ -1214,6 +1216,10 @@ local_state:
 #endif
         case 'h':
             usage(stdout, argv[0]);
+            ret = EXIT_SUCCESS;
+            goto error_parse_args;
+        case 'V':
+            printf("%s\n", LIBXKBCOMMON_VERSION);
             ret = EXIT_SUCCESS;
             goto error_parse_args;
         default:

--- a/tools/interactive-x11.c
+++ b/tools/interactive-x11.c
@@ -516,7 +516,7 @@ static void
 usage(FILE *fp, char *progname)
 {
         fprintf(fp,
-                "Usage: %s [--help] [--verbose]"
+                "Usage: %s [--help] [--version] [--verbose]"
 #ifndef KEYMAP_DUMP
                 " [--uniline] [--multiline] [--consumed-mode={xkb|gtk}] [--no-state-report]"
 #endif
@@ -581,7 +581,8 @@ usage(FILE *fp, char *progname)
                 "    --no-state-report    do not report changes to the state\n"
 #endif
                 "    --verbose            enable verbose debugging output\n"
-                "    --help               display this help and exit\n",
+                "    --help               display this help and exit\n"
+                "    --version            print version information and exit\n",
                 xkb_keymap_get_format_label(DEFAULT_INPUT_KEYMAP_FORMAT)
         );
 }
@@ -627,6 +628,7 @@ main(int argc, char *argv[])
     };
     static struct option opts[] = {
         {"help",                 no_argument,            0, 'h'},
+        {"version",              no_argument,            0, 'V'},
         {"verbose",              no_argument,            0, OPT_VERBOSE},
         {"format",               required_argument,      0, OPT_KEYMAP_FORMAT},
         {"strict",               no_argument,            0, OPT_KEYMAP_STRICT_PARSER},
@@ -662,7 +664,7 @@ main(int argc, char *argv[])
         int opt;
         int option_index = 0;
 
-        opt = getopt_long(argc, argv, "*1h", opts, &option_index);
+        opt = getopt_long(argc, argv, "*1hV", opts, &option_index);
         if (opt == -1)
             break;
 
@@ -773,6 +775,10 @@ local_state:
 #endif
         case 'h':
             usage(stdout, argv[0]);
+            ret = EXIT_SUCCESS;
+            goto error_parse_args;
+        case 'V':
+            printf("%s\n", LIBXKBCOMMON_VERSION);
             ret = EXIT_SUCCESS;
             goto error_parse_args;
         default:

--- a/tools/registry-list.c
+++ b/tools/registry-list.c
@@ -25,6 +25,7 @@ usage(const char *progname, FILE *fp)
             "  --skip-default-paths ... Do not load the default XKB paths\n"
             "  --load-exotic .......... Load the exotic (extra) rulesets\n"
             "  --help ................. Print this help and exit\n"
+           "   --version .............. Print version information and exit\n"
             "\n"
             "Trailing arguments are treated as XKB base directory installations.\n",
             progname);
@@ -45,6 +46,7 @@ main(int argc, char **argv)
 
     static const struct option opts[] = {
         {"help",                no_argument,        0, 'h'},
+        {"version",             no_argument,        0, 'V'},
         {"verbose",             no_argument,        0, 'v'},
         {"load-exotic",         no_argument,        0, 'e'},
         {"skip-default-paths",  no_argument,        0, 'd'},
@@ -58,14 +60,14 @@ main(int argc, char **argv)
         int c;
         int option_index = 0;
 
-        c = getopt_long(argc, argv, "hev", opts, &option_index);
+        c = getopt_long(argc, argv, "hedrvV", opts, &option_index);
         if (c == -1)
             break;
 
         switch (c) {
             case 'h':
                 usage(argv[0], stdout);
-                return 0;
+                return EXIT_SUCCESS;
             case 'd':
                 load_defaults = false;
                 break;
@@ -78,6 +80,9 @@ main(int argc, char **argv)
             case 'v':
                 verbosity++;
                 break;
+            case 'V':
+                printf("%s\n", LIBXKBCOMMON_VERSION);
+                exit(EXIT_SUCCESS);
             default:
                 usage(argv[0], stderr);
                 return EXIT_INVALID_USAGE;

--- a/tools/xkbcli-compile-compose.1
+++ b/tools/xkbcli-compile-compose.1
@@ -21,8 +21,11 @@ Path to the compose file to load, or
 .Dq \-
 to read the standard input
 .
-.It Fl \-help
+.It Fl h, \-help
 Print help and exit
+.
+.It Fl V, \-version
+Print version information and exit
 .
 .It Fl \-verbose
 Enable verbose debugging output

--- a/tools/xkbcli-compile-keymap.1
+++ b/tools/xkbcli-compile-keymap.1
@@ -21,8 +21,11 @@ Path to a keymap file, or
 .Dq \-
 to read the standard input
 .
-.It Fl \-help
+.It Fl h, \-help
 Print help and exit
+.
+.It Fl V, \-version
+Print version information and exit
 .
 .It Fl \-verbose
 Enable verbose debugging output

--- a/tools/xkbcli-dump-keymap-wayland.1
+++ b/tools/xkbcli-dump-keymap-wayland.1
@@ -21,8 +21,11 @@ This requires a Wayland compositor to be running.
 This is a debugging tool, its behavior or output is not guaranteed to be stable.
 .
 .Bl -tag -width Ds
-.It Fl \-help
+.It Fl h, \-help
 Print help and exit
+.
+.It Fl V, \-version
+Print version information and exit
 .
 .It Fl \-verbose
 Enable verbose debugging output

--- a/tools/xkbcli-dump-keymap-x11.1
+++ b/tools/xkbcli-dump-keymap-x11.1
@@ -21,8 +21,11 @@ This requires an X server to be running.
 This is a debugging tool, its behavior or output is not guaranteed to be stable.
 .
 .Bl -tag -width Ds
-.It Fl \-help
+.It Fl h, \-help
 Print help and exit
+.
+.It Fl V, \-version
+Print version information and exit
 .
 .It Fl \-verbose
 Enable verbose debugging output.

--- a/tools/xkbcli-how-to-type.1
+++ b/tools/xkbcli-how-to-type.1
@@ -133,8 +133,11 @@ Note that this option may affect the default values of the previous options.
 .It Fl \-verbose
 Enable verbose debugging output
 .
-.It Fl \-help
+.It Fl h, \-help
 Print a help message and exit.
+.
+.It Fl V, \-version
+Print version information and exit
 .El
 .
 .Sh SEE ALSO

--- a/tools/xkbcli-info.1
+++ b/tools/xkbcli-info.1
@@ -14,6 +14,20 @@
 Print information about libxkbcommon configuration.
 The output is in YAML 1.2 format.
 .
+.Bl -tag -width Ds
+.It Ar KEYMAP_PATH
+Path to a keymap file, or
+.Dq \-
+to read the standard input
+.
+.It Fl h, \-help
+Print help and exit
+.
+.It Fl V, \-version
+Print version information and exit
+.
+.El
+.
 .Sh SEE ALSO
 .Xr xkbcli 1 ,
 .Lk https://xkbcommon.org "The libxkbcommon online documentation"

--- a/tools/xkbcli-interactive-evdev.1
+++ b/tools/xkbcli-interactive-evdev.1
@@ -40,8 +40,11 @@ Path to a keymap file, or
 .Dq \-
 to read the standard input
 .
-.It Fl \-help
+.It Fl h, \-help
 Print help and exit
+.
+.It Fl V, \-version
+Print version information and exit
 .
 .It Fl \-verbose
 Enable verbose debugging output

--- a/tools/xkbcli-interactive-wayland.1
+++ b/tools/xkbcli-interactive-wayland.1
@@ -26,8 +26,11 @@ key to exit.
 This is a debugging tool, its behavior or output is not guaranteed to be stable.
 .
 .Bl -tag -width Ds
-.It Fl \-help
+.It Fl h, \-help
 Print help and exit
+.
+.It Fl V, \-version
+Print version information and exit
 .
 .It Fl \-format Ar KEYMAP_FORMAT
 Specify the keymap format (numeric or label, e.g.\&

--- a/tools/xkbcli-interactive-x11.1
+++ b/tools/xkbcli-interactive-x11.1
@@ -26,8 +26,11 @@ key to exit.
 This is a debugging tool, its behavior or output is not guaranteed to be stable.
 .
 .Bl -tag -width Ds
-.It Fl \-help
+.It Fl h, \-help
 Print help and exit
+.
+.It Fl V, \-version
+Print version information and exit
 .
 .It Fl \-local\-state
 Enable local state handling and ignore modifiers/layouts state updates

--- a/tools/xkbcli-list.1
+++ b/tools/xkbcli-list.1
@@ -18,8 +18,11 @@ The output is in YAML 1.2 format.
 Positional arguments are treated as XKB base directory installations.
 .
 .Bl -tag -width Ds
-.It Fl \-help
+.It Fl h, \-help
 Print help and exit
+.
+.It Fl V, \-version
+Print version information and exit
 .
 .It Fl \-verbose
 Increase verbosity, use multiple times for debugging output

--- a/tools/xkbcli-zsh-completion.zsh
+++ b/tools/xkbcli-zsh-completion.zsh
@@ -108,7 +108,8 @@ local -a rmlvo_opts_common=(
 _xkbcli-list() {
 	_arguments -S : \
 		'(-v --verbose)'{-v,--verbose}'[increase verbosity]' \
-		'--help[print a help message and exit]' \
+		'(-h --help)'{-h,--help}'[print a help message and exit]' \
+		'(-V --version)'{-V,--version}'[print version information and exit]' \
 		'--ruleset=[load a ruleset]' \
 		'--skip-default-paths[do not load the default XKB paths]' \
 		'--load-exotic[load the exotic (extra) rulesets]' \
@@ -116,7 +117,8 @@ _xkbcli-list() {
 }
 
 local -a interactive_common=(
-	'--help[print a help message and exit]'
+	'(-h --help)'{-h,--help}'[print a help message and exit]'
+	'(-V --version)'{-V,--version}'[print version information and exit]'
 	'--verbose[enable verbose debugging output]'
 	'(-* --multiline -1 --uniline)'{-\*,--multiline}'[enable multiline event output]'
 	'(-* --multiline -1 --uniline)'{-1,--uniline}'[enable uniline event output]'
@@ -157,7 +159,8 @@ _xkbcli-interactive-evdev() {
 
 local -a dump_common=(
 	'--verbose[enable verbose debugging output]'
-	'--help[print a help message and exit]'
+	'(-h --help)'{-h,--help}'[print a help message and exit]'
+	'(-V --version)'{-V,--version}'[print version information and exit]'
 	'(--format)--input-format=[use the given input keymap format]:xkb format:(v1 v2)'
 	'(--format)--output-format=[use the given output keymap format]:xkb format:(v1 v2)'
 	'(--input-format --output-format)--format=[use the given keymap format for input and output]:xkb format:(v1 v2)'
@@ -179,7 +182,8 @@ _xkbcli-dump-keymap-wayland() {
 
 _xkbcli-compile-keymap() {
 	_arguments -S : \
-		'--help[print a help message and exit]' \
+		'(-h --help)'{-h,--help}'[print a help message and exit]' \
+		'(-V --version)'{-V,--version}'[print version information and exit]' \
 		'--verbose[enable verbose debugging output]' \
 		'--test[test compilation but do not print the keymap]' \
 		+ input \
@@ -207,7 +211,8 @@ _xkbcli-compile-keymap() {
 
 _xkbcli-compile-compose() {
 	_arguments -S : \
-		'--help[print a help message and exit]' \
+	    '(-h --help)'{-h,--help}'[print a help message and exit]' \
+	    '(-V --version)'{-V,--version}'[print version information and exit]' \
 		'--verbose[enable verbose debugging output]' \
 		'--test[test compilation but do not print the Compose file]' \
 		'--locale=[use the specified locale]:locale:_locales'
@@ -225,7 +230,8 @@ _xkbcli-how-to-type() {
 
 	local ret=1
 	_arguments -S : \
-		'--help[print a help message and exit]' \
+	    '(-h --help)'{-h,--help}'[print a help message and exit]' \
+	    '(-V --version)'{-V,--version}'[print version information and exit]' \
 		'--verbose[enable verbose debugging output]' \
 		'--keysym[treat the argument only as a keysym]' \
 		'--disable-compose[disable Compose support]' \

--- a/tools/xkbcli.1
+++ b/tools/xkbcli.1
@@ -18,10 +18,10 @@
 is a commandline tool to query, compile and test XKB keymaps, layouts and other elements.
 .
 .Bl -tag -width Ds
-.It Fl \-help
+.It Fl h, \-help
 Print help and exit
 .
-.It Fl \-version
+.It Fl V, \-version
 Print the version and exit
 .El
 .


### PR DESCRIPTION
All tools have `--help` but lack `--version`, except base `xkbcli`.

Add `--version` to meet user expectations.