### PR TITLE
rules: Fix wild cards not matching empty options

### DIFF
--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -338,7 +338,11 @@ split_comma_separated_mlvo(struct xkb_context *ctx,
         ensure_at_least_one_value:
         /* Label followed by a declaration is a C23 extension */ ;
 
-        struct matched_sval val = { .sval = SVAL(NULL, 0) };
+        struct matched_sval val = {
+            .sval = SVAL(NULL, 0),
+            /* NOTE: Cannot store XKB_LAYOUT_INVALID */
+            .layout = OPTIONS_MATCH_ALL_GROUPS
+        };
         darray_append(arr, val);
         return arr;
     }
@@ -1530,9 +1534,22 @@ matcher_rule_apply_if_matches(struct matcher *m, struct scanner *s)
         struct matched_sval *to;
         bool matched = false;
 
-        /* NOTE: Wild card * matches empty values only for model and options, as
-         * implemented in libxkbfile and xserver. The reason for such different
-         * treatment is not documented. */
+        /*
+         * NOTE: The wildcard `*` behaves differently depending on the MLVO field:
+         * - model and options: matches any value, including empty;
+         * - layout and variant: matches any *non-empty* value.
+         *
+         * This aligns with the implementation in libxkbfile and xserver, with
+         * the exception of options, where `*` is entirely ignored.
+         *
+         * The underlying rationale for this discrepancy across MLVO fields is
+         * undocumented.
+         *
+         * In xkbcommon, `*` behaves identically for both model and options to
+         * maintain consistency and simplicity. This divergence is unlikely
+         * to have a practical impact: to the best of our knowledge, `*` has
+         * no real-world use for the options field.
+         */
         if (mlvo == MLVO_MODEL) {
             to = &m->rmlvo.model;
             matched = match_value_and_mark(m, value, to, match_type,

--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -335,6 +335,9 @@ split_comma_separated_mlvo(struct xkb_context *ctx,
      */
 
     if (!s) {
+        ensure_at_least_one_value:
+        /* Label followed by a declaration is a C23 extension */ ;
+
         struct matched_sval val = { .sval = SVAL(NULL, 0) };
         darray_append(arr, val);
         return arr;
@@ -391,11 +394,15 @@ split_comma_separated_mlvo(struct xkb_context *ctx,
             }
         }
 
-        darray_append(arr, val);
+        if (val.sval.len || mlvo != MLVO_OPTION)
+            darray_append(arr, val);
 
         if (*s == '\0') break;
         if (*s == ',') s++;
     }
+
+    if (darray_empty(arr))
+        goto ensure_at_least_one_value;
 
     return arr;
 }
@@ -1149,7 +1156,7 @@ match_group(struct matcher *m, struct sval group_name, struct sval to)
 }
 
 static bool
-match_value(struct matcher *m, struct sval val, struct sval to,
+match_value(struct matcher *m, const struct sval val, const struct sval to,
             enum mlvo_match_type match_type,
             enum wildcard_match_type wildcard_type)
 {
@@ -1173,7 +1180,7 @@ match_value(struct matcher *m, struct sval val, struct sval to,
 }
 
 static bool
-match_value_and_mark(struct matcher *m, struct sval val,
+match_value_and_mark(struct matcher *m, const struct sval val,
                      struct matched_sval *to, enum mlvo_match_type match_type,
                      enum wildcard_match_type wildcard_type)
 {
@@ -1565,6 +1572,8 @@ matcher_rule_apply_if_matches(struct matcher *m, struct scanner *s)
                     default:
                         assert(mlvo == MLVO_OPTION);
                         bool found_option = false;
+                        /* There is always at least one value "" */
+                        assert(!darray_empty(m->rmlvo.options));
                         darray_foreach(to, m->rmlvo.options) {
                             /*
                              * Skip if layout-specific option and the target
@@ -1605,6 +1614,8 @@ matcher_rule_apply_if_matches(struct matcher *m, struct scanner *s)
                 break;
             default:
                 assert(mlvo == MLVO_OPTION);
+                /* There is always at least one value "" */
+                assert(!darray_empty(m->rmlvo.options));
                 darray_foreach(to, m->rmlvo.options) {
                     /*
                      * Skip if it is a layout-specific option and either:

--- a/test/data/rules/extended-wild-cards
+++ b/test/data/rules/extended-wild-cards
@@ -2,13 +2,16 @@
   *     = evdev
 
 ! model = compat
-  *     = complete
+  <any> = complete
+  *     = xxx
 
 ! model = types
   *     = complete
 
 ! model = symbols
-  *     = pc
+  <none> = pc
+  <some> = pc
+  *      = xxx
 
 ! layout[any] variant[any] = symbols
   l1          <none>       = +l10:%i             // compatibity mapping: l1, no variant
@@ -20,4 +23,14 @@
   *           <any>        = +%l[%i]%(v[%i]):%i  // catch-all
 
 ! option = symbols
-  opt1   = +opt1
+  opt0   = +o0
+  *      = +o1
+  <none> = +o2
+  <some> = +o3
+  <any>  = +o4
+
+! layout[any] option = symbols
+  <none>      <any>  = +o5:%i
+  <any>       <none> = +o6:%i
+  <some>      <some> = +o7:%i
+  <any>       <any>  = +o8:%i

--- a/test/rules-file.c
+++ b/test/rules-file.c
@@ -345,40 +345,72 @@ test_wild_card(struct xkb_context *ctx)
 static void
 test_extended_wilcards(struct xkb_context *ctx)
 {
-#define ENTRY(_rules, _layout, _variant, _symbols, _layouts, _fail)   \
-    { .rules = (_rules), .model = NULL,                               \
-      .layout = (_layout), .variant = (_variant), .options = NULL,    \
-      .keycodes = "evdev", .types = "complete", .compat = "complete", \
-      .symbols = (_symbols) , .explicit_layouts = (_layouts),         \
-      .should_fail = (_fail) }
+#define ENTRY(_model, _layout, _variant, _options, _symbols, _layouts, _fail) {\
+      .rules = "extended-wild-cards", .model = (_model),                       \
+      .layout = (_layout), .variant = (_variant), .options = (_options),       \
+      .keycodes = "evdev", .types = "complete", .compat = "complete",          \
+      .symbols = (_symbols) , .explicit_layouts = (_layouts),                  \
+      .should_fail = (_fail)                                                   \
+    }
 
     static const struct test_data tests[] = {
-        ENTRY("extended-wild-cards", "l1", NULL, "pc+l10:1", 1, false),
-        ENTRY("extended-wild-cards", "l1", "v1", "pc+l20:1", 1, false),
-        ENTRY("extended-wild-cards", "l1", "v2", "pc+l30(v2):1", 1, false),
+        /*
+         * Model
+         */
+
+        ENTRY(NULL, "l1", NULL, NULL, "pc+l10:1+o1+o2+o4+o6:1+o8:1", 1, false),
+        ENTRY("", "l1", NULL, NULL, "pc+l10:1+o1+o2+o4+o6:1+o8:1", 1, false),
+        ENTRY("m", "l1", NULL, NULL, "pc+l10:1+o1+o2+o4+o6:1+o8:1", 1, false),
+
+        /*
+         * Layout / variant
+         */
+
+        ENTRY("m", "l1", NULL, NULL, "pc+l10:1+o1+o2+o4+o6:1+o8:1", 1, false),
+        ENTRY("m", "l1", "v1", NULL, "pc+l20:1+o1+o2+o4+o6:1+o8:1", 1, false),
+        ENTRY("m", "l1", "v2", NULL, "pc+l30(v2):1+o1+o2+o4+o6:1+o8:1", 1, false),
         /* legacy wild card * does not catch empty variant */
-        ENTRY("extended-wild-cards", "l2", NULL, "pc+l2:1", 1, false),
-        ENTRY("extended-wild-cards", "l2", "v1", "pc+l40(v1):1", 1, false),
-        ENTRY("extended-wild-cards", "l2", "v2", "pc+l40(v2):1", 1, false),
-        ENTRY("extended-wild-cards", "l3", NULL, "pc+l50:1", 1, false),
-        ENTRY("extended-wild-cards", "l3", "v1", "pc+l50(v1):1", 1, false),
-        ENTRY("extended-wild-cards", "l3", "v2", "pc+l50(v2):1", 1, false),
+        ENTRY("m", "l2", NULL, NULL, "pc+l2:1+o1+o2+o4+o6:1+o8:1", 1, false),
+        ENTRY("m", "l2", "v1", NULL, "pc+l40(v1):1+o1+o2+o4+o6:1+o8:1", 1, false),
+        ENTRY("m", "l2", "v2", NULL, "pc+l40(v2):1+o1+o2+o4+o6:1+o8:1", 1, false),
+        ENTRY("m", "l3", NULL, NULL, "pc+l50:1+o1+o2+o4+o6:1+o8:1", 1, false),
+        ENTRY("m", "l3", "v1", NULL, "pc+l50(v1):1+o1+o2+o4+o6:1+o8:1", 1, false),
+        ENTRY("m", "l3", "v2", NULL, "pc+l50(v2):1+o1+o2+o4+o6:1+o8:1", 1, false),
         /* ? wild card does catch empty variant */
-        ENTRY("extended-wild-cards", "l4", NULL, "pc+l4:1", 1, false),
-        ENTRY("extended-wild-cards", "l4", "v1", "pc+l4(v1):1", 1, false),
-        ENTRY("extended-wild-cards", "l4", "v2", "pc+l4(v20):1", 1, false),
-        ENTRY("extended-wild-cards", "l1,l1,l1,l2", ",v1,v2,",
-              "pc+l10:1+l20:2+l30(v2):3+l2:4", 4, false),
-        ENTRY("extended-wild-cards", "l2,l2,l3,l3", "v1,v2,,v1",
-              "pc+l40(v1):1+l40(v2):2+l50:3+l50(v1):4", 4, false),
-        ENTRY("extended-wild-cards", "l3,l4,l4,l4", "v2,,v1,v2",
-              "pc+l50(v2):1+l4:2+l4(v1):3+l4(v20):4", 4, false),
+        ENTRY("m", "l4", NULL, NULL, "pc+l4:1+o1+o2+o4+o6:1+o8:1", 1, false),
+        ENTRY("m", "l4", "v1", NULL, "pc+l4(v1):1+o1+o2+o4+o6:1+o8:1", 1, false),
+        ENTRY("m", "l4", "v2", NULL, "pc+l4(v20):1+o1+o2+o4+o6:1+o8:1", 1, false),
+        ENTRY("m", "l1,l1,l1,l2", ",v1,v2,", NULL,
+              "pc+l10:1+l20:2+l30(v2):3+l2:4"
+              "+o1+o2+o4+o6:1+o8:1+o6:2+o8:2+o6:3+o8:3+o6:4+o8:4", 4, false),
+        ENTRY("m", "l2,l2,l3,l3", "v1,v2,,v1", NULL,
+              "pc+l40(v1):1+l40(v2):2+l50:3+l50(v1):4"
+              "+o1+o2+o4+o6:1+o8:1+o6:2+o8:2+o6:3+o8:3+o6:4+o8:4", 4, false),
+        ENTRY("m", "l3,l4,l4,l4", "v2,,v1,v2", NULL,
+              "pc+l50(v2):1+l4:2+l4(v1):3+l4(v20):4"
+              "+o1+o2+o4+o6:1+o8:1+o6:2+o8:2+o6:3+o8:3+o6:4+o8:4", 4, false),
+
+        /*
+         * Options
+         */
+
+        /* Empty list: check `*`, `<none>`, `<any>` wild cards */
+        ENTRY("m", "l1", NULL, NULL, "pc+l10:1+o1+o2+o4+o6:1+o8:1", 1, false),
+        ENTRY("m", "l1", NULL, "", "pc+l10:1+o1+o2+o4+o6:1+o8:1", 1, false),
+        ENTRY("m", "l1", NULL, ",", "pc+l10:1+o1+o2+o4+o6:1+o8:1", 1, false),
+        ENTRY("m", "l1", NULL, "!", "pc+l10:1+o1+o2+o4+o6:1+o8:1", 1, false), /* discarded */
+        /* Some values */
+        ENTRY("m", "l1", NULL, "*", "pc+l10:1+o1+o3+o4+o7:1+o8:1", 1, false),
+        ENTRY("m", "l1", NULL, ":", "pc+l10:1+o1+o3+o4+o7:1+o8:1", 1, false),
+        ENTRY("m", "l1", NULL, "=", "pc+l10:1+o1+o3+o4+o7:1+o8:1", 1, false),
+        ENTRY("m", "l1", NULL, "opt0", "pc+l10:1+o0+o1+o3+o4+o7:1+o8:1", 1, false),
     };
+
 #undef ENTRY
 
-    for (unsigned int k = 0; k < ARRAY_SIZE(tests); k++) {
-        fprintf(stderr, "------\n*** %s: #%u ***\n", __func__, k);
-        assert(test_rules(ctx, &tests[k]));
+    for (size_t t = 0; t < ARRAY_SIZE(tests); t++) {
+        fprintf(stderr, "------\n*** %s: #%zu ***\n", __func__, t);
+        assert(test_rules(ctx, &tests[t]));
     }
 }
 

--- a/test/rulescomp.c
+++ b/test/rulescomp.c
@@ -17,6 +17,44 @@
 #include "test.h"
 #include "utils.h"
 
+static void
+test_components_names_from_rules(struct xkb_context *ctx) {
+    static const struct xkb_rule_names tests[] = {
+        {
+            .rules = "evdev",
+            .model = "pc105",
+            .layout = "us",
+            .variant = NULL,
+            .options = NULL
+        },
+        {
+            .rules = "evdev",
+            .model = "pc105",
+            .layout = "us",
+            .variant = NULL,
+            .options = "" /* empty string */
+        },
+        {
+            .rules = "evdev",
+            .model = "pc105",
+            .layout = "us",
+            .variant = NULL,
+            .options = "," /* dummy list */
+        },
+    };
+
+    for (size_t t = 0; t < ARRAY_SIZE(tests); t++) {
+        fprintf(stderr, "------\n*** %s: #%zu ***\n", __func__, t);
+        struct xkb_rule_names rmlvo = {0};
+        assert(xkb_components_names_from_rules(ctx, &tests[t], &rmlvo, NULL));
+        assert_streq_not_null("rules", tests[t].rules, rmlvo.rules);
+        assert_streq_not_null("model", tests[t].model, rmlvo.model);
+        assert_streq_not_null("layout", tests[t].layout, rmlvo.layout);
+        assert_streq("variant", tests[t].variant, rmlvo.variant);
+        assert_streq("options", tests[t].options, rmlvo.options);
+    }
+}
+
 /* xkb_rule_names API */
 static int
 test_rmlvo_va(struct xkb_context *context, enum xkb_keymap_format format,
@@ -214,6 +252,8 @@ main(int argc, char *argv[])
                                         XKB_KEYMAP_FORMAT_TEXT_V1, -1));
     assert(!xkb_keymap_new_from_names2(ctx, &rmlvo,
                                         XKB_KEYMAP_FORMAT_TEXT_V1, 5453));
+
+    test_components_names_from_rules(ctx);
 
     /* Test “Last” group constant as an array index */
     struct xkb_keymap *keymap =

--- a/test/test.h
+++ b/test/test.h
@@ -31,6 +31,10 @@
        assert(__cond);                                     \
     }} while (0)
 
+#define assert_streq(test_name, expected, got) \
+    assert_printf(streq_null(expected, got), \
+                  test_name ". Expected \"%s\", got: \"%s\"\n", expected, got)
+
 #define assert_streq_not_null(test_name, expected, got) \
     assert_printf(streq_not_null(expected, got), \
                   test_name ". Expected \"%s\", got: \"%s\"\n", expected, got)


### PR DESCRIPTION
Wild cards `*`, `<none>` and `<any>` should match an *empty* list of options. Note that this is mainly to maintain consistency with other MLVO items, as wild cards have no practical use (yet) for options.

Note: contrary to Xorg’s xkbcomp (at least up to v1.5), xkbcommon interprets `*` as a wild card for options. However this difference should not matter: to the best of our knowledge, this feature has no real-world use.