### PR TITLE
rules: Add special layout index `multiple`

### DIFF
--- a/changes/rules-text-format/+multiple-layout-index.feature.md
+++ b/changes/rules-text-format/+multiple-layout-index.feature.md
@@ -1,0 +1,3 @@
+Added [`multiple`](@ref rules-layout-index-multiple) as a special layout index.
+It is the dual of [`single`](@ref rules-layout-index-single): it matches layouts at
+any position, but only if there are *at least 2 layouts*.

--- a/doc/rules-format.md
+++ b/doc/rules-format.md
@@ -185,7 +185,7 @@ Mapping      ::= { Mlvo } "=" { Kccgst } "\n"
 Mlvo         ::= "model" | "option" | ("layout" | "variant") [ Index ]
 Index        ::= "[" ({ NumericIndex } | { SpecialIndex }) "]"
 NumericIndex ::= 1..XKB_MAX_GROUPS
-SpecialIndex ::= "single" | "first" | "later" | "any"
+SpecialIndex ::= "single" | "first" | "later" | "multiple" | "any"
 Kccgst       ::= "keycodes" | "symbols" | "types" | "compat" | "geometry"
 
 Rule         ::= { MlvoValue } "=" { KccgstValue } "\n"
@@ -227,29 +227,36 @@ or %%H seems to do the job though.
   clarify the semantics:
 
   <dl>
-    <dt>`single`</dt>
+    <dt>`single` @anchor rules-layout-index-single</dt>
     <dd>
         Matches a single layout; `layout[single]` is the same as without
         explicit index: `layout`.
     </dd>
-    <dt>`first`</dt>
+    <dt>`first` @anchor rules-layout-index-first</dt>
     <dd>
         Matches the first layout/variant, no matter how many layouts are in
         the RMLVO configuration. Acts as both `layout` and `layout[1]`.
     </dd>
-    <dt>`later`</dt>
+    <dt>`later` @anchor rules-layout-index-later</dt>
     <dd>
         Matches all but the first layout. This is an index *range*.
-        Acts as `layout[2]` .. `layout[4]`.
+        Acts as `layout[2]` .. `layout[32]`.
     </dd>
-    <dt>any</dt>
+    <dt>`multiple` @anchor rules-layout-index-multiple</dt>
     <dd>
-        Matches layout at any position. This is an index *range*.
-        Acts as `layout`, `layout[1]` .. `layout[4]`.
+        Matches layouts at any position, but only if there are *at least 2 layouts*.
+        This is an index *range*. Acts as `layout[1]` .. `layout[32]`.
+
+        Available since version `1.14.0`.
+    </dd>
+    <dt>`any` @anchor rules-layout-index-any</dt>
+    <dd>
+        Matches layouts at any position. This is an index *range*.
+        Acts as `layout`, `layout[1]` .. `layout[32]`.
     </dd>
   </dl>
 
-  When using a layout index *range* (`later`, `any`), the @ref rules-i-expansion "%i expansion"
+  When using a layout index *range* (`later`, `multiple`, `any`), the @ref rules-i-expansion "%i expansion"
   can be used in the `KccgstValue` to refer to the index of the matched layout.
 
 - The order of values in a `Rule` must be the same as the `Mapping` it
@@ -513,6 +520,9 @@ Using the following example:
 
 ! layout[3] = symbols
   *         = +%l[3]%(v[3]):3
+
+! layout[4] = symbols
+  *         = +%l[4]%(v[4]):4
 ```
 
 we would have the following resolutions of <em>[symbols]</em>:
@@ -528,10 +538,10 @@ Since version `1.8.0`, the previous code can be replaced with simply:
 
 ```c
 ! layout[first] = symbols
-  *             = pc+%l[%i]%(v[%i])
+  *             = pc
 
-! layout[later] = symbols
-  *             = +%l[%i]%(v[%i]):%i
+! layout[any] = symbols
+  *           = +%l[%i]%(v[%i]):%i
 ```
 
 ### Example: layout, option and symbols {#rules-options-example}
@@ -612,7 +622,7 @@ Using the following example:
   *             = pc
 
 ! layout[any] = symbols
-  *           = %l[%i]%(v[%i])
+  *           = +%l[%i]%(v[%i])
 
 // Not layout-specific
 ! option      = symbols

--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -726,10 +726,11 @@ extract_layout_index(const char *s, size_t max_len, xkb_layout_index_t *out)
 
 /* Special layout indices */
 enum layout_index_ranges {
-    LAYOUT_INDEX_SINGLE = XKB_LAYOUT_INVALID - 4,
-    LAYOUT_INDEX_FIRST  = XKB_LAYOUT_INVALID - 3,
-    LAYOUT_INDEX_LATER  = XKB_LAYOUT_INVALID - 2,
-    LAYOUT_INDEX_ANY    = XKB_LAYOUT_INVALID - 1
+    LAYOUT_INDEX_SINGLE = XKB_LAYOUT_INVALID - 5,
+    LAYOUT_INDEX_FIRST,
+    LAYOUT_INDEX_LATER,
+    LAYOUT_INDEX_MULTIPLE,
+    LAYOUT_INDEX_ANY,
 };
 
 static_assert((xkb_layout_index_t) XKB_MAX_GROUPS <
@@ -740,6 +741,8 @@ static_assert((xkb_layout_index_t) LAYOUT_INDEX_SINGLE <
               (xkb_layout_index_t) LAYOUT_INDEX_FIRST <
               (xkb_layout_index_t) LAYOUT_INDEX_LATER &&
               (xkb_layout_index_t) LAYOUT_INDEX_LATER <
+              (xkb_layout_index_t) LAYOUT_INDEX_MULTIPLE &&
+              (xkb_layout_index_t) LAYOUT_INDEX_MULTIPLE <
               (xkb_layout_index_t) LAYOUT_INDEX_ANY &&
               (xkb_layout_index_t) LAYOUT_INDEX_ANY <
               (xkb_layout_index_t) XKB_LAYOUT_INVALID,
@@ -755,10 +758,11 @@ extract_mapping_layout_index(const char *s, size_t max_len,
         uint8_t length;
         enum layout_index_ranges range;
     } names[] = {
-        { "single]", 7, LAYOUT_INDEX_SINGLE },
-        { "first]" , 6, LAYOUT_INDEX_FIRST  },
-        { "later]" , 6, LAYOUT_INDEX_LATER  },
-        { "any]"   , 4, LAYOUT_INDEX_ANY    },
+        { "multiple]", 9, LAYOUT_INDEX_MULTIPLE },
+        { "single]"  , 7, LAYOUT_INDEX_SINGLE   },
+        { "first]"   , 6, LAYOUT_INDEX_FIRST    },
+        { "later]"   , 6, LAYOUT_INDEX_LATER    },
+        { "any]"     , 4, LAYOUT_INDEX_ANY      },
     };
 
     /* Check for minimal `[` + index + `]` */
@@ -896,6 +900,7 @@ matcher_mapping_set_layout_bounds(struct matcher *m)
                 ((UINT64_C(1) << m->mapping.layout_idx_max) - UINT64_C(1)) &
                 ~UINT64_C(1);
             break;
+        case LAYOUT_INDEX_MULTIPLE:
         case LAYOUT_INDEX_ANY:
             m->mapping.has_layout_idx_range = true;
             m->mapping.layout_idx_min = 0;
@@ -987,8 +992,13 @@ matcher_mapping_verify(struct matcher *m, struct scanner *s)
                 if (darray_size(m->rmlvo.layouts) > 1)
                     goto skip;
                 break;
-            case LAYOUT_INDEX_ANY:
+            case LAYOUT_INDEX_MULTIPLE:
             case LAYOUT_INDEX_LATER:
+                /* Layout rule matches when at least 2 layouts are specified */
+                if (darray_size(m->rmlvo.layouts) < 2)
+                    goto skip;
+                break;
+            case LAYOUT_INDEX_ANY:
             case LAYOUT_INDEX_FIRST:
                 /* No restrictions */
                 break;

--- a/test/data/rules/special_indices
+++ b/test/data/rules/special_indices
@@ -31,6 +31,9 @@
   layout_b      = +y:%i
   *             = +%l[%i]%(v[%i]):%i
 
+! layout[multiple] = symbols
+  layout_a         = +m:%i
+
 ! layout[any]   = symbols
   layout_c      = +z:%i
 

--- a/test/rules-file.c
+++ b/test/rules-file.c
@@ -392,18 +392,18 @@ test_layout_index_ranges(struct xkb_context *ctx, const char *too_much_layouts,
         /* Test index ranges: multiple layouts */
         ENTRY("a,b", NULL, NULL, "a+b:2", 2, false),
         ENTRY("a,b", ",c", NULL, "a+b(c):2", 2, false),
-        ENTRY("layout_e,layout_a", NULL, NULL, "e:1+x:2", 2, false),
+        ENTRY("layout_e,layout_a", NULL, NULL, "e:1+x:2+m:2", 2, false),
         ENTRY("layout_a,layout_b,layout_c,layout_d", NULL, NULL,
-              "a:1+y:2+layout_c:3+layout_d:4+z:3", 4, false),
+              "a:1+y:2+layout_c:3+layout_d:4+m:1+z:3", 4, false),
         ENTRY("layout_a,layout_b,layout_c,layout_d",
               "extra,,,extra", NULL,
-              "a:1+y:2+layout_c:3+layout_d(extra):4+z:3"
+              "a:1+y:2+layout_c:3+layout_d(extra):4+m:1+z:3"
               "+foo:1|bar:1+foo:4|bar:4", 4, false),
         ENTRY("layout_a,layout_b,layout_c,layout_d,layout_e", NULL, NULL,
-              "a:1+y:2+layout_c:3+layout_d:4+layout_e:5+z:3", 5, false),
+              "a:1+y:2+layout_c:3+layout_d:4+layout_e:5+m:1+z:3", 5, false),
         /* Check that special indices merge the KcCGST values in the expected order */
         ENTRY("layout_a,layout_b,layout_c", NULL, "option_3,option_2,option_1",
-              "a:1+y:2+layout_c:3+z:3+III:2+JJJ:2+HHH:3+KKK:3+LLL+OOO:2+MMM:3+NNN:3",
+              "a:1+y:2+layout_c:3+m:1+z:3+III:2+JJJ:2+HHH:3+KKK:3+LLL+OOO:2+MMM:3+NNN:3",
               3, false),
 #undef ENTRY
         /* Test index ranges: too much layouts */


### PR DESCRIPTION
It is the dual of `single`: it matches layouts at any position, but only if there are *at least 2 layouts*.