### PR TITLE
fix: Use automatically generated masks to check flags

### DIFF
--- a/src/compose/state.c
+++ b/src/compose/state.c
@@ -8,9 +8,10 @@
 #include <assert.h>
 
 #include "context.h"
+#include "features/enums.h"
+#include "keysym.h"
 #include "table.h"
 #include "utils.h"
-#include "keysym.h"
 
 struct xkb_compose_state {
     int refcnt;
@@ -34,13 +35,12 @@ struct xkb_compose_state *
 xkb_compose_state_new(struct xkb_compose_table *table,
                       enum xkb_compose_state_flags flags)
 {
-    static const enum xkb_compose_state_flags XKB_COMPOSE_STATE_FLAGS =
-        XKB_COMPOSE_STATE_NO_FLAGS;
-
-    if (flags & ~XKB_COMPOSE_STATE_FLAGS) {
+    const enum xkb_compose_state_flags invalid_flags =
+        (flags & ~(enum xkb_compose_state_flags)XKB_COMPOSE_STATE_FLAGS_VALUES);
+    if (invalid_flags) {
         log_err_func(table->ctx, XKB_LOG_MESSAGE_NO_ID,
                      "Unsupported compose state flags: %#x\n",
-                     (flags & ~XKB_COMPOSE_STATE_FLAGS));
+                     invalid_flags);
         return NULL;
     }
 

--- a/src/compose/table.c
+++ b/src/compose/table.c
@@ -8,12 +8,13 @@
 #include <assert.h>
 
 #include "xkbcommon/xkbcommon.h"
-#include "messages-codes.h"
-#include "utils.h"
+#include "features/enums.h"
 #include "constants.h"
-#include "table.h"
+#include "messages-codes.h"
 #include "parser.h"
 #include "paths.h"
+#include "table.h"
+#include "utils.h"
 
 static struct xkb_compose_table *
 xkb_compose_table_new(struct xkb_context *ctx, const char *func,
@@ -21,13 +22,12 @@ xkb_compose_table_new(struct xkb_context *ctx, const char *func,
                       enum xkb_compose_format format,
                       enum xkb_compose_compile_flags flags)
 {
-    static const enum xkb_compose_compile_flags XKB_COMPOSE_COMPILE_FLAGS =
-        XKB_COMPOSE_COMPILE_NO_FLAGS;
-
-    if (flags & ~XKB_COMPOSE_COMPILE_FLAGS) {
+    const enum xkb_compose_compile_flags invalid_flags = (
+        flags & ~(enum xkb_compose_compile_flags)XKB_COMPOSE_COMPILE_FLAGS_VALUES
+    );
+    if (invalid_flags) {
         log_err(ctx, XKB_LOG_MESSAGE_NO_ID,
-                "%s: unrecognized flags: %#x\n", func,
-                (flags & ~XKB_COMPOSE_COMPILE_FLAGS));
+                "%s: unrecognized flags: %#x\n", func, invalid_flags);
         return NULL;
     }
 

--- a/src/context.c
+++ b/src/context.c
@@ -25,6 +25,7 @@
 #include "xkbcommon/xkbcommon.h"
 #include "context.h"
 #include "darray.h"
+#include "features/enums.h"
 #include "messages-codes.h"
 #include "utils.h"
 
@@ -501,15 +502,11 @@ xkb_context_new(enum xkb_context_flags flags)
     ctx->log_level = XKB_LOG_LEVEL_ERROR;
     ctx->log_verbosity = XKB_LOG_VERBOSITY_DEFAULT;
 
-    static const enum xkb_context_flags XKB_CONTEXT_FLAGS
-        = XKB_CONTEXT_NO_DEFAULT_INCLUDES
-        | XKB_CONTEXT_NO_ENVIRONMENT_NAMES
-        | XKB_CONTEXT_NO_SECURE_GETENV;
-
-    if (flags & ~XKB_CONTEXT_FLAGS) {
-        log_err(ctx, XKB_LOG_MESSAGE_NO_ID,
-                "Invalid context flags: 0x%x\n",
-                (flags & ~XKB_CONTEXT_FLAGS));
+    const enum xkb_context_flags invalid_flags =
+        (flags & ~(enum xkb_context_flags)XKB_CONTEXT_FLAGS_VALUES);
+    if (invalid_flags) {
+        log_err_func(ctx, XKB_LOG_MESSAGE_NO_ID,
+                     "Invalid context flags: 0x%x\n", invalid_flags);
         free(ctx);
         return NULL;
     }

--- a/src/keymap-priv.c
+++ b/src/keymap-priv.c
@@ -50,13 +50,13 @@ xkb_keymap_new(struct xkb_context *ctx, const char *func,
                enum xkb_keymap_format format,
                enum xkb_keymap_compile_flags flags)
 {
-    static const enum xkb_keymap_compile_flags XKB_KEYMAP_COMPILE_FLAGS =
-        (enum xkb_keymap_compile_flags) XKB_KEYMAP_COMPILE_FLAGS_VALUES;
-
-    if (flags & ~XKB_KEYMAP_COMPILE_FLAGS) {
+    const enum xkb_keymap_compile_flags invalid_flags = (
+        flags & ~(enum xkb_keymap_compile_flags)XKB_KEYMAP_COMPILE_FLAGS_VALUES
+    );
+    if (invalid_flags) {
         log_err(ctx, XKB_LOG_MESSAGE_NO_ID,
-                "%s: unrecognized keymap compilation flags: 0x%x\n", func,
-                (flags & ~XKB_KEYMAP_COMPILE_FLAGS));
+                "%s: unrecognized keymap compilation flags: 0x%x\n",
+                func, invalid_flags);
         return NULL;
     }
 

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -279,21 +279,22 @@ xkb_keymap_serialize(const struct xkb_keymap *keymap,
                      struct xkb_keymap_serialize_result *result)
 {
     /* Check ABI compatibility */
-    enum xkb_error_code error =
+    const enum xkb_error_code error =
         check_keymap_serialize_abi(keymap->ctx, __func__, config, result);
     if (error)
         return error;
 
     struct xkb_keymap_serialize_config new_config = *config;
 
-    static const enum xkb_keymap_serialize_flags XKB_KEYMAP_SERIALIZE_FLAGS
-        = (enum xkb_keymap_serialize_flags) XKB_KEYMAP_SERIALIZE_FLAGS_VALUES;
-
-    if (new_config.flags & ~XKB_KEYMAP_SERIALIZE_FLAGS) {
+    const enum xkb_keymap_serialize_flags invalid_flags = (
+        new_config.flags &
+        ~(enum xkb_keymap_serialize_flags)XKB_KEYMAP_SERIALIZE_FLAGS_VALUES
+    );
+    if (invalid_flags) {
         log_err_func(keymap->ctx,
                      XKB_ERROR_UNSUPPORTED_KEYMAP_SERIALIZATION_FLAGS_,
                      "unrecognized serialization flags: %#x\n",
-                     (new_config.flags & ~XKB_KEYMAP_SERIALIZE_FLAGS));
+                     invalid_flags);
         return XKB_ERROR_UNSUPPORTED_KEYMAP_SERIALIZATION_FLAGS;
     }
 

--- a/src/keysym.c
+++ b/src/keysym.c
@@ -16,11 +16,12 @@
 
 #include "xkbcommon/xkbcommon-keysyms.h"
 #include "xkbcommon/xkbcommon.h"
+#include "features/enums.h"
+#include "keysym.h"
+#include "keysym-names.h"
 #include "utf8-decoding.h"
 #include "utils.h"
 #include "utils-numbers.h"
-#include "keysym.h"
-#include "keysym-names.h"
 
 static ssize_t
 find_keysym_index(xkb_keysym_t ks)
@@ -239,10 +240,7 @@ parse_keysym_hex(const char *s, uint32_t *out)
 xkb_keysym_t
 xkb_keysym_from_name(const char *name, enum xkb_keysym_flags flags)
 {
-    static const enum xkb_keysym_flags XKB_KEYSYM_FLAGS =
-        XKB_KEYSYM_CASE_INSENSITIVE;
-
-    if (flags & ~XKB_KEYSYM_FLAGS)
+    if (flags & ~(enum xkb_keysym_flags)XKB_KEYSYM_FLAGS_VALUES)
         return XKB_KEY_NoSymbol;
 
     const struct name_keysym *entry = NULL;

--- a/src/rmlvo.c
+++ b/src/rmlvo.c
@@ -12,6 +12,7 @@
 #include "xkbcommon/xkbcommon.h"
 #include "xkbcommon/xkbcommon-errors.h"
 #include "context.h"
+#include "features/enums.h"
 #include "keymap.h"
 #include "messages-codes.h"
 #include "rmlvo.h"
@@ -24,13 +25,12 @@ xkb_rmlvo_builder_new(struct xkb_context *context,
                       const char *rules, const char *model,
                       enum xkb_rmlvo_builder_flags flags)
 {
-    static const enum xkb_rmlvo_builder_flags XKB_RMLVO_BUILDER_FLAGS =
-        XKB_RMLVO_BUILDER_NO_FLAGS;
-
-    if (flags & ~XKB_RMLVO_BUILDER_FLAGS) {
-        log_err(context, XKB_LOG_MESSAGE_NO_ID,
-                "Unsupported RMLVO flags: 0x%x\n",
-                (flags & ~XKB_RMLVO_BUILDER_FLAGS));
+    const enum xkb_rmlvo_builder_flags invalid_flags =
+        (flags & ~(enum xkb_rmlvo_builder_flags)XKB_RMLVO_BUILDER_FLAGS_VALUES);
+    if (invalid_flags) {
+        log_err_func(context, XKB_LOG_MESSAGE_NO_ID,
+                     "Unsupported RMLVO flags: 0x%x\n",
+                     invalid_flags);
         return NULL;
     }
 

--- a/src/state.c
+++ b/src/state.c
@@ -3729,12 +3729,12 @@ xkb_machine_process_key(struct xkb_machine *sm,
 struct xkb_events *
 xkb_events_new_batch(struct xkb_context *context, enum xkb_events_flags flags)
 {
-    static const enum xkb_events_flags XKB_EVENTS_FLAGS = XKB_EVENTS_NO_FLAGS;
-
-    if (flags & ~XKB_EVENTS_FLAGS) {
+    const enum xkb_events_flags invalid_flags =
+        (flags & ~(enum xkb_events_flags)XKB_EVENTS_FLAGS_VALUES);
+    if (invalid_flags) {
         log_err_func(context, XKB_LOG_MESSAGE_NO_ID,
                      "unrecognized events batch flags: %#x\n",
-                     (flags & ~XKB_EVENTS_FLAGS));
+                     invalid_flags);
         return NULL;
     }
 


### PR DESCRIPTION
- Do not create the mask manually: it is prone to out-of-sync and they are already generated for `xkb_has_feature()`.
- Use an intermediate `invalid_flags` variable to improve the readability of flags checks.
- Reorder some headers.