### PR TITLE
Rules: fix parser

### DIFF
--- a/changes/api/+rules_plus_wild_card.bugfix.md
+++ b/changes/api/+rules_plus_wild_card.bugfix.md
@@ -1,0 +1,1 @@
+rules: Fixed parsing `+` as `<some>`.

--- a/changes/api/+rules_token_boundaries.bugfix.md
+++ b/changes/api/+rules_token_boundaries.bugfix.md
@@ -1,0 +1,1 @@
+rules: Fixed token right boundaries for `=`, `*` and extended wild cards.

--- a/doc/rules-format.md
+++ b/doc/rules-format.md
@@ -168,7 +168,38 @@ This wild card usually appears near the end of a rule set to set *default* value
 It is advised to look at a file like `rules/evdev` along with
 this grammar.
 
-@note Comments, whitespace, etc. are not shown.
+<dl>
+<dt>`<ident>`</dt>
+<dd>
+Denotes a lexical identifier: a non-empty maximal sequence of printable ASCII
+characters in the range `!` – `~`, excluding backslash `\`.
+The first character shall not be one of `!`, `=`, `$`, `*`, or `<`.
+</dd>
+<dt>`<kccgst-ident>`</dt>
+<dd>
+Same as `<ident>`, except it excludes also merge mode characters `+|^` and
+the qualifier prefix `:`.
+</dd>
+</dl>
+
+@remark It is recommended to avoid any unnecessary punctuation in identifiers,
+because later versions of the rules may assign syntactic meaning to characters
+that are currently unreserved.
+
+@note *Whitespace*, except line feed `\n`, may appear between lexical tokens
+unless explicitly prohibited by the lexical grammar. It is not shown in the
+productions below.
+
+@note The sequence consisting of a backslash `\`, an optional carriage return
+`\r` and a line feed `\n` is discarded during lexical analysis. It serves only
+to allow a grammar production to span multiple physical lines and does not
+affect tokenization.
+
+@note A comment begins with `//` and extends to, but does not include, the next
+line feed `\n` or the end of the input.
+
+@note In the following, comments are treated as whitespace and are omitted
+from the grammar.
 
 ```bnf
 File         ::= { "!" (Include | Group | RuleSet) }
@@ -181,17 +212,29 @@ GroupElement ::= <ident>
 
 RuleSet      ::= Mapping { Rule }
 
-Mapping      ::= { Mlvo } "=" { Kccgst } "\n"
+Mapping      ::= Mlvo { Mlvo } "=" Kccgst { Kccgst } "\n"
 Mlvo         ::= "model" | "option" | ("layout" | "variant") [ Index ]
-Index        ::= "[" ({ NumericIndex } | { SpecialIndex }) "]"
+Index        ::= "[" (NumericIndex | SpecialIndex) "]"
 NumericIndex ::= 1..XKB_MAX_GROUPS
 SpecialIndex ::= "single" | "first" | "later" | "multiple" | "any"
 Kccgst       ::= "keycodes" | "symbols" | "types" | "compat" | "geometry"
 
-Rule         ::= { MlvoValue } "=" { KccgstValue } "\n"
-MlvoValue    ::= "*" | "<none>" | "<some>" | "<any>" | GroupName | <ident>
-KccgstValue  ::= <ident> [ { Qualifier } ]
-Qualifier    ::= ":" ({ NumericIndex } | "all")
+Rule         ::= MlvoValue { MlvoValue } "=" KccgstValue { KccgstValue } "\n"
+MlvoValue    ::= Wildcard | GroupName | <ident>
+Wildcard     ::= "*" | "<none>" | "<some>" | "<any>"
+KccgstValue  ::= <kccgst-value>
+```
+
+The following is a subgrammar for `<kccgst-value>`:
+
+@important In the following grammar, *whitespace* is prohibited between lexical
+tokens unless explicitly allowed.
+
+```bnf
+<kccgst-value>  ::= [ MergeMode ] KccgstEntry { MergeMode KccgstEntry }
+MergeMode       ::= "+" | "|" | "^"
+KccgstEntry     ::= <kccgst-ident> [ ":" KccgstQualifier ]
+KccgstQualifier ::= "%i" | "all" | NumericIndex
 ```
 
 <!--

--- a/src/scanner-utils.h
+++ b/src/scanner-utils.h
@@ -200,6 +200,17 @@ scanner_rules_str_token(struct scanner *s, const char *string, size_t len)
 #define scanner_rules_lit_token(s, literal) \
     scanner_rules_str_token((s), (literal), sizeof(literal) - 1)
 
+static inline size_t
+scanner_rules_ident_token(struct scanner *s)
+{
+    size_t len = 0;
+    while (!scanner_eof(s) && scanner_rules_is_ident(s->s[s->pos])) {
+        s->pos++;
+        len++;
+    }
+    return len;
+}
+
 static inline bool
 scanner_buf_append(struct scanner *s, char ch)
 {

--- a/src/scanner-utils.h
+++ b/src/scanner-utils.h
@@ -174,6 +174,33 @@ scanner_str(struct scanner *s, const char *string, size_t len)
 #define scanner_lit(s, literal) scanner_str(s, literal, sizeof(literal) - 1)
 
 static inline bool
+scanner_rules_is_ident(char ch)
+{
+    return is_graph(ch) && ch != '\\';
+}
+
+/*
+ * A keyword/operator is only valid when it is followed by a character
+ * which cannot continue the token.
+ */
+static inline bool
+scanner_rules_str_token(struct scanner *s, const char *string, size_t len)
+{
+    if (!scanner_str(s, string, len)) {
+        return false;
+    }
+    if (scanner_rules_is_ident(scanner_peek(s))) {
+        /* Backtrack */
+        s->pos -= len;
+        return false;
+    }
+    return true;
+}
+
+#define scanner_rules_lit_token(s, literal) \
+    scanner_rules_str_token((s), (literal), sizeof(literal) - 1)
+
+static inline bool
 scanner_buf_append(struct scanner *s, char ch)
 {
     if (s->buf_pos + 1 >= sizeof(s->buf))

--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -2029,12 +2029,8 @@ rule_mlvo:
 rule_mlvo_no_tok:
     switch (tok) {
     case TOK_IDENTIFIER:
-        if (!m->rule.skip) {
-            if (m->val.string.len == 1 && m->val.string.start[0] == '+')
-                matcher_rule_set_mlvo_wildcard(m, s, MLVO_MATCH_WILDCARD_SOME);
-            else
-                matcher_rule_set_mlvo(m, s, m->val.string);
-        }
+        if (!m->rule.skip)
+            matcher_rule_set_mlvo(m, s, m->val.string);
         goto rule_mlvo;
     case TOK_WILD_CARD_STAR:
         if (!m->rule.skip)

--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -56,21 +56,21 @@ static enum rules_token
 lex(struct scanner *s, union lvalue *val)
 {
 skip_more_whitespace_and_comments:
-    /* Skip spaces. */
+    /* Skip spaces */
     while (scanner_chr(s, ' ') || scanner_chr(s, '\t') || scanner_chr(s, '\r'));
 
-    /* Skip comments. */
+    /* Skip comments */
     if (scanner_lit(s, "//")) {
         scanner_skip_to_eol(s);
     }
 
-    /* New line. */
+    /* New line */
     if (scanner_eol(s)) {
         while (scanner_eol(s)) scanner_next(s);
         return TOK_END_OF_LINE;
     }
 
-    /* Escaped line continuation. */
+    /* Escaped line continuation */
     if (scanner_chr(s, '\\')) {
         /* Optional \r. */
         scanner_chr(s, '\r');
@@ -83,74 +83,90 @@ skip_more_whitespace_and_comments:
         goto skip_more_whitespace_and_comments;
     }
 
-    /* See if we're done. */
+    /* See if we're done */
     if (scanner_eof(s)) return TOK_END_OF_FILE;
 
-    /* New token. */
+    /* New token */
     s->token_pos = s->pos;
+    enum rules_token token = TOK_IDENTIFIER;
 
-    /* Operators and punctuation. */
-    if (scanner_chr(s, '!')) return TOK_BANG;
-    if (scanner_chr(s, '=')) {
+    const char next = scanner_next(s);
+    switch (next) {
+    case '!':
+        return TOK_BANG;
+    case '$':
+        /* Group */
+        token = TOK_GROUP_NAME;
+        val->string.len = 0;
+        break;
+    case '*':
         if (scanner_rules_is_ident(scanner_peek(s))) {
             /* Backtrack */
             s->pos--;
+            break;
+        } else {
+            /* Legacy wild card */
+            return TOK_WILD_CARD_STAR;
+        }
+    case '<':
+        /* Extended wild cards */
+        if (scanner_rules_lit_token(s, "none>")) return TOK_WILD_CARD_NONE;
+        if (scanner_rules_lit_token(s, "some>")) return TOK_WILD_CARD_SOME;
+        if (scanner_rules_lit_token(s, "any>")) return TOK_WILD_CARD_ANY;
+        /* No match: continue lax parsing */
+        assert(scanner_rules_is_ident('<'));
+        val->string.len = 1;
+        break;
+    case '=':
+        if (scanner_rules_is_ident(scanner_peek(s))) {
+            /* Backtrack */
+            s->pos--;
+            break;
         } else {
             return TOK_EQUALS;
         }
-    }
-
-    /* Wild cards */
-    if (scanner_chr(s, '*')) {
-        if (scanner_rules_is_ident(scanner_peek(s))) {
-            /* Backtrack */
-            s->pos--;
+    case 'i':
+        if (scanner_rules_lit_token(s, "nclude")) {
+            /* Include statement */
+            return TOK_INCLUDE;
+        }
+        /* Identifier */
+        assert(scanner_rules_is_ident('i'));
+        val->string.len = 1;
+        break;
+    default:
+        if (likely(scanner_rules_is_ident(next))) {
+            /* Identifier */
+            val->string.len = 1;
         } else {
-            return TOK_WILD_CARD_STAR;
+            /* Invalid */
+            s->pos--;
+            val->string.len = 0;
         }
     }
-    if (scanner_rules_lit_token(s, "<none>")) return TOK_WILD_CARD_NONE;
-    if (scanner_rules_lit_token(s, "<some>")) return TOK_WILD_CARD_SOME;
-    if (scanner_rules_lit_token(s, "<any>")) return TOK_WILD_CARD_ANY;
 
-    /* Group name. */
-    if (scanner_chr(s, '$')) {
-        val->string.start = s->s + s->pos;
-        val->string.len = 0;
-        while (scanner_rules_is_ident(scanner_peek(s))) {
-            scanner_next(s);
-            val->string.len++;
-        }
-        if (val->string.len == 0) {
-            scanner_err(s, XKB_ERROR_INVALID_RULES_SYNTAX,
-                        "unexpected character after \'$\'; expected name");
-            return TOK_ERROR;
-        }
-        return TOK_GROUP_NAME;
-    }
-
-    /* Include statement. */
-    if (scanner_rules_lit_token(s, "include"))
-        return TOK_INCLUDE;
-
-    /* Identifier. */
+    /* Identifier */
+    val->string.start = s->s + s->pos - val->string.len;
     /* Ensure that we can parse KcCGST values with merge modes */
     assert(scanner_rules_is_ident(MERGE_OVERRIDE_PREFIX));
     assert(scanner_rules_is_ident(MERGE_AUGMENT_PREFIX));
     assert(scanner_rules_is_ident(MERGE_REPLACE_PREFIX));
-    if (scanner_rules_is_ident(scanner_peek(s))) {
-        val->string.start = s->s + s->pos;
-        val->string.len = 0;
-        while (scanner_rules_is_ident(scanner_peek(s))) {
-            scanner_next(s);
-            val->string.len++;
+    assert(scanner_rules_is_ident('('));
+    assert(scanner_rules_is_ident(')'));
+    val->string.len += scanner_rules_ident_token(s);
+
+    if (unlikely(val->string.len == 0)) {
+        if (token == TOK_GROUP_NAME) {
+            scanner_err(s, XKB_ERROR_INVALID_RULES_SYNTAX,
+                        "unexpected character after \'$\'; expected name");
+        } else {
+            scanner_err(s, XKB_ERROR_INVALID_RULES_SYNTAX,
+                        "unrecognized token");
         }
-        return TOK_IDENTIFIER;
+        return TOK_ERROR;
     }
 
-    scanner_err(s, XKB_ERROR_INVALID_RULES_SYNTAX,
-                "unrecognized token");
-    return TOK_ERROR;
+    return token;
 }
 
 /***====================================================================***/
@@ -2095,7 +2111,7 @@ finish:
 
 state_error:
     scanner_err(s, XKB_ERROR_INVALID_RULES_SYNTAX,
-                "unexpected token");
+                "unexpected token (0x%x)", tok);
 error:
     return false;
 }

--- a/src/xkbcomp/rules.c
+++ b/src/xkbcomp/rules.c
@@ -52,12 +52,6 @@ enum rules_token {
     TOK_ERROR
 };
 
-static inline bool
-is_ident(char ch)
-{
-    return is_graph(ch) && ch != '\\';
-}
-
 static enum rules_token
 lex(struct scanner *s, union lvalue *val)
 {
@@ -97,19 +91,33 @@ skip_more_whitespace_and_comments:
 
     /* Operators and punctuation. */
     if (scanner_chr(s, '!')) return TOK_BANG;
-    if (scanner_chr(s, '=')) return TOK_EQUALS;
+    if (scanner_chr(s, '=')) {
+        if (scanner_rules_is_ident(scanner_peek(s))) {
+            /* Backtrack */
+            s->pos--;
+        } else {
+            return TOK_EQUALS;
+        }
+    }
 
     /* Wild cards */
-    if (scanner_chr(s, '*')) return TOK_WILD_CARD_STAR;
-    if (scanner_lit(s, "<none>")) return TOK_WILD_CARD_NONE;
-    if (scanner_lit(s, "<some>")) return TOK_WILD_CARD_SOME;
-    if (scanner_lit(s, "<any>")) return TOK_WILD_CARD_ANY;
+    if (scanner_chr(s, '*')) {
+        if (scanner_rules_is_ident(scanner_peek(s))) {
+            /* Backtrack */
+            s->pos--;
+        } else {
+            return TOK_WILD_CARD_STAR;
+        }
+    }
+    if (scanner_rules_lit_token(s, "<none>")) return TOK_WILD_CARD_NONE;
+    if (scanner_rules_lit_token(s, "<some>")) return TOK_WILD_CARD_SOME;
+    if (scanner_rules_lit_token(s, "<any>")) return TOK_WILD_CARD_ANY;
 
     /* Group name. */
     if (scanner_chr(s, '$')) {
         val->string.start = s->s + s->pos;
         val->string.len = 0;
-        while (is_ident(scanner_peek(s))) {
+        while (scanner_rules_is_ident(scanner_peek(s))) {
             scanner_next(s);
             val->string.len++;
         }
@@ -122,18 +130,18 @@ skip_more_whitespace_and_comments:
     }
 
     /* Include statement. */
-    if (scanner_lit(s, "include"))
+    if (scanner_rules_lit_token(s, "include"))
         return TOK_INCLUDE;
 
     /* Identifier. */
     /* Ensure that we can parse KcCGST values with merge modes */
-    assert(is_ident(MERGE_OVERRIDE_PREFIX));
-    assert(is_ident(MERGE_AUGMENT_PREFIX));
-    assert(is_ident(MERGE_REPLACE_PREFIX));
-    if (is_ident(scanner_peek(s))) {
+    assert(scanner_rules_is_ident(MERGE_OVERRIDE_PREFIX));
+    assert(scanner_rules_is_ident(MERGE_AUGMENT_PREFIX));
+    assert(scanner_rules_is_ident(MERGE_REPLACE_PREFIX));
+    if (scanner_rules_is_ident(scanner_peek(s))) {
         val->string.start = s->s + s->pos;
         val->string.len = 0;
-        while (is_ident(scanner_peek(s))) {
+        while (scanner_rules_is_ident(scanner_peek(s))) {
             scanner_next(s);
             val->string.len++;
         }

--- a/test/data/rules/token-boundaries-1
+++ b/test/data/rules/token-boundaries-1
@@ -1,0 +1,1 @@
+! includeevdev // Syntax error: invalid keyword

--- a/test/data/rules/token-boundaries-2
+++ b/test/data/rules/token-boundaries-2
@@ -1,0 +1,4 @@
+! include simple
+
+! layout= symbols // Syntax error: missing space before “=”
+  *     = +aaa

--- a/test/data/rules/token-boundaries-3
+++ b/test/data/rules/token-boundaries-3
@@ -1,0 +1,4 @@
+! include simple
+
+! layout =symbols // Syntax error: missing space after “=”
+  <any>  = +aaa

--- a/test/data/rules/token-boundaries-4
+++ b/test/data/rules/token-boundaries-4
@@ -1,0 +1,25 @@
+! include simple
+
+! layout variant = symbols
+  <any><any>     = +aaa // skipped: single value on LHS
+
+! layout variant = symbols
+  *<any>         = +bbb // skipped: single value on LHS
+
+! variant layout = symbols
+  <any>*         = +ccc // skipped: single value on LHS
+
+! layout variant = symbols
+  *      <any> * = +ddd // skipped: too many values in LHS
+
+! layout variant = symbols
+  *      <any>*  = +eee // skipped: invalid wild card
+
+! layout variant = symbols
+  *      *<any>  = +fff // skipped: invalid wild card
+
+! layout variant = symbols
+  *      <any><any> = +ggg // skipped: invalid wild card
+
+! layout variant = symbols
+  *      <any>   = +valid

--- a/test/rules-file.c
+++ b/test/rules-file.c
@@ -162,6 +162,50 @@ test_encodings(struct xkb_context *ctx)
     }
 }
 
+static void
+test_token_boundaries(struct xkb_context *ctx)
+{
+    static const struct test_data tests[] = {
+        {
+            .rules = "token-boundaries-1",
+
+            .model = "my_model", .layout = "my_layout", .variant = "",
+            .options = NULL,
+            .should_fail = true,
+        },
+        {
+            .rules = "token-boundaries-2",
+
+            .model = "my_model", .layout = "my_layout", .variant = "",
+            .options = NULL,
+            .should_fail = true,
+        },
+        {
+            .rules = "token-boundaries-3",
+
+            .model = "my_model", .layout = "my_layout", .variant = "",
+            .options = NULL,
+            .should_fail = true,
+        },
+        {
+            .rules = "token-boundaries-4",
+
+            .model = "my_model", .layout = "my_layout", .variant = "my_variant",
+            .options = NULL,
+
+            .keycodes = "my_keycodes", .types = "my_types",
+            .compat = "my_compat",
+            .symbols = "my_symbols+extra_variant+valid",
+            .explicit_layouts = 1,
+        },
+    };
+
+    for (size_t t = 0; t < ARRAY_SIZE(tests); t++) {
+        fprintf(stderr, "------\n*** %s: #%zu ***\n", __func__, t);
+        assert(test_rules(ctx, &tests[t]));
+    }
+}
+
 /* Only parse strict decimal groups */
 static void
 test_strict_decimal_groups(struct xkb_context *ctx)
@@ -903,6 +947,7 @@ main(int argc, char *argv[])
     assert(ctx);
 
     test_encodings(ctx);
+    test_token_boundaries(ctx);
     test_strict_decimal_groups(ctx);
     test_simple(ctx);
     test_wild_card(ctx);


### PR DESCRIPTION
- Remove single `+` interpreted as `<some>`.

  This is a leftover of a previous proposal of extended wild cards, introduced in 6fc6e64b563600e30f18bec138f0b0b127940848.
- Fix token boundaries
  - Make `=` and wild cards parse as tokens only if not followed by identifier characters.
  - Add corresponding tests.
- Optimize lexer (1.28× speedup)