### PR TITLE
State: refactor machine builder updates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,7 +22,7 @@ libxkbcommon [1.14.0-beta1] – 2026-07-22
 [supported features]: @ref xkb_feature
 [lenient keymap parser]: @ref XKB_KEYMAP_COMPILE_STRICT_MODE
 [keyboard overlays]: @ref key-behavior-overlay
-[reference layout for keyboard shortcuts]: @ref xkb_machine_builder::xkb_machine_builder_remap_shortcut_layout
+[reference layout for keyboard shortcuts]: @ref xkb_machine_builder::xkb_machine_builder_update_shortcut_layout
 [modifier-remapping]: @ref xkb_machine_builder::xkb_machine_builder_update_mods_remap
 [sticky keys]: @ref XKB_KEYBOARD_CONTROL_A11Y_STICKY_KEYS
 
@@ -240,8 +240,8 @@ libxkbcommon [1.14.0-beta1] – 2026-07-22
       `struct xkb_machine_builder_a11y_update`
     - `xkb_machine_builder::xkb_machine_builder_update_mods_remap()`,
       `struct xkb_machine_builder_mods_remap_update`
-    - `xkb_machine_builder::xkb_machine_builder_update_shortcut_mods()`
-    - `xkb_machine_builder::xkb_machine_builder_remap_shortcut_layout()`
+    - `xkb_machine_builder::xkb_machine_builder_update_shortcut_layout()`,
+      `struct xkb_machine_builder_shortcut_layout_update`
   - `enum xkb_machine_builder_flags` (new)
   - `enum xkb_events_flags` (new)
   - `struct xkb_events` (new):
@@ -313,8 +313,8 @@ libxkbcommon [1.14.0-beta1] – 2026-07-22
   in the mapping, if any, otherwise it is left unchanged.
 
   See the new API:
-  - `xkb_machine_builder::xkb_machine_builder_update_shortcut_mods()`
-  - `xkb_machine_builder::xkb_machine_builder_remap_shortcut_layout()`
+  - `xkb_machine_builder::xkb_machine_builder_update_shortcut_layout()`
+  - `struct` `xkb_machine_builder_shortcut_layout_update`
 
   ([#753](https://github.com/xkbcommon/libxkbcommon/issues/753))
 - Added `xkb_machine_builder::xkb_machine_builder_update_mods_remap()` to enable remapping

--- a/NEWS.md
+++ b/NEWS.md
@@ -236,7 +236,8 @@ libxkbcommon [1.14.0-beta1] – 2026-07-22
     - `xkb_machine_builder::xkb_machine_builder_new()`
     - `xkb_machine_builder::xkb_machine_builder_destroy()`
     - `xkb_machine_builder::xkb_machine_builder_get_keymap()`
-    - `xkb_machine_builder::xkb_machine_builder_update_a11y_flags()`
+    - `xkb_machine_builder::xkb_machine_builder_update_a11y()`,
+      `struct xkb_machine_builder_a11y_update`
     - `xkb_machine_builder::xkb_machine_builder_remap_mods()`
     - `xkb_machine_builder::xkb_machine_builder_update_shortcut_mods()`
     - `xkb_machine_builder::xkb_machine_builder_remap_shortcut_layout()`

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,7 +23,7 @@ libxkbcommon [1.14.0-beta1] – 2026-07-22
 [lenient keymap parser]: @ref XKB_KEYMAP_COMPILE_STRICT_MODE
 [keyboard overlays]: @ref key-behavior-overlay
 [reference layout for keyboard shortcuts]: @ref xkb_machine_builder::xkb_machine_builder_remap_shortcut_layout
-[modifier-remapping]: @ref xkb_machine_builder::xkb_machine_builder_remap_mods
+[modifier-remapping]: @ref xkb_machine_builder::xkb_machine_builder_update_mods_remap
 [sticky keys]: @ref XKB_KEYBOARD_CONTROL_A11Y_STICKY_KEYS
 
 ## Keymap text format
@@ -238,7 +238,8 @@ libxkbcommon [1.14.0-beta1] – 2026-07-22
     - `xkb_machine_builder::xkb_machine_builder_get_keymap()`
     - `xkb_machine_builder::xkb_machine_builder_update_a11y()`,
       `struct xkb_machine_builder_a11y_update`
-    - `xkb_machine_builder::xkb_machine_builder_remap_mods()`
+    - `xkb_machine_builder::xkb_machine_builder_update_mods_remap()`,
+      `struct xkb_machine_builder_mods_remap_update`
     - `xkb_machine_builder::xkb_machine_builder_update_shortcut_mods()`
     - `xkb_machine_builder::xkb_machine_builder_remap_shortcut_layout()`
   - `enum xkb_machine_builder_flags` (new)
@@ -316,7 +317,7 @@ libxkbcommon [1.14.0-beta1] – 2026-07-22
   - `xkb_machine_builder::xkb_machine_builder_remap_shortcut_layout()`
 
   ([#753](https://github.com/xkbcommon/libxkbcommon/issues/753))
-- Added `xkb_machine_builder::xkb_machine_builder_remap_mods()` to enable remapping
+- Added `xkb_machine_builder::xkb_machine_builder_update_mods_remap()` to enable remapping
   modifiers combos, e.g. to make `Control+Alt` map to `LevelThree` (`AltGr`).
   This helps improving *compatibility* across platforms.
   ([#914](https://github.com/xkbcommon/libxkbcommon/issues/914))

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -546,6 +546,14 @@ Nevertheless, the following snippet provide a minimal example to achieve it.
 
 @snippet "test/modifiers.c" xkb_keymap_mod_get_codes
 
+#### How to use Windows-style `AltGr`, i.e. remap `Control+Alt` to `LevelThree`?
+
+@figure@figcaption
+Remap `Control+Alt` to `LevelThree`.
+@endfigcaption
+@snippet "test/server-state.c" xkb_machine_builder_mods_remap_update_example
+@endfigure
+
 #### How to use keyboard shortcuts from a different layout?
 
 ##### The keyboard shortcuts mess

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -122,7 +122,7 @@ to encourage developers to implement the relevant [API][shortcuts-api].
 </dd>
 </dl>
 
-[shortcuts-api]: @ref xkb_machine_builder::xkb_machine_builder_remap_shortcut_layout
+[shortcuts-api]: @ref xkb_machine_builder::xkb_machine_builder_update_shortcut_layout
 [keycodes]: @ref keycode-def
 [keysyms]: @ref keysym-def
 
@@ -584,31 +584,8 @@ keyboard database, [xkeyboard-config].
 ##### Custom and consistent shortcuts behavior using libxkbcommon
 
 Since libxkbcommon 1.14, tweaking the keyboard shortcuts can be achieved by using
-the following functions from the `xkb_machine` API:
+`xkb_machine_builder::xkb_machine_builder_update_shortcut_layout()`.
 
-<dl>
-<dt>
-`xkb_machine_builder::xkb_machine_builder_update_shortcut_mods()`
-</dt>
-<dd>
-Set the modifiers that will trigger the shortcuts tweak, typically
-`Control+Alt+Super`.
-
-```c
-const xkb_mod_mask_t ctrl = xkb_keymap_mod_get_mask(keymap, XKB_MOD_NAME_CTRL);
-const xkb_mod_mask_t alt = xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_ALT);
-const xkb_mod_mask_t super = xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_SUPER);
-const xkb_mod_mask_t shortcuts_mask = ctrl | alt | super;
-if (xkb_machine_builder_update_shortcut_mods(options, shortcuts_mask, shortcuts_mask)) {
-    /* handle error */
-    …
-}
-```
-</dd>
-<dt>
-`xkb_machine_builder::xkb_machine_builder_remap_shortcut_layout()`
-</dt>
-<dd>
 Set the layout to use for shortcuts for each relevant layout. There are 2 typical
 use cases:
 
@@ -617,34 +594,27 @@ use cases:
 <dd>
 The user types with a single layout, but want the shortcuts to act as if using
 another layout: e.g. Qwerty shortcuts for the Arabic layout. The keymap would
-be configured with *2* layouts: the user layout then the shortcut layout (e.g.
-`ara,us`).
+actually be configured with *2* layouts: the user layout then the shortcut layout
+(e.g. `ara,us`).
 
-```c
-if (xkb_machine_builder_remap_shortcut_layout(options, 0, 1)) {
-    /* handle error */
-    …
-}
-```
+@figure@figcaption
+Example: substitute layout #0 with layout #1 when any of the modifiers
+`Control`, `Alt` and `Super` triggers shortcut overrides.
+@endfigcaption
+@snippet "test/server-state.c" shortcut_layout_update_example_1
+@endfigure
 </dd>
 <dt>*Multiple* layouts</dt>
 <dd>
 The user types with multiple layouts but wants shortcuts consistency across
 all the layouts, typically using the first layout as the reference.
 
-```c
-// When using shortcuts, all layouts will behave as if using the *first* layout.
-const xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(keymap);
-for (xkb_layout_index_t source = 1; source < num_layouts; source++) {
-    if (xkb_machine_builder_remap_shortcut_layout(options, source, 0)) {
-        /* handle error */
-        …
-    }
-}
-```
-</dd>
-</dl>
-
+@figure@figcaption
+Example: all layouts will behave as if using the *first* layout any of the
+modifiers `Control`, `Alt` and `Super` triggers shortcut overrides.
+@endfigcaption
+@snippet "test/server-state.c" shortcut_layout_update_example_2
+@endfigure
 </dd>
 </dl>
 

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -3341,57 +3341,123 @@ xkb_machine_builder_update_mods_remap(
 );
 
 /**
- * Set the modifiers that trigger the keyboard shortcut overrides.
+ * @struct xkb_machine_builder_shortcut_layout_update
+ * @ingroup abi-struct-contract
  *
- * When any of the specified modifiers is active, the effective layout
- * is substituted according to the mapping set by
- * `xkb_machine_builder_remap_shortcut_layout()`.
- * This ensures a consistent user experience with keyboard shortcuts
- * across the layouts.
+ * Update a layout substitution of the shortcut layout overrides for
+ * `xkb_machine_builder::xkb_machine_builder_update()`
  *
- * @param[in,out] builder The `xkb_machine` builder object to modify.
- * @param[in]     affect  Modifiers to consider, using their [encoding].
- * @param[in]     mask    Modifiers to set or unset, using their [encoding].
- *                        Modifiers in @p affect but not in @p mask are cleared.
- *                        Modifiers outside @p affect are not changed.
+ * When any of the specified modifiers (see #mods and #mods_affect) is active,
+ * the effective layout #source is substituted with layout #target in key
+ * processing. This ensures a consistent user experience with keyboard
+ * shortcuts across the layouts.
  *
- * @returns `::XKB_SUCCESS` on success, otherwise an error code.
+ * @figure@figcaption
+ * Example: substitute layout #0 with layout #1 when any of the modifiers
+ * `Control`, `Alt` and `Super` triggers shortcut overrides.
+ * @endfigcaption
+ * @snippet "test/server-state.c" shortcut_layout_update_example_1
+ * @endfigure
  *
- * @sa `xkb_machine_builder_remap_shortcut_layout()`
- * @sa `xkb_keymap::xkb_keymap_mod_get_mask2()`
+ * @figure@figcaption
+ * Example: all layouts will behave as if using the *first* layout any of the
+ * modifiers `Control`, `Alt` and `Super` triggers shortcut overrides.
+ * @endfigcaption
+ * @snippet "test/server-state.c" shortcut_layout_update_example_2
+ * @endfigure
+ *
+ * @figure@figcaption
+ * Example: substitute layout #0 with #2 for modifiers `Control` and `Alt`,
+ * substitute layout #1 with #3 for modifier `Super`.
+ * @endfigcaption
+ * @snippet "test/server-state.c" shortcut_layout_update_example_3
+ * @endfigure
+ *
+ * @sa `xkb_layout_index_t`
+ * @sa @ref modifiers-encoding
+ * @sa `xkb_machine_builder::xkb_machine_builder_update_shortcut_layout()`
+ *
  * @since 1.14.0
- * @memberof xkb_machine_builder
- *
- * [encoding]: @ref modifiers-encoding
  */
-XKB_EXPORT enum xkb_error_code
-xkb_machine_builder_update_shortcut_mods(struct xkb_machine_builder *builder,
-                                         xkb_mod_mask_t affect,
-                                         xkb_mod_mask_t mask);
+struct xkb_machine_builder_shortcut_layout_update {
+    /**
+     * Size of this structure in bytes.
+     *
+     * @sa @ref abi-struct-contract
+     *
+     * @since 1.14.0
+     */
+    uint32_t size;
+    /**
+     * Source layout to substitute.
+     *
+     * If set to `::XKB_LAYOUT_INVALID`, then #source and #target are ignored
+     * and all the active substitution entries are modified with the other
+     * fields.
+     *
+     * @since 1.14.0
+     */
+    xkb_layout_index_t source;
+    /**
+     * Target layout to substitute to #source when any of the specified
+     * modifiers (see #mods and #mods_affect) are active.
+     *
+     * If set to `::XKB_LAYOUT_INVALID` or #source, then the substitution is
+     * deactivated for layout #source.
+     *
+     * @since 1.14.0
+     */
+    xkb_layout_index_t target;
+    /**
+     * Modifiers to affected by the update, using their [encoding].
+     *
+     * If set to `0`, then #mods_affect and #mods are ignored.
+     *
+     * See #mods.
+     *
+     * @since 1.14.0
+     *
+     * [encoding]: @ref modifiers-encoding
+     */
+    xkb_mod_mask_t mods_affect;
+    /**
+     * Modifiers triggering the layout substitution, using their [encoding].
+     *
+     * - If there was no previous mapping (#source, #target):
+     *   - Modifiers in both #mods_affect and #mods are set.
+     * - Otherwise:
+     *   - Previous modifiers in #mods_affect but not in #mods are cleared.
+     *   - Previous modifiers outside #mods_affect are left unchanged.
+     *   - Modifiers in #mods_affect and #mods but not in previous modifiers
+     *     are added.
+     *
+     * @since 1.14.0
+     *
+     * [encoding]: @ref modifiers-encoding
+     */
+    xkb_mod_mask_t mods;
+};
 
 /**
- * Set a layout substitution for the shortcut layout override.
- *
- * When any modifier set via `xkb_machine_builder_update_shortcut_mods()` is
- * active, the effective layout @p source is substituted with layout @p target
- * in key processing. This allows shortcuts defined in layout @p target
- * (typically a Latin layout) to remain reachable when layout @p source is
- * active.
+ * Update layout substitution of the shortcut layout overrides for
+ * `xkb_machine_builder::xkb_machine_builder_update()`
  *
  * @param[in,out] builder The `xkb_machine` builder object to modify.
- * @param[in]     source  Source layout to substitute.
- * @param[in]     target  Target layout to use instead of @p source.
+ * @param[in]     update  Shortcut layout substitution update object.
  *
  * @returns `::XKB_SUCCESS` on success, otherwise an error code.
  *
+ * @sa `xkb_machine_builder_shortcut_layout_update`
+ *
  * @since 1.14.0
- * @sa `xkb_machine_builder_update_shortcut_mods()`
+ *
  * @memberof xkb_machine_builder
  */
 XKB_EXPORT enum xkb_error_code
-xkb_machine_builder_remap_shortcut_layout(struct xkb_machine_builder *builder,
-                                          xkb_layout_index_t source,
-                                          xkb_layout_index_t target);
+xkb_machine_builder_update_shortcut_layout(
+    struct xkb_machine_builder *builder,
+    const struct xkb_machine_builder_shortcut_layout_update *update
+);
 
 /**
  * Create a new keyboard state machine object.

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -3261,6 +3261,12 @@ xkb_machine_builder_update_a11y(
 );
 
 /**
+ * @struct xkb_machine_builder_mods_remap_update
+ * @ingroup abi-struct-contract
+ *
+ * Modifiers remapping update for
+ * `xkb_machine_builder::xkb_machine_builder_update_mods_remap()`
+ *
  * Remap a modifier combination, e.g. to make `Control+Alt` act as
  * `LevelThree` (`AltGr`). This helps improve *compatibility* across platforms.
  *
@@ -3274,42 +3280,64 @@ xkb_machine_builder_update_a11y(
  * - There is no other remapping entry with the source modifiers being a
  *   superset of this entry. E.g. `Control+Alt` has priority over `Control`.
  *
+ * @figure@figcaption
+ * Example: remap `Control+Alt` to `LevelThree`.
+ * @endfigcaption
+ * @snippet "test/server-state.c" xkb_machine_builder_mods_remap_update_example
+ * @endfigure
+ *
+ * @sa `xkb_keymap::xkb_keymap_mod_get_mask()`
+ * @sa `xkb_machine_builder::xkb_machine_builder_update_mods_remap()`
+ *
+ * @since 1.14.0
+ */
+struct xkb_machine_builder_mods_remap_update {
+    /**
+     * Size of this structure in bytes.
+     *
+     * @sa @ref abi-struct-contract
+     *
+     * @since 1.14.0
+     */
+    uint32_t size;
+    /**
+     * Modifier combination to remap, using their [encoding].
+     * Must be non-zero, unless both #source and #target are 0 to clear all
+     * entries.
+     *
+     * @since 1.14.0
+     *
+     * [encoding]: @ref modifiers-encoding
+     */
+    xkb_mod_mask_t source;
+    /**
+     * Modifier combination to remap to, using their [encoding], or 0 to remove
+     * the entry for #source. If both #source and #target are 0, all
+     * entries are cleared.
+     *
+     * @since 1.14.0
+     *
+     * [encoding]: @ref modifiers-encoding
+     */
+    xkb_mod_mask_t target;
+};
+
+/**
+ * Update the modifiers remapping of an `xkb_machine_builder` object.
+ *
  * @param[in,out] builder The `xkb_machine` builder object to modify.
- * @param[in]     source  Modifier combination to remap, using their [encoding].
- *                        Must be non-zero, unless both @p source and @p target
- *                        are 0 to clear all entries.
- * @param[in]     target  Modifier combination to remap to, using their
- *                        [encoding], or 0 to remove the entry for @p source.
- *                        If both @p source and @p target are 0, all entries are
- *                        cleared.
+ * @param[in]     update  Modifiers remapping update object.
  *
  * @returns `::XKB_SUCCESS` on success, otherwise an error code.
- *
- * Example:
- *
- * ```c
- * struct xkb_keymap *keymap = xkb_machine_builder_get_keymap(builder);
- * // Remap Control+Alt to LevelThree (AltGr)
- * const xkb_mod_mask_t ctrl = xkb_keymap_mod_get_mask(keymap, XKB_MOD_NAME_CTRL);
- * const xkb_mod_mask_t alt = xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_ALT);
- * const xkb_mod_mask_t level3 = xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_LEVEL3);
- * if (xkb_machine_builder_remap_mods(builder, ctrl | alt, level3)) {
- *     // handle error
- *     …
- * }
- * ```
  *
  * @since 1.14.0
  *
  * @memberof xkb_machine_builder
- *
- * [encoding]: @ref modifiers-encoding
  */
 XKB_EXPORT enum xkb_error_code
-xkb_machine_builder_remap_mods(
+xkb_machine_builder_update_mods_remap(
     struct xkb_machine_builder *builder,
-    xkb_mod_mask_t source,
-    xkb_mod_mask_t target
+    const struct xkb_machine_builder_mods_remap_update *update
 );
 
 /**

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -3122,8 +3122,7 @@ xkb_machine_builder_get_keymap(const struct xkb_machine_builder *builder);
 
 /**
  * @enum xkb_a11y_flags
- * Flags for
- * `xkb_machine_builder::xkb_machine_builder_update_a11y_flags()`.
+ * Flags for `xkb_machine_builder_a11y_update`.
  *
  * These flags configure the accessibility (*a11y*) features.
  *
@@ -3200,25 +3199,65 @@ enum xkb_a11y_flags {
 };
 
 /**
+ * @struct xkb_machine_builder_a11y_update
+ * @ingroup abi-struct-contract
+ *
+ * Accessibility update for
+ * `xkb_machine_builder::xkb_machine_builder_update_a11y()`
+ *
+ * @sa `xkb_a11y_flags`
+ * @sa `xkb_machine_builder::xkb_machine_builder_update_a11y()`
+ *
+ * @since 1.14.0
+ */
+struct xkb_machine_builder_a11y_update {
+    /**
+     * Size of this structure in bytes.
+     *
+     * @sa @ref abi-struct-contract
+     *
+     * @since 1.14.0
+     */
+    uint32_t size;
+    /**
+     * Mask of [accessibility flags] to modify.
+     *
+     * @since 1.14.0
+     *
+     * [accessibility flags]: @ref xkb_a11y_flags
+     */
+    uint32_t affect;
+    /**
+     * Mask of [accessibility flags] to to set or unset.
+     *
+     * Flags in #affect but not in #flags are cleared.
+     * Flags outside #affect are not changed.
+     *
+     * @since 1.14.0
+     *
+     * [accessibility flags]: @ref xkb_a11y_flags
+     */
+    uint32_t flags;
+};
+
+/**
  * Update the accessibility flags of an `xkb_machine_builder` object.
  *
  * @param[in,out] builder The `xkb_machine` builder object to modify.
- * @param[in]     affect  Accessibility flags to modify.
- * @param[in]     flags   Accessibility flags to set or unset.
- *                        Flags in @p affect but not in @p flags are cleared.
- *                        Flags outside @p affect are not changed.
+ * @param[in]     update  Accessibility update object.
  *
  * @returns `::XKB_SUCCESS` on success, otherwise an error code.
+ *
+ * @sa `xkb_machine_builder_a11y_update`
  *
  * @since 1.14.0
  *
  * @memberof xkb_machine_builder
  */
 XKB_EXPORT enum xkb_error_code
-xkb_machine_builder_update_a11y_flags(
+xkb_machine_builder_update_a11y(
     struct xkb_machine_builder *builder,
-    enum xkb_a11y_flags affect,
-    enum xkb_a11y_flags flags
+    const struct xkb_machine_builder_a11y_update *update
 );
 
 /**

--- a/src/abi-check.h
+++ b/src/abi-check.h
@@ -17,17 +17,13 @@ enum {
 };
 
 /**
- * Check that field `f` in compound type `T` must be contiguous with either
- * the next field (the 3rd argument) or the struct end (only 2 arguments).
+ * Check that field `f` in compound type `T` must be contiguous with either the
+ * next field (3rd argument) or the struct end (when using only 2 arguments).
  */
-#define assert_no_padding(T, f, ...) static_assert(\
-    offsetof(T, f) +                               \
-    sizeof(((T){0}).f) == sizeof(T)                \
-    __VA_OPT__(                                    \
-        - sizeof(T)                                \
-        + offsetof(T, __VA_ARGS__)                 \
-    ),                                             \
-    #T " has implicit padding after " #f           \
+#define assert_no_padding(T, f, ...) static_assert(      \
+    offsetof(T, f) + sizeof(((T){0}).f) ==               \
+    __VA_OPT__(offsetof(T, __VA_ARGS__) + 0 *) sizeof(T),\
+    #T " has implicit padding after " #f                 \
 )
 
 /**

--- a/src/state-priv.h
+++ b/src/state-priv.h
@@ -179,6 +179,35 @@ assert_same_field(struct xkb_machine_builder_a11y_update, _v1, flags);
 static_assert(sizeof(struct xkb_machine_builder_a11y_update) * 30 <=
               (size_t)XKB_ABI_MAX_SIZE, "");
 
+/**
+ * Version 1 of `xkb_machine_builder_mods_remap_update`, used for ABI check only
+ *
+ * @since 1.14.0
+ */
+struct xkb_machine_builder_mods_remap_update_v1 {
+    uint32_t size;
+    xkb_mod_mask_t source;
+    xkb_mod_mask_t target;
+};
+
+/* Ensure there is no implicit padding */
+assert_no_padding(struct xkb_machine_builder_mods_remap_update, size, source);
+assert_no_padding(struct xkb_machine_builder_mods_remap_update, source, target);
+assert_no_padding(struct xkb_machine_builder_mods_remap_update, target);
+
+/* Current version is 1 */
+static_assert(
+    sizeof(struct xkb_machine_builder_mods_remap_update) ==
+    sizeof(struct xkb_machine_builder_mods_remap_update_v1), ""
+);
+assert_same_field(struct xkb_machine_builder_mods_remap_update, _v1, size);
+assert_same_field(struct xkb_machine_builder_mods_remap_update, _v1, source);
+assert_same_field(struct xkb_machine_builder_mods_remap_update, _v1, target);
+
+/* Ensure reasonable margin to the upper size limit */
+static_assert(sizeof(struct xkb_machine_builder_mods_remap_update) * 30 <=
+              (size_t)XKB_ABI_MAX_SIZE, "");
+
 /** Size of the *first version* of the struct */
 #define xkb_versioned_struct_size_v1(x) _Generic(                 \
     (x),                                                          \
@@ -189,7 +218,9 @@ static_assert(sizeof(struct xkb_machine_builder_a11y_update) * 30 <=
     const struct xkb_layout_policy_update *:                      \
         sizeof(struct xkb_layout_policy_update_v1),               \
     const struct xkb_machine_builder_a11y_update *:               \
-        sizeof(struct xkb_machine_builder_a11y_update_v1)         \
+        sizeof(struct xkb_machine_builder_a11y_update_v1),        \
+    const struct xkb_machine_builder_mods_remap_update *:         \
+        sizeof(struct xkb_machine_builder_mods_remap_update_v1)   \
 )
 
 /** Minimal *current* valid size of the struct */
@@ -202,7 +233,9 @@ static_assert(sizeof(struct xkb_machine_builder_a11y_update) * 30 <=
     const struct xkb_layout_policy_update *:                      \
         sizeof(struct xkb_layout_policy_update_v1),               \
     const struct xkb_machine_builder_a11y_update *:               \
-        sizeof(struct xkb_machine_builder_a11y_update_v1)         \
+        sizeof(struct xkb_machine_builder_a11y_update_v1),        \
+    const struct xkb_machine_builder_mods_remap_update *:         \
+        sizeof(struct xkb_machine_builder_mods_remap_update_v1)   \
 )
 
 /** Offset of the last meaningful field of the current struct */
@@ -215,7 +248,9 @@ static_assert(sizeof(struct xkb_machine_builder_a11y_update) * 30 <=
     const struct xkb_layout_policy_update *:                     \
         sizeof(struct xkb_layout_policy_update),                 \
     const struct xkb_machine_builder_a11y_update *:              \
-        sizeof(struct xkb_machine_builder_a11y_update)           \
+        sizeof(struct xkb_machine_builder_a11y_update),          \
+    const struct xkb_machine_builder_mods_remap_update *:        \
+        sizeof(struct xkb_machine_builder_mods_remap_update)     \
 )
 
 #define xkb_check_update_size(x) xkb_check_versioned_struct_size( \
@@ -246,6 +281,11 @@ static_assert(
     xkb_versioned_struct_size_min(((const struct xkb_machine_builder_a11y_update *)NULL)),
     ""
 );
+static_assert(
+    xkb_versioned_struct_size_v1(((const struct xkb_machine_builder_mods_remap_update *)NULL)) <=
+    xkb_versioned_struct_size_min(((const struct xkb_machine_builder_mods_remap_update *)NULL)),
+    ""
+);
 
 /* Minimal size is lower or equal to the current size */
 static_assert(
@@ -266,6 +306,11 @@ static_assert(
 static_assert(
     xkb_versioned_struct_size_min(((const struct xkb_machine_builder_a11y_update *)NULL)) <=
     sizeof(const struct xkb_machine_builder_a11y_update),
+    ""
+);
+static_assert(
+    xkb_versioned_struct_size_min(((const struct xkb_machine_builder_mods_remap_update *)NULL)) <=
+    sizeof(const struct xkb_machine_builder_mods_remap_update),
     ""
 );
 

--- a/src/state-priv.h
+++ b/src/state-priv.h
@@ -185,6 +185,13 @@ static_assert(sizeof(struct xkb_state_update) * 30 <=
         sizeof(struct xkb_layout_policy_update)           \
 )
 
+#define xkb_check_update_size(x) xkb_check_versioned_struct_size( \
+    xkb_versioned_struct_size_v1(x),                              \
+    xkb_versioned_struct_size_min(x),                             \
+    xkb_versioned_struct_reserved_offset(x),                      \
+    (x)                                                           \
+)
+
 /* V1 is the smallest struct version */
 static_assert(
     xkb_versioned_struct_size_v1(((const struct xkb_state_update *)NULL)) <=

--- a/src/state-priv.h
+++ b/src/state-priv.h
@@ -152,37 +152,70 @@ assert_same_field(struct xkb_state_update, _v1, layout_policy);
 static_assert(sizeof(struct xkb_state_update) * 30 <=
               (size_t)XKB_ABI_MAX_SIZE, "");
 
+/**
+ * Version 1 of `xkb_machine_builder_a11y_update`, used for ABI check only
+ *
+ * @since 1.14.0
+ */
+struct xkb_machine_builder_a11y_update_v1 {
+    uint32_t size;
+    uint32_t affect;
+    uint32_t flags;
+};
+
+/* Ensure there is no implicit padding */
+assert_no_padding(struct xkb_machine_builder_a11y_update, size, affect);
+assert_no_padding(struct xkb_machine_builder_a11y_update, affect, flags);
+assert_no_padding(struct xkb_machine_builder_a11y_update, flags);
+
+/* Current version is 1 */
+static_assert(sizeof(struct xkb_machine_builder_a11y_update) ==
+              sizeof(struct xkb_machine_builder_a11y_update_v1), "");
+assert_same_field(struct xkb_machine_builder_a11y_update, _v1, size);
+assert_same_field(struct xkb_machine_builder_a11y_update, _v1, affect);
+assert_same_field(struct xkb_machine_builder_a11y_update, _v1, flags);
+
+/* Ensure reasonable margin to the upper size limit */
+static_assert(sizeof(struct xkb_machine_builder_a11y_update) * 30 <=
+              (size_t)XKB_ABI_MAX_SIZE, "");
+
 /** Size of the *first version* of the struct */
-#define xkb_versioned_struct_size_v1(x) _Generic(      \
-    (x),                                               \
-    const struct xkb_state_update *:                   \
-        sizeof(struct xkb_state_update_v1),            \
-    const struct xkb_state_components_update *:        \
-        sizeof(struct xkb_state_components_update_v1), \
-    const struct xkb_layout_policy_update *:           \
-        sizeof(struct xkb_layout_policy_update_v1)     \
+#define xkb_versioned_struct_size_v1(x) _Generic(                 \
+    (x),                                                          \
+    const struct xkb_state_update *:                              \
+        sizeof(struct xkb_state_update_v1),                       \
+    const struct xkb_state_components_update *:                   \
+        sizeof(struct xkb_state_components_update_v1),            \
+    const struct xkb_layout_policy_update *:                      \
+        sizeof(struct xkb_layout_policy_update_v1),               \
+    const struct xkb_machine_builder_a11y_update *:               \
+        sizeof(struct xkb_machine_builder_a11y_update_v1)         \
 )
 
 /** Minimal *current* valid size of the struct */
-#define xkb_versioned_struct_size_min(x) _Generic(     \
-    (x),                                               \
-    const struct xkb_state_update *:                   \
-        sizeof(struct xkb_state_update_v1),            \
-    const struct xkb_state_components_update *:        \
-        sizeof(struct xkb_state_components_update_v1), \
-    const struct xkb_layout_policy_update *:           \
-        sizeof(struct xkb_layout_policy_update_v1)     \
+#define xkb_versioned_struct_size_min(x) _Generic(                \
+    (x),                                                          \
+    const struct xkb_state_update *:                              \
+        sizeof(struct xkb_state_update_v1),                       \
+    const struct xkb_state_components_update *:                   \
+        sizeof(struct xkb_state_components_update_v1),            \
+    const struct xkb_layout_policy_update *:                      \
+        sizeof(struct xkb_layout_policy_update_v1),               \
+    const struct xkb_machine_builder_a11y_update *:               \
+        sizeof(struct xkb_machine_builder_a11y_update_v1)         \
 )
 
 /** Offset of the last meaningful field of the current struct */
-#define xkb_versioned_struct_reserved_offset(x) _Generic( \
-    (x),                                                  \
-    const struct xkb_state_update *:                      \
-        sizeof(struct xkb_state_update),                  \
-    const struct xkb_state_components_update *:           \
-        sizeof(struct xkb_state_components_update),       \
-    const struct xkb_layout_policy_update *:              \
-        sizeof(struct xkb_layout_policy_update)           \
+#define xkb_versioned_struct_reserved_offset(x) _Generic(        \
+    (x),                                                         \
+    const struct xkb_state_update *:                             \
+        sizeof(struct xkb_state_update),                         \
+    const struct xkb_state_components_update *:                  \
+        sizeof(struct xkb_state_components_update),              \
+    const struct xkb_layout_policy_update *:                     \
+        sizeof(struct xkb_layout_policy_update),                 \
+    const struct xkb_machine_builder_a11y_update *:              \
+        sizeof(struct xkb_machine_builder_a11y_update)           \
 )
 
 #define xkb_check_update_size(x) xkb_check_versioned_struct_size( \
@@ -208,6 +241,11 @@ static_assert(
     xkb_versioned_struct_size_min(((const struct xkb_layout_policy_update *)NULL)),
     ""
 );
+static_assert(
+    xkb_versioned_struct_size_v1(((const struct xkb_machine_builder_a11y_update *)NULL)) <=
+    xkb_versioned_struct_size_min(((const struct xkb_machine_builder_a11y_update *)NULL)),
+    ""
+);
 
 /* Minimal size is lower or equal to the current size */
 static_assert(
@@ -223,6 +261,11 @@ static_assert(
 static_assert(
     xkb_versioned_struct_size_min(((const struct xkb_layout_policy_update *)NULL)) <=
     sizeof(const struct xkb_layout_policy_update),
+    ""
+);
+static_assert(
+    xkb_versioned_struct_size_min(((const struct xkb_machine_builder_a11y_update *)NULL)) <=
+    sizeof(const struct xkb_machine_builder_a11y_update),
     ""
 );
 

--- a/src/state-priv.h
+++ b/src/state-priv.h
@@ -208,34 +208,71 @@ assert_same_field(struct xkb_machine_builder_mods_remap_update, _v1, target);
 static_assert(sizeof(struct xkb_machine_builder_mods_remap_update) * 30 <=
               (size_t)XKB_ABI_MAX_SIZE, "");
 
+/**
+ * Version 1 of `xkb_machine_builder_shortcut_layout_update`, used for ABI check only
+ *
+ * @since 1.14.0
+ */
+struct xkb_machine_builder_shortcut_layout_update_v1 {
+    uint32_t size;
+    xkb_layout_index_t source;
+    xkb_layout_index_t target;
+    xkb_mod_mask_t mods_affect;
+    xkb_mod_mask_t mods;
+};
+
+/* Ensure there is no implicit padding */
+assert_no_padding(struct xkb_machine_builder_shortcut_layout_update, size, source);
+assert_no_padding(struct xkb_machine_builder_shortcut_layout_update, source, target);
+assert_no_padding(struct xkb_machine_builder_shortcut_layout_update, target, mods_affect);
+assert_no_padding(struct xkb_machine_builder_shortcut_layout_update, mods_affect, mods);
+assert_no_padding(struct xkb_machine_builder_shortcut_layout_update, mods);
+
+/* Current version is 1 */
+static_assert(sizeof(struct xkb_machine_builder_shortcut_layout_update) ==
+              sizeof(struct xkb_machine_builder_shortcut_layout_update_v1), "");
+assert_same_field(struct xkb_machine_builder_shortcut_layout_update, _v1, size);
+assert_same_field(struct xkb_machine_builder_shortcut_layout_update, _v1, source);
+assert_same_field(struct xkb_machine_builder_shortcut_layout_update, _v1, target);
+assert_same_field(struct xkb_machine_builder_shortcut_layout_update, _v1, mods_affect);
+assert_same_field(struct xkb_machine_builder_shortcut_layout_update, _v1, mods);
+
+/* Ensure reasonable margin to the upper size limit */
+static_assert(sizeof(struct xkb_machine_builder_shortcut_layout_update) * 30 <=
+              (size_t)XKB_ABI_MAX_SIZE, "");
+
 /** Size of the *first version* of the struct */
-#define xkb_versioned_struct_size_v1(x) _Generic(                 \
-    (x),                                                          \
-    const struct xkb_state_update *:                              \
-        sizeof(struct xkb_state_update_v1),                       \
-    const struct xkb_state_components_update *:                   \
-        sizeof(struct xkb_state_components_update_v1),            \
-    const struct xkb_layout_policy_update *:                      \
-        sizeof(struct xkb_layout_policy_update_v1),               \
-    const struct xkb_machine_builder_a11y_update *:               \
-        sizeof(struct xkb_machine_builder_a11y_update_v1),        \
-    const struct xkb_machine_builder_mods_remap_update *:         \
-        sizeof(struct xkb_machine_builder_mods_remap_update_v1)   \
+#define xkb_versioned_struct_size_v1(x) _Generic(                   \
+    (x),                                                            \
+    const struct xkb_state_update *:                                \
+        sizeof(struct xkb_state_update_v1),                         \
+    const struct xkb_state_components_update *:                     \
+        sizeof(struct xkb_state_components_update_v1),              \
+    const struct xkb_layout_policy_update *:                        \
+        sizeof(struct xkb_layout_policy_update_v1),                 \
+    const struct xkb_machine_builder_a11y_update *:                 \
+        sizeof(struct xkb_machine_builder_a11y_update_v1),          \
+    const struct xkb_machine_builder_mods_remap_update *:           \
+        sizeof(struct xkb_machine_builder_mods_remap_update_v1),    \
+    const struct xkb_machine_builder_shortcut_layout_update *:      \
+        sizeof(struct xkb_machine_builder_shortcut_layout_update_v1)\
 )
 
 /** Minimal *current* valid size of the struct */
-#define xkb_versioned_struct_size_min(x) _Generic(                \
-    (x),                                                          \
-    const struct xkb_state_update *:                              \
-        sizeof(struct xkb_state_update_v1),                       \
-    const struct xkb_state_components_update *:                   \
-        sizeof(struct xkb_state_components_update_v1),            \
-    const struct xkb_layout_policy_update *:                      \
-        sizeof(struct xkb_layout_policy_update_v1),               \
-    const struct xkb_machine_builder_a11y_update *:               \
-        sizeof(struct xkb_machine_builder_a11y_update_v1),        \
-    const struct xkb_machine_builder_mods_remap_update *:         \
-        sizeof(struct xkb_machine_builder_mods_remap_update_v1)   \
+#define xkb_versioned_struct_size_min(x) _Generic(                  \
+    (x),                                                            \
+    const struct xkb_state_update *:                                \
+        sizeof(struct xkb_state_update_v1),                         \
+    const struct xkb_state_components_update *:                     \
+        sizeof(struct xkb_state_components_update_v1),              \
+    const struct xkb_layout_policy_update *:                        \
+        sizeof(struct xkb_layout_policy_update_v1),                 \
+    const struct xkb_machine_builder_a11y_update *:                 \
+        sizeof(struct xkb_machine_builder_a11y_update_v1),          \
+    const struct xkb_machine_builder_mods_remap_update *:           \
+        sizeof(struct xkb_machine_builder_mods_remap_update_v1),    \
+    const struct xkb_machine_builder_shortcut_layout_update *:      \
+        sizeof(struct xkb_machine_builder_shortcut_layout_update_v1)\
 )
 
 /** Offset of the last meaningful field of the current struct */
@@ -250,7 +287,9 @@ static_assert(sizeof(struct xkb_machine_builder_mods_remap_update) * 30 <=
     const struct xkb_machine_builder_a11y_update *:              \
         sizeof(struct xkb_machine_builder_a11y_update),          \
     const struct xkb_machine_builder_mods_remap_update *:        \
-        sizeof(struct xkb_machine_builder_mods_remap_update)     \
+        sizeof(struct xkb_machine_builder_mods_remap_update),    \
+    const struct xkb_machine_builder_shortcut_layout_update *:   \
+        sizeof(struct xkb_machine_builder_shortcut_layout_update)\
 )
 
 #define xkb_check_update_size(x) xkb_check_versioned_struct_size( \
@@ -286,6 +325,11 @@ static_assert(
     xkb_versioned_struct_size_min(((const struct xkb_machine_builder_mods_remap_update *)NULL)),
     ""
 );
+static_assert(
+    xkb_versioned_struct_size_v1(((const struct xkb_machine_builder_shortcut_layout_update *)NULL)) <=
+    xkb_versioned_struct_size_min(((const struct xkb_machine_builder_shortcut_layout_update *)NULL)),
+    ""
+);
 
 /* Minimal size is lower or equal to the current size */
 static_assert(
@@ -311,6 +355,11 @@ static_assert(
 static_assert(
     xkb_versioned_struct_size_min(((const struct xkb_machine_builder_mods_remap_update *)NULL)) <=
     sizeof(const struct xkb_machine_builder_mods_remap_update),
+    ""
+);
+static_assert(
+    xkb_versioned_struct_size_min(((const struct xkb_machine_builder_shortcut_layout_update *)NULL)) <=
+    sizeof(const struct xkb_machine_builder_shortcut_layout_update),
     ""
 );
 

--- a/src/state.c
+++ b/src/state.c
@@ -1872,13 +1872,6 @@ state_update_layout_policy(struct xkb_server_state *state,
     }
 }
 
-#define xkb_check_state_update_size(x) xkb_check_versioned_struct_size( \
-    xkb_versioned_struct_size_v1(x),                                    \
-    xkb_versioned_struct_size_min(x),                                   \
-    xkb_versioned_struct_reserved_offset(x),                            \
-    (x)                                                                 \
-)
-
 /* Check ABI compatibility */
 static enum xkb_error_code
 check_state_update_abi_(struct xkb_context * restrict ctx,
@@ -1886,12 +1879,12 @@ check_state_update_abi_(struct xkb_context * restrict ctx,
                         const struct xkb_state_update * restrict update)
 {
     enum xkb_error_code error = XKB_SUCCESS;
-    if ((error = xkb_check_state_update_size(update)) ||
+    if ((error = xkb_check_update_size(update)) ||
         (update->reserved0 != 0 && (error = XKB_ERROR_ABI_FORWARD_COMPAT)) ||
         (update->components &&
-         (error = xkb_check_state_update_size(update->components))) ||
+         (error = xkb_check_update_size(update->components))) ||
         (update->layout_policy &&
-         (error = xkb_check_state_update_size(update->layout_policy)))) {
+         (error = xkb_check_update_size(update->layout_policy)))) {
         xkb_log_abi_error(ctx, func, error);
     }
     return error;

--- a/src/state.c
+++ b/src/state.c
@@ -2720,6 +2720,13 @@ struct xkb_overlaid_key {
     int refcnt;
 };
 
+struct xkb_shortcuts_config_entry {
+    /** Real modifier mask to trigger shortcuts tweaks */
+    xkb_mod_mask_t mods;
+    /** Target layout */
+    xkb_layout_index_t target;
+};
+
 /*
  * `xkb_machine` have a similar role as the `xkb_state` state machine and is
  * indeed currently only a simple wrapper. However, having a separate type:
@@ -2774,10 +2781,8 @@ struct xkb_machine {
 
         /** Shortcuts tweak */
         struct machine_shortcuts_config {
-            /** Real modifier mask to trigger shortcuts tweaks */
-            xkb_mod_mask_t mask;
-            /** Layouts targets */
-            xkb_layout_index_t *targets;
+            /** Substitution entries */
+            struct xkb_shortcuts_config_entry *entries;
         } shortcuts;
     } config;
 };
@@ -2801,10 +2806,8 @@ struct xkb_machine_builder {
 
     /** Shortcuts tweak */
     struct xkb_shortcuts_config_options {
-        /** Modifier mask to trigger tweak */
-        xkb_mod_mask_t mask;
-        /** Target layouts targets */
-        darray(xkb_layout_index_t) targets;
+        /** Substitution entries */
+        darray(struct xkb_shortcuts_config_entry) entries;
     } shortcuts;
 
     enum xkb_machine_builder_flags flags;
@@ -2839,8 +2842,7 @@ xkb_machine_builder_new(struct xkb_keymap *keymap,
         },
         .mods = darray_new(),
         .shortcuts = {
-            .mask = 0,
-            .targets = darray_new(),
+            .entries = darray_new(),
         },
     };
 
@@ -2853,7 +2855,7 @@ xkb_machine_builder_destroy(struct xkb_machine_builder *builder)
     if (builder == NULL)
         return;
 
-    darray_free(builder->shortcuts.targets);
+    darray_free(builder->shortcuts.entries);
     darray_free(builder->mods);
     xkb_keymap_unref(builder->keymap);
     free(builder);
@@ -2964,67 +2966,95 @@ xkb_machine_builder_update_mods_remap(
 }
 
 enum xkb_error_code
-xkb_machine_builder_update_shortcut_mods(struct xkb_machine_builder *builder,
-                                         xkb_mod_mask_t affect,
-                                         xkb_mod_mask_t mask)
+xkb_machine_builder_update_shortcut_layout(
+    struct xkb_machine_builder * restrict builder,
+    const struct xkb_machine_builder_shortcut_layout_update * restrict update
+)
 {
+    struct xkb_keymap *keymap = builder->keymap;
+
     /* Check the modifiers against the keymap */
-    const xkb_mod_mask_t invalid = ~builder->keymap->canonical_state_mask;
-    if ((affect & invalid)) {
-        log_err(builder->keymap->ctx, XKB_ERROR_UNSUPPORTED_MODIFIER_MASK,
+    const xkb_mod_mask_t invalid = ~keymap->canonical_state_mask;
+    if ((update->mods_affect & invalid)) {
+        log_err(keymap->ctx, XKB_ERROR_UNSUPPORTED_MODIFIER_MASK,
                 "%s: Invalid affected modifiers: 0x%"PRIx32"\n",
-                __func__, affect);
+                __func__, update->mods_affect);
         return XKB_ERROR_UNSUPPORTED_MODIFIER_MASK;
     }
-    if ((mask & invalid)) {
-        log_err(builder->keymap->ctx, XKB_ERROR_UNSUPPORTED_MODIFIER_MASK,
+    if ((update->mods & invalid)) {
+        log_err(keymap->ctx, XKB_ERROR_UNSUPPORTED_MODIFIER_MASK,
                 "%s: Invalid modifiers: 0x%"PRIx32"\n",
-                __func__, mask);
+                __func__, update->mods);
         return XKB_ERROR_UNSUPPORTED_MODIFIER_MASK;
     }
 
-    builder->shortcuts.mask &= ~affect;
-    builder->shortcuts.mask |= (mask & affect);
-    return XKB_SUCCESS;
-}
-
-enum xkb_error_code
-xkb_machine_builder_remap_shortcut_layout(struct xkb_machine_builder *builder,
-                                          xkb_layout_index_t source,
-                                          xkb_layout_index_t target)
-{
-    if (source >= builder->keymap->num_groups) {
-        log_err(builder->keymap->ctx, XKB_ERROR_UNSUPPORTED_LAYOUT_INDEX_,
+    /* Check the layout indices against the keymap */
+    if (update->source >= keymap->num_groups &&
+        update->source != XKB_LAYOUT_INVALID) {
+        static_assert(XKB_LAYOUT_INVALID == UINT32_MAX, "integer overflow");
+        log_err(keymap->ctx, XKB_ERROR_UNSUPPORTED_LAYOUT_INDEX_,
                 "%s: Invalid source layout: "
                 "expected index in range 1..%"PRIu32", but got %"PRIu32"\n",
-                __func__, builder->keymap->num_groups, source + 1);
+                __func__, keymap->num_groups, update->source + 1);
         return XKB_ERROR_UNSUPPORTED_LAYOUT_INDEX;
     }
-    if (target >= builder->keymap->num_groups) {
-        log_err(builder->keymap->ctx, XKB_ERROR_UNSUPPORTED_LAYOUT_INDEX_,
+    if (update->target >= keymap->num_groups &&
+        update->target != XKB_LAYOUT_INVALID) {
+        static_assert(XKB_LAYOUT_INVALID == UINT32_MAX, "integer overflow");
+        log_err(keymap->ctx, XKB_ERROR_UNSUPPORTED_LAYOUT_INDEX_,
                 "%s: Invalid target layout: "
                 "expected index in range 1..%"PRIu32", but got %"PRIu32"\n",
-                __func__, builder->keymap->num_groups, target + 1);
+                __func__, keymap->num_groups, update->target + 1);
         return XKB_ERROR_UNSUPPORTED_LAYOUT_INDEX;
     }
 
     struct xkb_shortcuts_config_options * const config = &builder->shortcuts;
 
     /* Resize array & initialize new entries, if relevant */
-    if (source >= darray_size(config->targets)) {
-        if (target == source) {
+    if (update->source >= darray_size(config->entries) &&
+        update->source != XKB_LAYOUT_INVALID) {
+        if (update->target == update->source) {
             /* Skip default setting */
             return XKB_SUCCESS;
         }
-        xkb_layout_index_t new = darray_size(config->targets);
-        darray_resize(config->targets, source + 1);
-        for (; new < source; new++)
-            darray_item(config->targets, new) = XKB_LAYOUT_INVALID;
+        xkb_layout_index_t new = darray_size(config->entries);
+        darray_resize(config->entries, update->source + 1);
+        for (; new <= update->source; new++) {
+            darray_item(config->entries, new) =
+                (struct xkb_shortcuts_config_entry) {
+                    .target = XKB_LAYOUT_INVALID,
+                    .mods = 0
+                };
+        }
     }
 
-    darray_item(config->targets, source) = (source == target)
-        ? XKB_LAYOUT_INVALID
-        : target;
+    struct xkb_shortcuts_config_entry *entry;
+    xkb_layout_index_t source = (update->source == XKB_LAYOUT_INVALID)
+        ? 0               /* Loop over all entries */
+        : update->source; /* Single entry */
+    darray_foreach_from(entry, config->entries, source) {
+        if (update->source == XKB_LAYOUT_INVALID &&
+            entry->target == XKB_LAYOUT_INVALID) {
+            /* Skip previous deactivated entry */
+            source++;
+            continue;
+        }
+
+        if (update->mods_affect) {
+            entry->mods &= ~update->mods_affect;
+            entry->mods |= (update->mods_affect & update->mods);
+        }
+
+        if (update->source != XKB_LAYOUT_INVALID) {
+            entry->target = (update->target == source)
+                ? XKB_LAYOUT_INVALID
+                : update->target;
+            /* Single entry: exit loop */
+            break;
+        }
+        source++;
+    }
+
     return XKB_SUCCESS;
 }
 
@@ -3104,60 +3134,70 @@ machine_set_mods(struct xkb_machine *sm,
 }
 
 static bool
-machine_set_shortcuts(struct xkb_machine * restrict sm,
-                      const struct xkb_shortcuts_config_options * restrict options)
+machine_set_shortcuts(
+    struct xkb_machine * restrict sm,
+    const struct xkb_shortcuts_config_options * restrict options
+)
 {
-    if (darray_empty(options->targets)) {
+    if (darray_empty(options->entries)) {
         sm->config.shortcuts = (struct machine_shortcuts_config) {
-            .mask = 0,
-            .targets = NULL
+            .entries = NULL
         };
         return true;
     }
 
     struct xkb_keymap * const keymap = sm->base.base.keymap;
 
-    /* Consider only defined layouts */
-    xkb_layout_index_t count = MIN(
-        keymap->num_groups,
-        (xkb_layout_index_t) darray_size(options->targets)
-    );
-    /* Drop layout entries with default setting or invalid group */
-    static_assert(XKB_LAYOUT_INVALID > XKB_MAX_GROUPS, "");
-    while (count > 1) {
-        if (darray_item(options->targets, count - 1) <
-            keymap->num_groups)
-            break;
-        count--;
-    }
-    if (!count)
-        return true;
-
-    xkb_mod_mask_t mask = options->mask;
-    /* Sanitize mask */
-    mask &= sm->base.base.keymap->canonical_state_mask;
-    if (!mask)
-        return true;
-
-    xkb_layout_index_t * const targets = calloc(keymap->num_groups,
-                                                sizeof(*targets));
-    if (!targets)
+    struct xkb_shortcuts_config_entry * entries =
+        calloc(keymap->num_groups, sizeof(*entries));
+    if (!entries)
         return false;
 
+    const xkb_layout_index_t count = MIN(
+        keymap->num_groups,
+        (xkb_layout_index_t) darray_size(options->entries)
+    );
+
+    bool some_entries = false;
     for (xkb_layout_index_t l = 0; l < count; l++) {
-        /* Sanitize layouts targets */
-        targets[l] = (darray_item(options->targets, l) <
-                        keymap->num_groups)
-                        ? darray_item(options->targets, l)
-                        : XKB_LAYOUT_INVALID;
+        /* Sanitize layout target */
+        const xkb_layout_index_t target =
+            darray_item(options->entries, l).target;
+        /* Sanitize modifier mask */
+        const xkb_mod_mask_t mods = (
+            darray_item(options->entries, l).mods &
+            sm->base.base.keymap->canonical_state_mask
+        );
+        if (target < keymap->num_groups && target != l && mods) {
+            entries[l] = (struct xkb_shortcuts_config_entry) {
+                .target = target,
+                .mods = mods
+            };
+            some_entries = true;
+        } else {
+            entries[l] = (struct xkb_shortcuts_config_entry) {
+                .target = XKB_LAYOUT_INVALID,
+                .mods = 0
+            };
+            continue;
+        }
     }
-    for (xkb_layout_index_t l = count; l < keymap->num_groups; l++) {
-        targets[l] = XKB_LAYOUT_INVALID;
+
+    if (!some_entries) {
+        free(entries);
+        entries = NULL;
+    } else {
+        /* Initialize groups with no entries */
+        for (xkb_layout_index_t l = count; l < keymap->num_groups; l++) {
+            entries[l] = (struct xkb_shortcuts_config_entry) {
+                .target = XKB_LAYOUT_INVALID,
+                .mods = 0
+            };
+        }
     }
 
     sm->config.shortcuts = (struct machine_shortcuts_config) {
-        .mask = mask,
-        .targets = targets
+        .entries = entries
     };
     return true;
 }
@@ -3203,7 +3243,7 @@ xkb_machine_unref(struct xkb_machine *sm)
 
     xkb_state_destroy(&sm->base.base);
     darray_free(sm->overlays.keys);
-    free(sm->config.shortcuts.targets);
+    free(sm->config.shortcuts.entries);
     free(sm->config.modifiers.mappings);
     free(sm);
 }
@@ -3395,10 +3435,16 @@ do_shortcuts_tweak(const struct machine_shortcuts_config *config,
                    const struct state_components *previous_components,
                    struct xkb_events *events, ssize_t remap_event)
 {
-    if (config->targets &&
-        (state->components.mods & config->mask) &&
-        (config->targets[state->components.group] !=
-         XKB_LAYOUT_INVALID)) {
+    if (!config->entries) {
+        /* No shortcuts tweak */
+        return remap_event;
+    }
+
+    const struct xkb_shortcuts_config_entry * const entry =
+        &config->entries[state->components.group];
+
+    if (entry->target != XKB_LAYOUT_INVALID &&
+        (entry->mods & state->components.mods)) {
         /*
          * Activate shortcuts tweak:
          * 1. The real base group is saved by the caller, to be restored by
@@ -3424,7 +3470,7 @@ do_shortcuts_tweak(const struct machine_shortcuts_config *config,
                 darray_item(events->queue, remap_event).components.components;
         }
         new.components.base_group
-            = (int32_t) config->targets[state->components.group]
+            = (int32_t) entry->target
             - state->components.latched_group
             - state->components.locked_group;
         xkb_state_update_derived(&new);
@@ -3437,7 +3483,7 @@ do_shortcuts_tweak(const struct machine_shortcuts_config *config,
 
         state->components.group = new.components.group;
     } else {
-        /* No shortcuts tweak */
+        /* Deactivated entry or modifiers do not match */
     }
     return remap_event;
 }

--- a/src/state.c
+++ b/src/state.c
@@ -2867,30 +2867,36 @@ xkb_machine_builder_get_keymap(const struct xkb_machine_builder *builder)
 }
 
 enum xkb_error_code
-xkb_machine_builder_update_a11y_flags(
-    struct xkb_machine_builder *builder,
-    enum xkb_a11y_flags affect,
-    enum xkb_a11y_flags flags)
+xkb_machine_builder_update_a11y(
+    struct xkb_machine_builder * restrict builder,
+    const struct xkb_machine_builder_a11y_update * restrict update)
 {
+    /* Check ABI compatibility */
+    enum xkb_error_code error = xkb_check_update_size(update);
+    if (error) {
+        xkb_log_abi_error(builder->keymap->ctx, __func__, error);
+        return error;
+    }
+
     const enum xkb_a11y_flags invalid_flags =
         ~(enum xkb_a11y_flags)XKB_A11Y_FLAGS_VALUES;
 
-    if (affect & invalid_flags) {
-        log_err_func(builder->keymap->ctx, XKB_LOG_MESSAGE_NO_ID,
-                     "%s: unrecognized A11Y affected flags: %#x\n",
-                     __func__, affect & invalid_flags);
+    if (update->affect & invalid_flags) {
+        log_err(builder->keymap->ctx, XKB_LOG_MESSAGE_NO_ID,
+                "%s: unrecognized A11Y affected flags: %#x\n",
+                __func__, update->affect & invalid_flags);
         return XKB_ERROR_UNSUPPORTED_A11Y_FLAGS;
     }
-    if (flags & invalid_flags) {
-        log_err_func(builder->keymap->ctx, XKB_LOG_MESSAGE_NO_ID,
-                     "%s: unrecognized A11Y flags: %#x\n",
-                     __func__, flags & invalid_flags);
+    if (update->flags & invalid_flags) {
+        log_err(builder->keymap->ctx, XKB_LOG_MESSAGE_NO_ID,
+                "%s: unrecognized A11Y flags: %#x\n",
+                __func__, update->flags & invalid_flags);
         return XKB_ERROR_UNSUPPORTED_A11Y_FLAGS;
     }
 
-    builder->controls.a11y.affect |= affect;
-    builder->controls.a11y.flags &= ~affect;
-    builder->controls.a11y.flags |= (flags & affect);
+    builder->controls.a11y.affect |= update->affect;
+    builder->controls.a11y.flags &= ~update->affect;
+    builder->controls.a11y.flags |= (update->flags & update->affect);
 
     return XKB_SUCCESS;
 }

--- a/src/state.c
+++ b/src/state.c
@@ -2902,14 +2902,13 @@ xkb_machine_builder_update_a11y(
 }
 
 enum xkb_error_code
-xkb_machine_builder_remap_mods(
-    struct xkb_machine_builder *builder,
-    xkb_mod_mask_t source,
-    xkb_mod_mask_t target
+xkb_machine_builder_update_mods_remap(
+    struct xkb_machine_builder * restrict builder,
+    const struct xkb_machine_builder_mods_remap_update * restrict update
 )
 {
-    if (!source) {
-        if (!target) {
+    if (!update->source) {
+        if (!update->target) {
             /* Reset mappings */
             darray_resize(builder->mods, 0);
             return XKB_SUCCESS;
@@ -2920,41 +2919,41 @@ xkb_machine_builder_remap_mods(
 
     /* Check the modifiers against the keymap */
     const xkb_mod_mask_t invalid = ~builder->keymap->canonical_state_mask;
-    if ((source & invalid)) {
+    if ((update->source & invalid)) {
         log_err(builder->keymap->ctx, XKB_ERROR_UNSUPPORTED_MODIFIER_MASK,
                 "%s: Invalid source modifiers: 0x%"PRIx32"\n",
-                __func__, source);
+                __func__, update->source);
         return XKB_ERROR_UNSUPPORTED_MODIFIER_MASK;
     }
-    if ((target & invalid)) {
+    if ((update->target & invalid)) {
         log_err(builder->keymap->ctx, XKB_ERROR_UNSUPPORTED_MODIFIER_MASK,
                 "%s: Invalid target modifiers: 0x%"PRIx32"\n",
-                __func__, target);
+                __func__, update->target);
         return XKB_ERROR_UNSUPPORTED_MODIFIER_MASK;
     }
 
     struct machine_mods_mapping *mapping = NULL;
     darray_size_t m = 0;
     darray_enumerate(m, mapping, builder->mods) {
-        if (mapping->source == source) {
-            if (!target) {
+        if (mapping->source == update->source) {
+            if (!update->target) {
                 /* Remove mapping */
                 darray_remove(builder->mods, m);
             } else {
                 /* Update mapping */
-                mapping->target = target;
+                mapping->target = update->target;
             }
             return XKB_SUCCESS;
         }
     }
 
-    if (target) {
+    if (update->target) {
         /* Append new mapping */
         darray_append(
             builder->mods,
             (struct machine_mods_mapping) {
-                .source = source,
-                .target = target
+                .source = update->source,
+                .target = update->target
             }
         );
     } else {

--- a/test/server-state.c
+++ b/test/server-state.c
@@ -179,19 +179,32 @@ test_machine_builder(struct xkb_context *ctx)
         xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
     assert(builder);
 
+    struct xkb_machine_builder_a11y_update a11y_update = {
+        .size = sizeof(a11y_update)
+    };
+
     /* Valid flags */
     static_assert(XKB_A11Y_NO_FLAGS == 0, "default flags");
-    assert(xkb_machine_builder_update_a11y_flags(
-            builder, XKB_A11Y_NO_FLAGS, XKB_A11Y_NO_FLAGS) == XKB_SUCCESS);
+    a11y_update.affect = XKB_A11Y_NO_FLAGS;
+    a11y_update.flags = XKB_A11Y_NO_FLAGS;
+    assert(xkb_machine_builder_update_a11y(builder, &a11y_update) == XKB_SUCCESS);
 
     /* Invalid flags */
-    assert(xkb_machine_builder_update_a11y_flags(builder, -1000, 0) ==
+    a11y_update.affect = -1000;
+    a11y_update.flags = 0;
+    assert(xkb_machine_builder_update_a11y(builder, &a11y_update) ==
            XKB_ERROR_UNSUPPORTED_A11Y_FLAGS);
-    assert(xkb_machine_builder_update_a11y_flags(builder, 0, -1000) ==
+    a11y_update.affect = 0;
+    a11y_update.flags = -1000;
+    assert(xkb_machine_builder_update_a11y(builder, &a11y_update) ==
            XKB_ERROR_UNSUPPORTED_A11Y_FLAGS);
-    assert(xkb_machine_builder_update_a11y_flags(builder, 1000, 0) ==
+    a11y_update.affect = 1000;
+    a11y_update.flags = 0;
+    assert(xkb_machine_builder_update_a11y(builder, &a11y_update) ==
            XKB_ERROR_UNSUPPORTED_A11Y_FLAGS);
-    assert(xkb_machine_builder_update_a11y_flags(builder, 0, 1000) ==
+    a11y_update.affect = 0;
+    a11y_update.flags = 1000;
+    assert(xkb_machine_builder_update_a11y(builder, &a11y_update) ==
            XKB_ERROR_UNSUPPORTED_A11Y_FLAGS);
 
     struct xkb_machine *sm = xkb_machine_new(builder);
@@ -915,10 +928,13 @@ test_sticky_keys(struct xkb_context *ctx)
     struct xkb_machine_builder * const sm_builder =
         xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
     assert(sm_builder);
-    assert(xkb_machine_builder_update_a11y_flags(
-                sm_builder,
-                XKB_A11Y_STICKY_KEYS_LATCH_TO_LOCK,
-                XKB_A11Y_STICKY_KEYS_LATCH_TO_LOCK) == XKB_SUCCESS);
+    const struct xkb_machine_builder_a11y_update a11y_update = {
+        .size = sizeof(a11y_update),
+        .affect = XKB_A11Y_STICKY_KEYS_LATCH_TO_LOCK,
+        .flags = XKB_A11Y_STICKY_KEYS_LATCH_TO_LOCK
+    };
+    assert(xkb_machine_builder_update_a11y(sm_builder, &a11y_update) ==
+           XKB_SUCCESS);
     sm = xkb_machine_new(sm_builder);
     assert(sm);
     xkb_machine_builder_destroy(sm_builder);

--- a/test/server-state.c
+++ b/test/server-state.c
@@ -2152,7 +2152,12 @@ test_shortcuts_tweak(struct xkb_context *context)
      * Use modifiers tweak in addition to the shortcuts tweak
      */
 
-    assert(xkb_machine_builder_remap_mods(builder, ctrl | alt, level3) ==
+    const struct xkb_machine_builder_mods_remap_update mods_remap_update = {
+        .size = sizeof(mods_remap_update),
+        .source = ctrl | alt,
+        .target = level3
+    };
+    assert(xkb_machine_builder_update_mods_remap(builder, &mods_remap_update) ==
            XKB_SUCCESS);
 
     sm = xkb_machine_new(builder);
@@ -2630,16 +2635,34 @@ test_modifiers_tweak(struct xkb_context *context)
         xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
     assert(builder);
 
-    assert(xkb_machine_builder_remap_mods(builder, 0, 0) == XKB_SUCCESS);
-    assert(xkb_machine_builder_remap_mods(builder, 0, level3) ==
-           XKB_ERROR_UNSUPPORTED_MODIFIER_MASK);
-    assert(xkb_machine_builder_remap_mods(builder, scroll, alt) == XKB_SUCCESS);
-    assert(xkb_machine_builder_remap_mods(builder, super, level3) == XKB_SUCCESS);
-    assert(xkb_machine_builder_remap_mods(builder, alt, level5) == XKB_SUCCESS);
-    assert(xkb_machine_builder_remap_mods(builder, ctrl | alt, level3) == XKB_SUCCESS);
+    struct xkb_machine_builder_mods_remap_update update = {
+        .size = sizeof(update)
+    };
 
-    assert(xkb_machine_builder_remap_mods(builder, ctrl, shift) == XKB_SUCCESS);
-    assert(xkb_machine_builder_remap_mods(builder, ctrl, 0) == XKB_SUCCESS);
+    assert(xkb_machine_builder_update_mods_remap(builder, &update) == XKB_SUCCESS);
+    update.source = 0;
+    update.target = level3;
+    assert(xkb_machine_builder_update_mods_remap(builder, &update) ==
+           XKB_ERROR_UNSUPPORTED_MODIFIER_MASK);
+    update.source = scroll;
+    update.target = alt;
+    assert(xkb_machine_builder_update_mods_remap(builder, &update) == XKB_SUCCESS);
+    update.source = super;
+    update.target = level3;
+    assert(xkb_machine_builder_update_mods_remap(builder, &update) == XKB_SUCCESS);
+    update.source = alt;
+    update.target = level5;
+    assert(xkb_machine_builder_update_mods_remap(builder, &update) == XKB_SUCCESS);
+    update.source = ctrl | alt;
+    update.target = level3;
+    assert(xkb_machine_builder_update_mods_remap(builder, &update) == XKB_SUCCESS);
+
+    update.source = ctrl;
+    update.target = shift;
+    assert(xkb_machine_builder_update_mods_remap(builder, &update) == XKB_SUCCESS);
+    update.source = ctrl;
+    update.target = 0;
+    assert(xkb_machine_builder_update_mods_remap(builder, &update) == XKB_SUCCESS);
 
     struct xkb_machine * const sm = xkb_machine_new(builder);
     assert(sm);
@@ -3312,6 +3335,46 @@ test_modifiers_tweak(struct xkb_context *context)
     xkb_keymap_unref(keymap);
 }
 
+/* Example from the public header */
+static void
+test_xkb_machine_builder_mods_remap_update(struct xkb_context *context)
+{
+    struct xkb_keymap * const keymap_ =
+        test_compile_rules(context, XKB_KEYMAP_FORMAT_TEXT_V2,
+                           "evdev", "pc104", "us,de", ",T3",
+                           "grp:menu_toggle,grp:alt_caps_toggle,"
+                           "terminate:ctrl_alt_bksp,ctrl:copy");
+    assert(keymap_);
+
+    struct xkb_machine_builder *builder =
+        xkb_machine_builder_new(keymap_, XKB_MACHINE_BUILDER_NO_FLAGS);
+    assert(builder);
+
+    /* Use another variable `keymap` for the snippet */
+//! [xkb_machine_builder_mods_remap_update_example]
+    struct xkb_keymap *keymap = xkb_machine_builder_get_keymap(builder);
+
+    const xkb_mod_mask_t ctrl = xkb_keymap_mod_get_mask(keymap, XKB_MOD_NAME_CTRL);
+    const xkb_mod_mask_t alt = xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_ALT);
+    const xkb_mod_mask_t level3 = xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_LEVEL3);
+
+    const struct xkb_machine_builder_mods_remap_update update = {
+        .size = sizeof(update),
+        .source = ctrl | alt,
+        .target = level3
+    };
+    const enum xkb_error_code error =
+        xkb_machine_builder_update_mods_remap(builder, &update);
+    if (error != XKB_SUCCESS) {
+        // handle error
+        assert(!"error");
+    }
+//! [xkb_machine_builder_mods_remap_update_example]
+
+    xkb_machine_builder_destroy(builder);
+    xkb_keymap_unref(keymap_);
+}
+
 int
 main(void)
 {
@@ -3340,6 +3403,7 @@ main(void)
     test_overlays(context);
     test_modifiers_tweak(context);
     test_shortcuts_tweak(context);
+    test_xkb_machine_builder_mods_remap_update(context);
 
     xkb_context_unref(context);
     return EXIT_SUCCESS;

--- a/test/server-state.c
+++ b/test/server-state.c
@@ -28,6 +28,8 @@
 
 #define GOLDEN_TESTS_OUTPUTS "keymaps/"
 
+#define U(cp) (XKB_KEYSYM_UNICODE_OFFSET + (cp))
+
 static enum xkb_state_component
 xkb_state_update_enabled_controls(struct xkb_state *state,
                                   enum xkb_keyboard_control_flags affect,
@@ -1213,7 +1215,7 @@ test_shortcuts_tweak(struct xkb_context *context)
                            "grp:menu_toggle,grp:win_switch,ctrl:rctrl_latch,ctrl:copy");
     assert(keymap);
 
-    const xkb_mod_mask_t ctrl = UINT32_C(1) << XKB_MOD_INDEX_CTRL;
+    const xkb_mod_mask_t ctrl = _xkb_keymap_mod_get_mask(keymap, XKB_MOD_NAME_CTRL);
     const xkb_mod_mask_t alt = _xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_ALT);
     const xkb_mod_mask_t level3 = _xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_LEVEL3);
     const xkb_mod_mask_t level5 = _xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_LEVEL5);
@@ -1222,9 +1224,19 @@ test_shortcuts_tweak(struct xkb_context *context)
         xkb_machine_builder_new(keymap, XKB_MACHINE_BUILDER_NO_FLAGS);
     assert(builder);
 
-    assert(xkb_machine_builder_update_shortcut_mods(builder, ctrl, ctrl) == XKB_SUCCESS);
-    assert(xkb_machine_builder_remap_shortcut_layout(builder, 1, 2) == XKB_SUCCESS);
-    assert(xkb_machine_builder_remap_shortcut_layout(builder, 3, 0) == XKB_SUCCESS);
+    struct xkb_machine_builder_shortcut_layout_update update = {
+        .size = sizeof(update),
+    };
+    update.source = 1;
+    update.target = 2;
+    assert(xkb_machine_builder_update_shortcut_layout(builder, &update) == XKB_SUCCESS);
+    update.source = 3;
+    update.target = 0;
+    assert(xkb_machine_builder_update_shortcut_layout(builder, &update) == XKB_SUCCESS);
+    update.source = XKB_LAYOUT_INVALID;
+    update.mods_affect = ctrl;
+    update.mods = ctrl;
+    assert(xkb_machine_builder_update_shortcut_layout(builder, &update) == XKB_SUCCESS);
 
     struct xkb_machine * sm = xkb_machine_new(builder);
     assert(sm);
@@ -2672,8 +2684,6 @@ test_modifiers_tweak(struct xkb_context *context)
                                                             XKB_EVENTS_NO_FLAGS);
     assert(events);
 
-#define U(cp) (XKB_KEYSYM_UNICODE_OFFSET + (cp))
-
     assert(test_key_seq2(
         keymap, sm, events,
 
@@ -2730,8 +2740,6 @@ test_modifiers_tweak(struct xkb_context *context)
         KEY_Y       , BOTH, XKB_KEY_z             , NEXT,
         KEY_LEFTCTRL, UP  , XKB_KEY_Control_L     , FINISH
     ));
-
-#undef U
 
     const xkb_led_mask_t num_led =
         UINT32_C(1) << xkb_keymap_led_get_index(keymap, XKB_LED_NAME_NUM);
@@ -3375,6 +3383,279 @@ test_xkb_machine_builder_mods_remap_update(struct xkb_context *context)
     xkb_keymap_unref(keymap_);
 }
 
+/* Example from the public header */
+static void
+test_machine_builder_shortcut_layout_update(struct xkb_context *context)
+{
+    enum {
+        SHORTCUT_LAYOUT_UPDATE_EXAMPLE_1 = 0,
+        SHORTCUT_LAYOUT_UPDATE_EXAMPLE_2,
+        SHORTCUT_LAYOUT_UPDATE_EXAMPLE_3,
+        SHORTCUT_LAYOUT_UPDATE_EXAMPLE_COUNT
+    };
+    struct xkb_keymap *keymap_ = NULL;
+    struct xkb_machine_builder *builder = NULL;
+    static const struct {
+        xkb_keysym_t unmatched;
+        xkb_keysym_t ctrl_alt;
+        xkb_keysym_t super;
+        xkb_keysym_t some;
+    } ys[][2] = {
+        [SHORTCUT_LAYOUT_UPDATE_EXAMPLE_1] = {
+            {
+                .unmatched = XKB_KEY_z,
+                .ctrl_alt = XKB_KEY_y,
+                .super = XKB_KEY_y,
+                .some = XKB_KEY_y,
+            },
+            {
+                .unmatched = XKB_KEY_y,
+                .ctrl_alt = XKB_KEY_y,
+                .super = XKB_KEY_y,
+                .some = XKB_KEY_y,
+            }
+        },
+        [SHORTCUT_LAYOUT_UPDATE_EXAMPLE_2] = {
+            {
+                .unmatched = XKB_KEY_y,
+                .ctrl_alt = XKB_KEY_y,
+                .super = XKB_KEY_y,
+                .some = XKB_KEY_y,
+            },
+            {
+                .unmatched = XKB_KEY_z,
+                .ctrl_alt = XKB_KEY_y,
+                .super = XKB_KEY_y,
+                .some = XKB_KEY_y,
+            }
+        },
+        [SHORTCUT_LAYOUT_UPDATE_EXAMPLE_3] = {
+            {
+                .unmatched = XKB_KEY_f,
+                .ctrl_alt = XKB_KEY_y,
+                .super = XKB_KEY_f,
+                .some = XKB_KEY_y,
+            },
+            {
+                .unmatched = XKB_KEY_z,
+                .ctrl_alt = XKB_KEY_z,
+                .super = U(0x92c),
+                .some = U(0x92c),
+            }
+        },
+    };
+
+    for (int example = SHORTCUT_LAYOUT_UPDATE_EXAMPLE_1;
+         example < SHORTCUT_LAYOUT_UPDATE_EXAMPLE_COUNT;
+         example++) {
+        if (example == SHORTCUT_LAYOUT_UPDATE_EXAMPLE_1) {
+            keymap_ = test_compile_rules(context, XKB_KEYMAP_FORMAT_TEXT_V2,
+                                         "evdev", "pc104", "de,us", NULL,
+                                         "grp:menu_toggle");
+            assert(keymap_);
+
+            builder = xkb_machine_builder_new(keymap_,
+                                              XKB_MACHINE_BUILDER_NO_FLAGS);
+            assert(builder);
+
+/* Use another variable `keymap` for the snippet */
+//! [shortcut_layout_update_example_1]
+struct xkb_keymap *keymap = xkb_machine_builder_get_keymap(builder);
+
+const xkb_mod_mask_t ctrl = xkb_keymap_mod_get_mask(keymap, XKB_MOD_NAME_CTRL);
+const xkb_mod_mask_t alt = xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_ALT);
+const xkb_mod_mask_t super = xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_SUPER);
+const xkb_mod_mask_t mods = ctrl | alt | super;
+
+const struct xkb_machine_builder_shortcut_layout_update update = {
+    .size = sizeof(update),
+    .source = 0,
+    .target = 1,
+    .mods_affect = mods,
+    .mods = mods,
+};
+const enum xkb_error_code error =
+    xkb_machine_builder_update_shortcut_layout(builder, &update);
+if (error != XKB_SUCCESS) {
+    // handle error
+    assert(!"error");
+}
+//! [shortcut_layout_update_example_1]
+        }
+
+        if (example == SHORTCUT_LAYOUT_UPDATE_EXAMPLE_2) {
+            keymap_ = test_compile_rules(context, XKB_KEYMAP_FORMAT_TEXT_V2,
+                                         "evdev", "pc104", "us,de", NULL,
+                                         "grp:menu_toggle");
+            assert(keymap_);
+
+            builder = xkb_machine_builder_new(keymap_,
+                                              XKB_MACHINE_BUILDER_NO_FLAGS);
+            assert(builder);
+
+/* Use another variable `keymap` for the snippet */
+//! [shortcut_layout_update_example_2]
+struct xkb_keymap *keymap = xkb_machine_builder_get_keymap(builder);
+
+const xkb_mod_mask_t ctrl = xkb_keymap_mod_get_mask(keymap, XKB_MOD_NAME_CTRL);
+const xkb_mod_mask_t alt = xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_ALT);
+const xkb_mod_mask_t super = xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_SUPER);
+const xkb_mod_mask_t mods = ctrl | alt | super;
+
+const xkb_layout_index_t num_layouts = xkb_keymap_num_layouts(keymap);
+for (xkb_layout_index_t source = num_layouts; source-- > 1;) {
+    const struct xkb_machine_builder_shortcut_layout_update update = {
+        .size = sizeof(update),
+        .source = source,
+        .target = 0,
+        .mods_affect = mods,
+        .mods = mods,
+    };
+    const enum xkb_error_code error =
+        xkb_machine_builder_update_shortcut_layout(builder, &update);
+    if (error != XKB_SUCCESS) {
+        // handle error
+        assert(!"error");
+    }
+}
+//! [shortcut_layout_update_example_2]
+        }
+
+        if (example == SHORTCUT_LAYOUT_UPDATE_EXAMPLE_3) {
+            keymap_ = test_compile_rules(context, XKB_KEYMAP_FORMAT_TEXT_V2,
+                                         "evdev", "pc104", "us,de,us,in", "dvorak,,,",
+                                         "grp:menu_toggle");
+            assert(keymap_);
+
+            builder = xkb_machine_builder_new(keymap_,
+                                              XKB_MACHINE_BUILDER_NO_FLAGS);
+            assert(builder);
+
+/* Use another variable `keymap` for the snippet */
+//! [shortcut_layout_update_example_3]
+struct xkb_keymap *keymap = xkb_machine_builder_get_keymap(builder);
+
+const xkb_mod_mask_t ctrl = xkb_keymap_mod_get_mask(keymap, XKB_MOD_NAME_CTRL);
+const xkb_mod_mask_t alt = xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_ALT);
+const xkb_mod_mask_t super = xkb_keymap_mod_get_mask(keymap, XKB_VMOD_NAME_SUPER);
+
+struct xkb_machine_builder_shortcut_layout_update update = {
+    .size = sizeof(update),
+    .source = 0,
+    .target = 2,
+    .mods_affect = ctrl | alt,
+    .mods = ctrl | alt,
+};
+enum xkb_error_code error =
+    xkb_machine_builder_update_shortcut_layout(builder, &update);
+if (error != XKB_SUCCESS) {
+    // handle error
+    assert(!"error");
+}
+update = (struct xkb_machine_builder_shortcut_layout_update) {
+    .size = sizeof(update),
+    .source = 1,
+    .target = 3,
+    .mods_affect = super,
+    .mods = super,
+};
+error = xkb_machine_builder_update_shortcut_layout(builder, &update);
+if (error != XKB_SUCCESS) {
+    // handle error
+    assert(!"error");
+}
+//! [shortcut_layout_update_example_3]
+        }
+
+        struct xkb_machine * sm = xkb_machine_new(builder);
+        assert(sm);
+
+        struct xkb_events * const events =
+            xkb_events_new_batch(context, XKB_EVENTS_NO_FLAGS);
+        assert(events);
+
+        assert(test_key_seq2(
+            keymap_, sm, events,
+            /* Layout #0 */
+            KEY_Y        , BOTH, ys[example][0].unmatched, NEXT,
+            KEY_LEFTSHIFT, DOWN, XKB_KEY_Shift_L         , NEXT,
+            KEY_Y        , BOTH, xkb_keysym_to_upper(ys[example][0].unmatched), NEXT,
+            KEY_LEFTSHIFT, UP  , XKB_KEY_Shift_L         , NEXT,
+            KEY_Y        , BOTH, ys[example][0].unmatched, NEXT,
+            KEY_LEFTCTRL , DOWN, XKB_KEY_Control_L       , NEXT,
+            KEY_Y        , BOTH, ys[example][0].ctrl_alt , NEXT,
+            KEY_LEFTCTRL , UP  , XKB_KEY_Control_L       , NEXT,
+            KEY_Y        , BOTH, ys[example][0].unmatched, NEXT,
+            KEY_LEFTALT  , DOWN, XKB_KEY_Alt_L           , NEXT,
+            KEY_Y        , BOTH, ys[example][0].ctrl_alt , NEXT,
+            KEY_LEFTALT  , UP  , XKB_KEY_Alt_L           , NEXT,
+            KEY_Y        , BOTH, ys[example][0].unmatched, NEXT,
+            KEY_LEFTMETA , DOWN, XKB_KEY_Super_L         , NEXT,
+            KEY_Y        , BOTH, ys[example][0].super    , NEXT,
+            KEY_LEFTMETA , UP  , XKB_KEY_Super_L         , NEXT,
+            KEY_Y        , BOTH, ys[example][0].unmatched, NEXT,
+            KEY_LEFTCTRL , DOWN, XKB_KEY_Control_L       , NEXT,
+            KEY_Y        , BOTH, ys[example][0].ctrl_alt , NEXT,
+            KEY_LEFTSHIFT, DOWN, XKB_KEY_Shift_L         , NEXT,
+            KEY_Y        , BOTH, xkb_keysym_to_upper(ys[example][0].ctrl_alt), NEXT,
+            KEY_LEFTSHIFT, UP  , XKB_KEY_Shift_L         , NEXT,
+            KEY_Y        , BOTH, ys[example][0].ctrl_alt , NEXT,
+            KEY_LEFTALT  , DOWN, XKB_KEY_Alt_L           , NEXT,
+            KEY_Y        , BOTH, ys[example][0].ctrl_alt , NEXT,
+            KEY_LEFTALT  , UP  , XKB_KEY_Alt_L           , NEXT,
+            KEY_Y        , BOTH, ys[example][0].ctrl_alt , NEXT,
+            KEY_LEFTMETA , DOWN, XKB_KEY_Super_L         , NEXT,
+            KEY_Y        , BOTH, ys[example][0].some     , NEXT,
+            KEY_LEFTMETA , UP  , XKB_KEY_Super_L         , NEXT,
+            KEY_Y        , BOTH, ys[example][0].ctrl_alt , NEXT,
+            KEY_LEFTCTRL , UP  , XKB_KEY_Control_L       , NEXT,
+            KEY_Y        , BOTH, ys[example][0].unmatched, NEXT,
+
+            KEY_COMPOSE , BOTH, XKB_KEY_ISO_Next_Group, NEXT,
+
+            /* Layout #1 */
+            KEY_Y        , BOTH, ys[example][1].unmatched, NEXT,
+            KEY_LEFTSHIFT, DOWN, XKB_KEY_Shift_L         , NEXT,
+            KEY_Y        , BOTH, xkb_keysym_to_upper(ys[example][1].unmatched), NEXT,
+            KEY_LEFTSHIFT, UP  , XKB_KEY_Shift_L         , NEXT,
+            KEY_Y        , BOTH, ys[example][1].unmatched, NEXT,
+            KEY_LEFTCTRL , DOWN, XKB_KEY_Control_L       , NEXT,
+            KEY_Y        , BOTH, ys[example][1].ctrl_alt , NEXT,
+            KEY_LEFTCTRL , UP  , XKB_KEY_Control_L       , NEXT,
+            KEY_Y        , BOTH, ys[example][1].unmatched, NEXT,
+            KEY_LEFTALT  , DOWN, XKB_KEY_Alt_L           , NEXT,
+            KEY_Y        , BOTH, ys[example][1].ctrl_alt , NEXT,
+            KEY_LEFTALT  , UP  , XKB_KEY_Alt_L           , NEXT,
+            KEY_Y        , BOTH, ys[example][1].unmatched, NEXT,
+            KEY_LEFTMETA , DOWN, XKB_KEY_Super_L         , NEXT,
+            KEY_Y        , BOTH, ys[example][1].super    , NEXT,
+            KEY_LEFTMETA , UP  , XKB_KEY_Super_L         , NEXT,
+            KEY_Y        , BOTH, ys[example][1].unmatched, NEXT,
+            KEY_LEFTCTRL , DOWN, XKB_KEY_Control_L       , NEXT,
+            KEY_Y        , BOTH, ys[example][1].ctrl_alt , NEXT,
+            KEY_LEFTSHIFT, DOWN, XKB_KEY_Shift_L         , NEXT,
+            KEY_Y        , BOTH, xkb_keysym_to_upper(ys[example][1].ctrl_alt), NEXT,
+            KEY_LEFTSHIFT, UP  , XKB_KEY_Shift_L         , NEXT,
+            KEY_Y        , BOTH, ys[example][1].ctrl_alt , NEXT,
+            KEY_LEFTALT  , DOWN, XKB_KEY_Alt_L           , NEXT,
+            KEY_Y        , BOTH, ys[example][1].ctrl_alt , NEXT,
+            KEY_LEFTALT  , UP  , XKB_KEY_Alt_L           , NEXT,
+            KEY_Y        , BOTH, ys[example][1].ctrl_alt , NEXT,
+            KEY_LEFTMETA , DOWN, XKB_KEY_Super_L         , NEXT,
+            KEY_Y        , BOTH, ys[example][1].some     , NEXT,
+            KEY_LEFTMETA , UP  , XKB_KEY_Super_L         , NEXT,
+            KEY_Y        , BOTH, ys[example][1].ctrl_alt , NEXT,
+            KEY_LEFTCTRL , UP  , XKB_KEY_Control_L       , NEXT,
+            KEY_Y        , BOTH, ys[example][1].unmatched, FINISH
+        ));
+
+        xkb_events_destroy(events);
+        xkb_machine_unref(sm);
+        xkb_machine_builder_destroy(builder);
+        xkb_keymap_unref(keymap_);
+    }
+}
+
 int
 main(void)
 {
@@ -3404,6 +3685,7 @@ main(void)
     test_modifiers_tweak(context);
     test_shortcuts_tweak(context);
     test_xkb_machine_builder_mods_remap_update(context);
+    test_machine_builder_shortcut_layout_update(context);
 
     xkb_context_unref(context);
     return EXIT_SUCCESS;

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -1548,9 +1548,13 @@ xkb_machine_builder_new_from_options(struct xkb_keymap *keymap,
     if (!builder)
         return NULL;
 
-    if ((unsigned)(xkb_machine_builder_update_a11y_flags(
-            builder, options->controls.a11y.affect, options->controls.a11y.flags
-        ) != XKB_SUCCESS) |
+    const struct xkb_machine_builder_a11y_update a11y_update = {
+        .size = sizeof(a11y_update),
+        .affect = options->controls.a11y.affect,
+        .flags = options->controls.a11y.flags
+    };
+    if ((unsigned)(xkb_machine_builder_update_a11y(builder, &a11y_update) !=
+                   XKB_SUCCESS) |
         (unsigned)!tools_set_modifiers_mappings(options, builder) |
         (unsigned)!tools_set_shortcuts_mask(options, builder) |
         (unsigned)!tools_set_shortcuts_mappings(options, builder)) {

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -1375,7 +1375,12 @@ tools_set_modifiers_mappings(const struct xkb_machine_options *options,
             continue;
         }
 
-        if (xkb_machine_builder_remap_mods(builder, source, target) !=
+        const struct xkb_machine_builder_mods_remap_update update = {
+            .size = sizeof(update),
+            .source = source,
+            .target = target
+        };
+        if (xkb_machine_builder_update_mods_remap(builder, &update) !=
             XKB_SUCCESS) {
             fprintf(stderr,
                     "ERROR: cannot add modifiers mapping: "

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -1416,13 +1416,19 @@ tools_set_shortcuts_mask(const struct xkb_machine_options *options,
                          struct xkb_machine_builder *builder)
 {
     struct xkb_keymap *keymap = xkb_machine_builder_get_keymap(builder);
-    xkb_mod_mask_t mask = 0;
+    xkb_mod_mask_t mods = 0;
 
-    return (
-        tools_parse_mod_mask(keymap, &options->shortcuts.mask,
-                             "shortcut modifier mask", &mask) &&
-        !xkb_machine_builder_update_shortcut_mods(builder, mask, mask)
-    );
+    if (!tools_parse_mod_mask(keymap, &options->shortcuts.mask,
+                             "shortcut modifier mask", &mods))
+        return false;
+    const struct xkb_machine_builder_shortcut_layout_update update = {
+        .size = sizeof(update),
+        .source = XKB_LAYOUT_INVALID,
+        .mods_affect = mods,
+        .mods = mods
+    };
+    return (xkb_machine_builder_update_shortcut_layout(builder, &update) !=
+            XKB_SUCCESS);
 }
 
 static int
@@ -1531,8 +1537,13 @@ tools_set_shortcuts_mappings(const struct xkb_machine_options *options,
     darray_enumerate(source, target, options->shortcuts.mappings) {
         if (*target == XKB_LAYOUT_INVALID)
             continue;
+        const struct xkb_machine_builder_shortcut_layout_update update = {
+            .size = sizeof(update),
+            .source = source,
+            .target = *target,
+        };
         const enum xkb_error_code error =
-            xkb_machine_builder_remap_shortcut_layout(builder, source, *target);
+            xkb_machine_builder_update_shortcut_layout(builder, &update);
         if (error != XKB_SUCCESS) {
             fprintf(stderr,
                     "ERROR %d: cannot add shortcuts layout mapping: "
@@ -1561,8 +1572,8 @@ xkb_machine_builder_new_from_options(struct xkb_keymap *keymap,
     if ((unsigned)(xkb_machine_builder_update_a11y(builder, &a11y_update) !=
                    XKB_SUCCESS) |
         (unsigned)!tools_set_modifiers_mappings(options, builder) |
-        (unsigned)!tools_set_shortcuts_mask(options, builder) |
-        (unsigned)!tools_set_shortcuts_mappings(options, builder)) {
+        (unsigned)!tools_set_shortcuts_mappings(options, builder) |
+        (unsigned)!tools_set_shortcuts_mask(options, builder)) {
             xkb_machine_builder_destroy(builder);
             return NULL;
     }

--- a/xkbcommon.map
+++ b/xkbcommon.map
@@ -164,8 +164,7 @@ global:
     xkb_machine_builder_get_keymap;
     xkb_machine_builder_update_a11y;
     xkb_machine_builder_update_mods_remap;
-    xkb_machine_builder_update_shortcut_mods;
-    xkb_machine_builder_remap_shortcut_layout;
+    xkb_machine_builder_update_shortcut_layout;
     xkb_machine_new;
     xkb_machine_ref;
     xkb_machine_unref;

--- a/xkbcommon.map
+++ b/xkbcommon.map
@@ -163,7 +163,7 @@ global:
     xkb_machine_builder_destroy;
     xkb_machine_builder_get_keymap;
     xkb_machine_builder_update_a11y;
-    xkb_machine_builder_remap_mods;
+    xkb_machine_builder_update_mods_remap;
     xkb_machine_builder_update_shortcut_mods;
     xkb_machine_builder_remap_shortcut_layout;
     xkb_machine_new;

--- a/xkbcommon.map
+++ b/xkbcommon.map
@@ -162,7 +162,7 @@ global:
     xkb_machine_builder_new;
     xkb_machine_builder_destroy;
     xkb_machine_builder_get_keymap;
-    xkb_machine_builder_update_a11y_flags;
+    xkb_machine_builder_update_a11y;
     xkb_machine_builder_remap_mods;
     xkb_machine_builder_update_shortcut_mods;
     xkb_machine_builder_remap_shortcut_layout;


### PR DESCRIPTION
Use extensible structs instead of just functions with no possible future extension.