### PR TITLE
license: Complete and correct SPDX notices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -164,8 +164,8 @@ OR PERFORMANCE OF THIS SOFTWARE.
 
 
 -------------------------------------------------------------------------------
-SPDX full name: <none>
-SPDX short identifier: LicenseRef-digital-equipment-corporation
+SPDX full name: Historical Permission Notice and Disclaimer
+SPDX short identifier: HPND
 License text:
 
 Copyright 1987, 1988 by Digital Equipment Corporation, Maynard, Massachusetts.

--- a/LICENSE
+++ b/LICENSE
@@ -17,6 +17,27 @@ BEGINNING OF SOFTWARE COPYRIGHT/LICENSE STATEMENTS:
 
 
 -------------------------------------------------------------------------------
+SPDX full name: ISC License
+SPDX short identifier: ISC
+License text:
+
+Copyright 2023 Justine Alexandra Roberts Tunney
+
+Permission to use, copy, modify, and/or distribute this software for
+any purpose with or without fee is hereby granted, provided that the
+above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+
+-------------------------------------------------------------------------------
 SPDX full name: MIT License
 SPDX short identifier: MIT
 License text:

--- a/src/atom.c
+++ b/src/atom.c
@@ -2,13 +2,11 @@
  * For MIT-open-group:
  * Copyright 1987, 1998  The Open Group
  *
- * For LicenseRef-digital-equipment-corporation:
- * Copyright 1987 by Digital Equipment Corporation, Maynard, Massachusetts.
- *
  * For HPND:
+ * Copyright 1987 by Digital Equipment Corporation, Maynard, Massachusetts.
  * Copyright 1994 by Silicon Graphics Computer Systems, Inc.
  *
- * SPDX-License-Identifier: MIT-open-group AND LicenseRef-digital-equipment-corporation AND HPND
+ * SPDX-License-Identifier: MIT-open-group AND HPND
  */
 
 #include "config.h"


### PR DESCRIPTION
## Summary

- add the ISC license notice from `src/utils-checked-arithmetic.h` to the top-level `LICENSE` file
- identify the Digital Equipment Corporation notice as SPDX `HPND` in `src/atom.c` and `LICENSE`
- simplify the file-level expression to `MIT-open-group AND HPND`

## Rationale

`src/utils-checked-arithmetic.h` was added in fb9fec18 with an ISC SPDX identifier and the full ISC notice. The top-level `LICENSE` says it lists all license statements in the source tree, but it was not updated when that file was introduced.

The Digital Equipment Corporation notice matches the [SPDX HPND](https://spdx.org/licenses/HPND.html) template: the copyright holder is replaceable, the no-endorsement clause is permitted, and the suitability / as-is paragraph is optional. Therefore the custom `LicenseRef-digital-equipment-corporation` identifier is unnecessary.
