### PR TITLE
state: refactor `xkb_event_get_keycode()`

### DIFF
--- a/data/enums/xkbcommon.yaml
+++ b/data/enums/xkbcommon.yaml
@@ -61,18 +61,21 @@ xkb_keymap_key_iterator_flags:
   - name: XKB_KEYMAP_KEY_ITERATOR_SKIP_UNBOUND
     value: 2
 xkb_event_type:
-  - name: XKB_EVENT_TYPE_KEY_DOWN
+  - name: XKB_EVENT_TYPE_KEY
     value: 1
-  - name: XKB_EVENT_TYPE_KEY_REPEATED
-    value: 2
-  - name: XKB_EVENT_TYPE_KEY_UP
-    value: 3
   - name: XKB_EVENT_TYPE_COMPONENTS_CHANGE
-    value: 4
+    value: 2
   - name: XKB_EVENT_TYPE_POINTER_MOTION
-    value: 5
+    value: 3
   - name: XKB_EVENT_TYPE_POINTER_BUTTON
-    value: 6
+    value: 4
+xkb_key_direction:
+  - name: XKB_KEY_UP
+    value: 0
+  - name: XKB_KEY_DOWN
+    value: 1
+  - name: XKB_KEY_REPEATED
+    value: 2
 xkb_state_component:
   - name: XKB_STATE_MODS_DEPRESSED
     value: 1
@@ -148,13 +151,6 @@ xkb_a11y_flags:
     value: 2
   - name: XKB_A11Y_LATCH_SIMULTANEOUS_KEYS
     value: 4
-xkb_key_direction:
-  - name: XKB_KEY_UP
-    value: 0
-  - name: XKB_KEY_DOWN
-    value: 1
-  - name: XKB_KEY_REPEATED
-    value: 2
 xkb_layout_out_of_range_policy:
   - name: XKB_LAYOUT_OUT_OF_RANGE_WRAP
     value: 0

--- a/doc/keymap-text-format-v1-v2.md
+++ b/doc/keymap-text-format-v1-v2.md
@@ -4658,9 +4658,9 @@ Legacy paramater: *do not use*.
 
 [pointer motion event]: @ref XKB_EVENT_TYPE_POINTER_MOTION
 [pointer button event]: @ref XKB_EVENT_TYPE_POINTER_BUTTON
-[key press event]: @ref XKB_EVENT_TYPE_KEY_DOWN
-[key repeated event]: @ref XKB_EVENT_TYPE_KEY_REPEATED
-[key release event]: @ref XKB_EVENT_TYPE_KEY_UP
+[key press event]: @ref XKB_EVENT_TYPE_KEY
+[key repeated event]: @ref XKB_EVENT_TYPE_KEY
+[key release event]: @ref XKB_EVENT_TYPE_KEY
 
 ### Legacy X11 actions {#legacy-x11-actions}
 

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -2726,29 +2726,13 @@ struct xkb_event;
  */
 enum xkb_event_type {
     /**
-     * **Key _down_** event
+     * **Key** event
      *
      * @sa `xkb_event::xkb_event_get_keycode()`
      *
      * @since 1.14.0
      */
-    XKB_EVENT_TYPE_KEY_DOWN = 1,
-    /**
-     * **Key _repeated_** event
-     *
-     * @sa `xkb_event::xkb_event_get_keycode()`
-     *
-     * @since 1.14.0
-     */
-    XKB_EVENT_TYPE_KEY_REPEATED,
-    /**
-     * **Key _up_** event
-     *
-     * @sa `xkb_event::xkb_event_get_keycode()`
-     *
-     * @since 1.14.0
-     */
-    XKB_EVENT_TYPE_KEY_UP,
+    XKB_EVENT_TYPE_KEY = 1,
     /**
      * **Components** change event
      *
@@ -2790,26 +2774,57 @@ XKB_EXPORT enum xkb_event_type
 xkb_event_get_type(const struct xkb_event *event);
 
 /**
- * Get the keycode associated to a [state event](@ref xkb_event) of type
- * `::XKB_EVENT_TYPE_KEY_DOWN`, `::XKB_EVENT_TYPE_KEY_REPEATED` or
- * `::XKB_EVENT_TYPE_KEY_UP`.
+ * @enum xkb_key_direction
+ * Specifies the direction of the key (press / release) or a repetition.
+ */
+enum xkb_key_direction {
+    /** The key was *released*. */
+    XKB_KEY_UP,
+    /** The key was *pressed*. */
+    XKB_KEY_DOWN,
+    /**
+     * The key was *repeated*.
+     *
+     * This should be used by the compositor only if it handles key repetition
+     * itself.
+     *
+     * @since 1.14.0
+     */
+    XKB_KEY_REPEATED
+};
+
+/**
+ * Get the [keycode] and [direction] associated to a [state event][event]
+ * of type `::XKB_EVENT_TYPE_KEY`.
  *
- * @param[in] event The event object to process.
+ * @param[in]  event
+ *   The event object to process.
+ * @param[out] keycode
+ *   A pointer to store the [keycode] of the key event.
+ * @param[out] direction
+ *   A pointer to store the [direction] of the key event.
  *
- * @pre The event must be of one of the following types:
- * - `::XKB_EVENT_TYPE_KEY_DOWN`
- * - `::XKB_EVENT_TYPE_KEY_REPEATED`
- * - `::XKB_EVENT_TYPE_KEY_UP`
- * Otherwise the result is *undefined*.
+ * @pre The event must be `::XKB_EVENT_TYPE_KEY`.
+ * Otherwise the @p keycode and @p direction are *not* updated.
  *
- * @returns The keycode corresponding to the event.
+ * @returns `::XKB_SUCCESS` on success, otherwise an [error code]&zwnj;:
+ * - `::XKB_ERROR_INVALID` if the [event] type is incorrect.
+ *
+ * @sa `xkb_machine::xkb_machine_process_key()`
  *
  * @since 1.14.0
  *
  * @memberof xkb_event
+ *
+ * [keycode]: @ref xkb_keycode_t
+ * [direction]: @ref xkb_key_direction
+ * [event]: @ref xkb_event
+ * [error code]: @ref xkb_error_code
  */
-XKB_EXPORT xkb_keycode_t
-xkb_event_get_keycode(const struct xkb_event *event);
+XKB_EXPORT enum xkb_error_code
+xkb_event_get_keycode(const struct xkb_event *event,
+                      xkb_keycode_t *keycode,
+                      enum xkb_key_direction *direction);
 
 /**
  * @enum xkb_state_component
@@ -4054,26 +4069,6 @@ xkb_machine_unref(struct xkb_machine *machine);
  */
 XKB_EXPORT struct xkb_keymap *
 xkb_machine_get_keymap(const struct xkb_machine *machine);
-
-/**
- * @enum xkb_key_direction
- * Specifies the direction of the key (press / release) or a repetition.
- */
-enum xkb_key_direction {
-    /** The key was *released*. */
-    XKB_KEY_UP,
-    /** The key was *pressed*. */
-    XKB_KEY_DOWN,
-    /**
-     * The key was *repeated*.
-     *
-     * This should be used by the compositor only if it handles key repetition
-     * itself.
-     *
-     * @since 1.14.0
-     */
-    XKB_KEY_REPEATED
-};
 
 /**
  * Process a key event – a pair ([keycode], [direction]) – through the XKB

--- a/src/features/enums.h
+++ b/src/features/enums.h
@@ -34,30 +34,26 @@ static_assert(XKB_KEYMAP_FORMAT_TEXT_V1 >= 0 &&
               XKB_KEYMAP_FORMAT_TEXT_V1 < UINT32_WIDTH, "");
 static_assert(XKB_KEYMAP_FORMAT_TEXT_V2 >= 0 &&
               XKB_KEYMAP_FORMAT_TEXT_V2 < UINT32_WIDTH, "");
-static_assert(XKB_EVENT_TYPE_KEY_DOWN >= 0 &&
-              XKB_EVENT_TYPE_KEY_DOWN < UINT32_WIDTH, "");
-static_assert(XKB_EVENT_TYPE_KEY_REPEATED >= 0 &&
-              XKB_EVENT_TYPE_KEY_REPEATED < UINT32_WIDTH, "");
-static_assert(XKB_EVENT_TYPE_KEY_UP >= 0 &&
-              XKB_EVENT_TYPE_KEY_UP < UINT32_WIDTH, "");
+static_assert(XKB_EVENT_TYPE_KEY >= 0 &&
+              XKB_EVENT_TYPE_KEY < UINT32_WIDTH, "");
 static_assert(XKB_EVENT_TYPE_COMPONENTS_CHANGE >= 0 &&
               XKB_EVENT_TYPE_COMPONENTS_CHANGE < UINT32_WIDTH, "");
 static_assert(XKB_EVENT_TYPE_POINTER_MOTION >= 0 &&
               XKB_EVENT_TYPE_POINTER_MOTION < UINT32_WIDTH, "");
 static_assert(XKB_EVENT_TYPE_POINTER_BUTTON >= 0 &&
               XKB_EVENT_TYPE_POINTER_BUTTON < UINT32_WIDTH, "");
-static_assert(XKB_POINTER_BUTTON_DOWN >= 0 &&
-              XKB_POINTER_BUTTON_DOWN < UINT32_WIDTH, "");
-static_assert(XKB_POINTER_BUTTON_UP >= 0 &&
-              XKB_POINTER_BUTTON_UP < UINT32_WIDTH, "");
-static_assert(XKB_POINTER_BUTTON_CLICK >= 0 &&
-              XKB_POINTER_BUTTON_CLICK < UINT32_WIDTH, "");
 static_assert(XKB_KEY_UP >= 0 &&
               XKB_KEY_UP < UINT32_WIDTH, "");
 static_assert(XKB_KEY_DOWN >= 0 &&
               XKB_KEY_DOWN < UINT32_WIDTH, "");
 static_assert(XKB_KEY_REPEATED >= 0 &&
               XKB_KEY_REPEATED < UINT32_WIDTH, "");
+static_assert(XKB_POINTER_BUTTON_DOWN >= 0 &&
+              XKB_POINTER_BUTTON_DOWN < UINT32_WIDTH, "");
+static_assert(XKB_POINTER_BUTTON_UP >= 0 &&
+              XKB_POINTER_BUTTON_UP < UINT32_WIDTH, "");
+static_assert(XKB_POINTER_BUTTON_CLICK >= 0 &&
+              XKB_POINTER_BUTTON_CLICK < UINT32_WIDTH, "");
 static_assert(XKB_LAYOUT_OUT_OF_RANGE_WRAP >= 0 &&
               XKB_LAYOUT_OUT_OF_RANGE_WRAP < UINT32_WIDTH, "");
 static_assert(XKB_LAYOUT_OUT_OF_RANGE_CLAMP >= 0 &&
@@ -126,12 +122,15 @@ enum xkb_enumerations_values {
         | XKB_KEYMAP_KEY_ITERATOR_SKIP_UNBOUND
     ,
     XKB_EVENT_TYPE_VALUES
-        = (1u << XKB_EVENT_TYPE_KEY_DOWN)
-        | (1u << XKB_EVENT_TYPE_KEY_REPEATED)
-        | (1u << XKB_EVENT_TYPE_KEY_UP)
+        = (1u << XKB_EVENT_TYPE_KEY)
         | (1u << XKB_EVENT_TYPE_COMPONENTS_CHANGE)
         | (1u << XKB_EVENT_TYPE_POINTER_MOTION)
         | (1u << XKB_EVENT_TYPE_POINTER_BUTTON)
+    ,
+    XKB_KEY_DIRECTION_VALUES
+        = (1u << XKB_KEY_UP)
+        | (1u << XKB_KEY_DOWN)
+        | (1u << XKB_KEY_REPEATED)
     ,
     XKB_STATE_COMPONENT_VALUES
         = XKB_STATE_MODS_DEPRESSED
@@ -180,11 +179,6 @@ enum xkb_enumerations_values {
         | XKB_A11Y_STICKY_KEYS_NO_SIMULTANEOUS_KEYS
         | XKB_A11Y_STICKY_KEYS_LATCH_TO_LOCK
         | XKB_A11Y_LATCH_SIMULTANEOUS_KEYS
-    ,
-    XKB_KEY_DIRECTION_VALUES
-        = (1u << XKB_KEY_UP)
-        | (1u << XKB_KEY_DOWN)
-        | (1u << XKB_KEY_REPEATED)
     ,
     XKB_LAYOUT_OUT_OF_RANGE_POLICY_VALUES
         = (1u << XKB_LAYOUT_OUT_OF_RANGE_WRAP)
@@ -296,12 +290,18 @@ static const uint32_t xkb_keymap_key_iterator_flags_values[] = {
 
 #ifdef ENABLE_PRIVATE_APIS
 static const uint32_t xkb_event_type_values[] = {
-    XKB_EVENT_TYPE_KEY_DOWN,
-    XKB_EVENT_TYPE_KEY_REPEATED,
-    XKB_EVENT_TYPE_KEY_UP,
+    XKB_EVENT_TYPE_KEY,
     XKB_EVENT_TYPE_COMPONENTS_CHANGE,
     XKB_EVENT_TYPE_POINTER_MOTION,
     XKB_EVENT_TYPE_POINTER_BUTTON,
+};
+#endif
+
+#ifdef ENABLE_PRIVATE_APIS
+static const uint32_t xkb_key_direction_values[] = {
+    XKB_KEY_UP,
+    XKB_KEY_DOWN,
+    XKB_KEY_REPEATED,
 };
 #endif
 
@@ -371,14 +371,6 @@ static const uint32_t xkb_a11y_flags_values[] = {
     XKB_A11Y_STICKY_KEYS_NO_SIMULTANEOUS_KEYS,
     XKB_A11Y_STICKY_KEYS_LATCH_TO_LOCK,
     XKB_A11Y_LATCH_SIMULTANEOUS_KEYS,
-};
-#endif
-
-#ifdef ENABLE_PRIVATE_APIS
-static const uint32_t xkb_key_direction_values[] = {
-    XKB_KEY_UP,
-    XKB_KEY_DOWN,
-    XKB_KEY_REPEATED,
 };
 #endif
 

--- a/src/state-priv.h
+++ b/src/state-priv.h
@@ -36,7 +36,10 @@ struct xkb_event {
     struct xkb_context *ctx;
     enum xkb_event_type type;
     union {
-        xkb_keycode_t keycode;
+        struct {
+            xkb_keycode_t keycode;
+            enum xkb_key_direction direction;
+        } key;
         struct {
             struct state_components components;
             enum xkb_state_component changed;

--- a/src/state.c
+++ b/src/state.c
@@ -1220,7 +1220,10 @@ append_redirect_key_events(struct xkb_server_state *state,
               : (direction == XKB_KEY_REPEATED)
                 ? XKB_EVENT_TYPE_KEY_REPEATED
                 : XKB_EVENT_TYPE_KEY_DOWN,
-        .keycode = redirect->keycode
+        .key = {
+            .keycode = redirect->keycode,
+            .direction = direction
+        }
     });
 
     if (mask && changed) {
@@ -3908,7 +3911,10 @@ xkb_machine_process_key(struct xkb_machine *sm,
                 : (direction == XKB_KEY_REPEATED)
                     ? XKB_EVENT_TYPE_KEY_REPEATED
                     : XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = key->keycode
+            .key = {
+                .keycode = key->keycode,
+                .direction = direction
+            }
         });
     }
 
@@ -4031,7 +4037,7 @@ xkb_event_get_keycode(const struct xkb_event *event)
     case XKB_EVENT_TYPE_KEY_DOWN:
     case XKB_EVENT_TYPE_KEY_REPEATED:
     case XKB_EVENT_TYPE_KEY_UP:
-        return event->keycode;
+        return event->key.keycode;
     default:
         return XKB_KEYCODE_INVALID;
     }

--- a/src/state.c
+++ b/src/state.c
@@ -1215,11 +1215,7 @@ append_redirect_key_events(struct xkb_server_state *state,
 
     darray_append(events->queue, (struct xkb_event) {
         .ctx = events->ctx, /* borrowed from events */
-        .type = (direction == XKB_KEY_UP)
-              ? XKB_EVENT_TYPE_KEY_UP
-              : (direction == XKB_KEY_REPEATED)
-                ? XKB_EVENT_TYPE_KEY_REPEATED
-                : XKB_EVENT_TYPE_KEY_DOWN,
+        .type = XKB_EVENT_TYPE_KEY,
         .key = {
             .keycode = redirect->keycode,
             .direction = direction
@@ -3906,11 +3902,7 @@ xkb_machine_process_key(struct xkb_machine *sm,
          */
         darray_append(events->queue, (struct xkb_event) {
             .ctx = events->ctx, /* borrowed from events */
-            .type = (direction == XKB_KEY_UP)
-                ? XKB_EVENT_TYPE_KEY_UP
-                : (direction == XKB_KEY_REPEATED)
-                    ? XKB_EVENT_TYPE_KEY_REPEATED
-                    : XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = key->keycode,
                 .direction = direction
@@ -4030,16 +4022,18 @@ xkb_event_get_type(const struct xkb_event *event)
     return event->type;
 }
 
-xkb_keycode_t
-xkb_event_get_keycode(const struct xkb_event *event)
+enum xkb_error_code
+xkb_event_get_keycode(const struct xkb_event *event,
+                      xkb_keycode_t *keycode,
+                      enum xkb_key_direction *direction)
 {
     switch (event->type) {
-    case XKB_EVENT_TYPE_KEY_DOWN:
-    case XKB_EVENT_TYPE_KEY_REPEATED:
-    case XKB_EVENT_TYPE_KEY_UP:
-        return event->key.keycode;
+    case XKB_EVENT_TYPE_KEY:
+        *keycode = event->key.keycode;
+        *direction = event->key.direction;
+        return XKB_SUCCESS;
     default:
-        return XKB_KEYCODE_INVALID;
+        return XKB_ERROR_INVALID;
     }
 }
 

--- a/test/common.c
+++ b/test/common.c
@@ -21,6 +21,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include "xkbcommon/xkbcommon-errors.h"
 #include "xkbcommon/xkbcommon.h"
 
 #include "darray.h"
@@ -88,27 +89,44 @@ consume_events(struct xkb_machine *sm,
                xkb_keycode_t *kc)
 {
     const struct xkb_event *event;
+    enum xkb_error_code error;
     while ((event = xkb_events_next(events))) {
         switch (xkb_event_get_type(event)) {
-        case XKB_EVENT_TYPE_KEY_DOWN:
-        case XKB_EVENT_TYPE_KEY_REPEATED:
-        case XKB_EVENT_TYPE_KEY_UP:
-            *kc = xkb_event_get_keycode(event);
+        case XKB_EVENT_TYPE_KEY: {
+            enum xkb_key_direction direction;
+            error = xkb_event_get_keycode(event, kc, &direction);
+            assert(error == XKB_SUCCESS);
             if (flags & UNTIL_KEY_EVENT) {
                 /* Stop on key event */
                 return true;
             }
             break;
+        }
         case XKB_EVENT_TYPE_COMPONENTS_CHANGE:
+            // TODO: check error
             xkb_state_update_event(state, event);
             break;
-        case XKB_EVENT_TYPE_POINTER_MOTION:
-        case XKB_EVENT_TYPE_POINTER_BUTTON:
+        case XKB_EVENT_TYPE_POINTER_MOTION: {
+            struct xkb_event_pointer_motion motion = {
+                .size = sizeof(motion)
+            };
+            error = xkb_event_get_pointer_motion(event, &motion);
+            assert(error == XKB_SUCCESS);
             /* Pointer events do not update the base state */
             break;
+        }
+        case XKB_EVENT_TYPE_POINTER_BUTTON: {
+            struct xkb_event_pointer_button button = {
+                .size = sizeof(button)
+            };
+            error = xkb_event_get_pointer_button(event, &button);
+            assert(error == XKB_SUCCESS);
+            /* Pointer events do not update the base state */
+            break;
+        }
         default:
             {} /* Label followed by declaration requires C23 */
-            static_assert(XKB_EVENT_TYPE_POINTER_BUTTON == 6 &&
+            static_assert(XKB_EVENT_TYPE_POINTER_BUTTON == 4 &&
                           XKB_EVENT_TYPE_POINTER_BUTTON ==
                           (enum xkb_event_type) _LAST_XKB_EVENT_TYPE,
                           "Missing state event type");

--- a/test/quick-guide.c
+++ b/test/quick-guide.c
@@ -169,15 +169,14 @@ handle_key(struct my_keyboard *keyboard, uint32_t key, uint32_t state)
         const enum xkb_event_type event_type =
             xkb_event_get_type(event);
         switch (event_type) {
-            case XKB_EVENT_TYPE_KEY_DOWN:
-            case XKB_EVENT_TYPE_KEY_REPEATED:
-            case XKB_EVENT_TYPE_KEY_UP: {
-                const xkb_keycode_t kc = xkb_event_get_keycode(event);
-                direction = (event_type == XKB_EVENT_TYPE_KEY_UP)
-                    ? XKB_KEY_UP
-                    : (XKB_EVENT_TYPE_KEY_REPEATED)
-                        ? XKB_KEY_REPEATED
-                        : XKB_KEY_DOWN;
+            case XKB_EVENT_TYPE_KEY: {
+                xkb_keycode_t kc = XKB_KEYCODE_INVALID;
+                error = xkb_event_get_keycode(event, &kc, &direction);
+                if (error != XKB_SUCCESS) {
+                    /* Handle error */
+                    // ...
+                    exit(EXIT_FAILURE);
+                }
                 // Send key event to clients
                 // ...
                 assert(kc != XKB_KEYCODE_INVALID);

--- a/test/server-state.c
+++ b/test/server-state.c
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include "abi-check.h"
 #include "config.h"
 #include "test-config.h"
 
@@ -17,6 +16,7 @@
 #include "xkbcommon/xkbcommon-keysyms.h"
 #include "xkbcommon/xkbcommon-names.h"
 
+#include "abi-check.h"
 #include "context.h"
 #include "evdev-scancodes.h"
 #include "src/keysym.h"
@@ -1071,7 +1071,7 @@ test_redirect_key(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_DOWN,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_A + EVDEV_OFFSET,
                             .direction = XKB_KEY_DOWN
@@ -1084,7 +1084,7 @@ test_redirect_key(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_UP,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_A + EVDEV_OFFSET,
                             .direction = XKB_KEY_UP
@@ -1101,7 +1101,7 @@ test_redirect_key(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_DOWN,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_A + EVDEV_OFFSET,
                             .direction = XKB_KEY_DOWN
@@ -1114,7 +1114,7 @@ test_redirect_key(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_UP,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_A + EVDEV_OFFSET,
                             .direction = XKB_KEY_UP
@@ -1147,7 +1147,7 @@ test_redirect_key(struct xkb_context *ctx)
                     },
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_DOWN,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_S + EVDEV_OFFSET,
                             .direction = XKB_KEY_DOWN
@@ -1192,7 +1192,7 @@ test_redirect_key(struct xkb_context *ctx)
                     },
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_UP,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_S + EVDEV_OFFSET,
                             .direction = XKB_KEY_UP
@@ -1236,8 +1236,6 @@ test_redirect_key(struct xkb_context *ctx)
         if (tests[t].repeats) {
             struct xkb_event ref[ARRAY_SIZE(tests->down.events)] = {0};
             memcpy(ref, tests[t].down.events, sizeof(tests->down.events));
-            ref[tests[t].down.events_count == 3].type =
-                XKB_EVENT_TYPE_KEY_REPEATED;
             ref[tests[t].down.events_count == 3].key.direction =
                 XKB_KEY_REPEATED;
             assert(check_events(events, ref, tests[t].down.events_count));
@@ -1307,7 +1305,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_DOWN,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_DOWN
@@ -1333,7 +1331,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_REPEATED,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_REPEATED
@@ -1346,7 +1344,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_UP,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_UP
@@ -1379,7 +1377,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_DOWN,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_KP7 + EVDEV_OFFSET,
                             .direction = XKB_KEY_DOWN
@@ -1404,7 +1402,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_REPEATED,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_KP7 + EVDEV_OFFSET,
                             .direction = XKB_KEY_REPEATED
@@ -1417,7 +1415,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_UP,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_KP7 + EVDEV_OFFSET,
                             .direction = XKB_KEY_UP
@@ -1437,7 +1435,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_DOWN,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_DOWN
@@ -1464,7 +1462,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_UP,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_UP
@@ -1497,7 +1495,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_DOWN,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_KP5 + EVDEV_OFFSET,
                             .direction = XKB_KEY_DOWN
@@ -1522,7 +1520,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_REPEATED,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_KP5 + EVDEV_OFFSET,
                             .direction = XKB_KEY_REPEATED
@@ -1535,7 +1533,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_UP,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_KP5 + EVDEV_OFFSET,
                             .direction = XKB_KEY_UP
@@ -1555,7 +1553,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_DOWN,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_DOWN
@@ -1582,7 +1580,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_UP,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_UP
@@ -1615,7 +1613,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_DOWN,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_KP0 + EVDEV_OFFSET,
                             .direction = XKB_KEY_DOWN
@@ -1640,7 +1638,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_REPEATED,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_KP0 + EVDEV_OFFSET,
                             .direction = XKB_KEY_REPEATED
@@ -1653,7 +1651,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_UP,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_KP0 + EVDEV_OFFSET,
                             .direction = XKB_KEY_UP
@@ -1673,7 +1671,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_DOWN,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_DOWN
@@ -1700,7 +1698,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_UP,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_UP
@@ -1733,7 +1731,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_DOWN,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_KPASTERISK + EVDEV_OFFSET,
                             .direction = XKB_KEY_DOWN
@@ -1758,7 +1756,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_REPEATED,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_KPASTERISK + EVDEV_OFFSET,
                             .direction = XKB_KEY_REPEATED
@@ -1771,7 +1769,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_UP,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_KPASTERISK + EVDEV_OFFSET,
                             .direction = XKB_KEY_UP
@@ -1793,7 +1791,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_DOWN,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_KPPLUSMINUS + EVDEV_OFFSET,
                             .direction = XKB_KEY_DOWN
@@ -1818,7 +1816,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_UP,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_KPPLUSMINUS + EVDEV_OFFSET,
                             .direction = XKB_KEY_UP
@@ -1838,7 +1836,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_DOWN,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_DOWN
@@ -1865,7 +1863,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_REPEATED,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_REPEATED
@@ -1878,7 +1876,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_UP,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_UP
@@ -2007,7 +2005,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_DOWN,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_DOWN
@@ -2035,7 +2033,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_UP,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_UP
@@ -2108,7 +2106,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_DOWN,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_DOWN
@@ -2136,7 +2134,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_UP,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_UP
@@ -2209,7 +2207,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_DOWN,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_DOWN
@@ -2237,7 +2235,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_UP,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_UP
@@ -2360,7 +2358,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_DOWN,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_DOWN
@@ -2388,7 +2386,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_UP,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                             .direction = XKB_KEY_UP
@@ -2713,7 +2711,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_DOWN,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_KPPLUSMINUS + EVDEV_OFFSET,
                             .direction = XKB_KEY_DOWN
@@ -2726,7 +2724,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_UP,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_KPPLUSMINUS + EVDEV_OFFSET,
                             .direction = XKB_KEY_UP
@@ -2816,7 +2814,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_DOWN,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_KPPLUSMINUS + EVDEV_OFFSET,
                             .direction = XKB_KEY_DOWN
@@ -2841,7 +2839,7 @@ test_mouse_keys(struct xkb_context *ctx)
                 .events = {
                     {
                         .ctx = ctx,
-                        .type = XKB_EVENT_TYPE_KEY_UP,
+                        .type = XKB_EVENT_TYPE_KEY,
                         .key = {
                             .keycode = KEY_KPPLUSMINUS + EVDEV_OFFSET,
                             .direction = XKB_KEY_UP
@@ -3125,7 +3123,7 @@ test_shortcuts_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_Q + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -3173,7 +3171,7 @@ test_shortcuts_tweak(struct xkb_context *context)
         events,
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_REPEATED,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_Q + EVDEV_OFFSET,
                 .direction = XKB_KEY_REPEATED
@@ -3187,7 +3185,7 @@ test_shortcuts_tweak(struct xkb_context *context)
         events,
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_UP,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_Q + EVDEV_OFFSET,
                 .direction = XKB_KEY_UP
@@ -3201,7 +3199,7 @@ test_shortcuts_tweak(struct xkb_context *context)
         events,
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_RIGHTCTRL + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -3258,7 +3256,7 @@ test_shortcuts_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_UP,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_RIGHTCTRL + EVDEV_OFFSET,
                 .direction = XKB_KEY_UP
@@ -3325,7 +3323,7 @@ test_shortcuts_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_102ND + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -3393,7 +3391,7 @@ test_shortcuts_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_Q + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -3443,7 +3441,7 @@ test_shortcuts_tweak(struct xkb_context *context)
         events,
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_UP,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_Q + EVDEV_OFFSET,
                 .direction = XKB_KEY_UP
@@ -3457,7 +3455,7 @@ test_shortcuts_tweak(struct xkb_context *context)
         events,
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_UP,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_102ND + EVDEV_OFFSET,
                 .direction = XKB_KEY_UP
@@ -3561,7 +3559,7 @@ test_shortcuts_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_Q + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -3611,7 +3609,7 @@ test_shortcuts_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_REPEATED,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_Q + EVDEV_OFFSET,
                 .direction = XKB_KEY_REPEATED
@@ -3661,7 +3659,7 @@ test_shortcuts_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_UP,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_Q + EVDEV_OFFSET,
                 .direction = XKB_KEY_UP
@@ -3908,7 +3906,7 @@ test_shortcuts_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_COPY + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -3996,7 +3994,7 @@ test_shortcuts_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_Q + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -4063,7 +4061,7 @@ test_shortcuts_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_COPY + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -4156,7 +4154,7 @@ test_shortcuts_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_Q + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -4212,7 +4210,7 @@ test_shortcuts_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_Q + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -4262,7 +4260,7 @@ test_shortcuts_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_COPY + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -4432,12 +4430,17 @@ test_overlays(struct xkb_context *context)
         ) == XKB_SUCCESS);
         const struct xkb_event *event;
         while ((event = xkb_events_next(events))) {
-            switch (xkb_event_get_type(event)) {
-            case XKB_EVENT_TYPE_KEY_DOWN:
-            case XKB_EVENT_TYPE_KEY_UP:
-                assert_eq("keycode", EVDEV_OFFSET + keycode_tests[t].kc,
-                          xkb_event_get_keycode(event), "%"PRIu32);
+            switch(xkb_event_get_type(event)) {
+            case XKB_EVENT_TYPE_KEY: {
+                xkb_keycode_t kc;
+                enum xkb_key_direction direction;
+                assert(xkb_event_get_keycode(event, &kc, &direction) == XKB_SUCCESS);
+                assert_eq("keycode", keycode_tests[t].kc + EVDEV_OFFSET,
+                          kc, "%"PRIu32);
+                assert_eq("direction", keycode_tests[t].direction,
+                          direction, "%d");
                 break;
+            }
             default:
                 ;
             }
@@ -4578,7 +4581,7 @@ test_modifiers_tweak(struct xkb_context *context)
         events,
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_LEFTALT + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -4620,7 +4623,7 @@ test_modifiers_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_Y + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -4662,7 +4665,7 @@ test_modifiers_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_REPEATED,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_Y + EVDEV_OFFSET,
                 .direction = XKB_KEY_REPEATED
@@ -4704,7 +4707,7 @@ test_modifiers_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_UP,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_Y + EVDEV_OFFSET,
                 .direction = XKB_KEY_UP
@@ -4772,7 +4775,7 @@ test_modifiers_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_Y + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -4819,7 +4822,7 @@ test_modifiers_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_UP,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_Y + EVDEV_OFFSET,
                 .direction = XKB_KEY_UP
@@ -4850,7 +4853,7 @@ test_modifiers_tweak(struct xkb_context *context)
         events,
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_BACKSPACE + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -4880,7 +4883,7 @@ test_modifiers_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_UP,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_LEFTALT + EVDEV_OFFSET,
                 .direction = XKB_KEY_UP
@@ -4966,7 +4969,7 @@ test_modifiers_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_CAPSLOCK + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -5049,7 +5052,7 @@ test_modifiers_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_COPY + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -5125,7 +5128,7 @@ test_modifiers_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_REPEATED,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_COPY + EVDEV_OFFSET,
                 .direction = XKB_KEY_REPEATED
@@ -5202,7 +5205,7 @@ test_modifiers_tweak(struct xkb_context *context)
         },
         {
             .ctx = context,
-            .type = XKB_EVENT_TYPE_KEY_UP,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_COPY + EVDEV_OFFSET,
                 .direction = XKB_KEY_UP

--- a/test/server-state.c
+++ b/test/server-state.c
@@ -1065,14 +1065,17 @@ test_redirect_key(struct xkb_context *ctx)
         struct test_events up;
     } tests[] = {
         {
-            .keycode = EVDEV_OFFSET + KEY_A,
+            .keycode = KEY_A + EVDEV_OFFSET,
             .repeats = false,
             .down = {
                 .events = {
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_DOWN,
-                        .keycode = EVDEV_OFFSET + KEY_A
+                        .key = {
+                            .keycode = KEY_A + EVDEV_OFFSET,
+                            .direction = XKB_KEY_DOWN
+                        }
                     }
                 },
                 .events_count = 1
@@ -1082,21 +1085,27 @@ test_redirect_key(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_UP,
-                        .keycode = EVDEV_OFFSET + KEY_A
+                        .key = {
+                            .keycode = KEY_A + EVDEV_OFFSET,
+                            .direction = XKB_KEY_UP
+                        }
                     }
                 },
                 .events_count = 1
             }
         },
         {
-            .keycode = EVDEV_OFFSET + KEY_S,
+            .keycode = KEY_S + EVDEV_OFFSET,
             .repeats = true,
             .down = {
                 .events = {
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_DOWN,
-                        .keycode = EVDEV_OFFSET + KEY_A
+                        .key = {
+                            .keycode = KEY_A + EVDEV_OFFSET,
+                            .direction = XKB_KEY_DOWN
+                        }
                     }
                 },
                 .events_count = 1
@@ -1106,14 +1115,17 @@ test_redirect_key(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_UP,
-                        .keycode = EVDEV_OFFSET + KEY_A
+                        .key = {
+                            .keycode = KEY_A + EVDEV_OFFSET,
+                            .direction = XKB_KEY_UP
+                        }
                     }
                 },
                 .events_count = 1
             }
         },
         {
-            .keycode = EVDEV_OFFSET + KEY_D,
+            .keycode = KEY_D + EVDEV_OFFSET,
             .repeats = true,
             .down = {
                 .events = {
@@ -1136,7 +1148,10 @@ test_redirect_key(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_DOWN,
-                        .keycode = EVDEV_OFFSET + KEY_S
+                        .key = {
+                            .keycode = KEY_S + EVDEV_OFFSET,
+                            .direction = XKB_KEY_DOWN
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -1178,7 +1193,10 @@ test_redirect_key(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_UP,
-                        .keycode = EVDEV_OFFSET + KEY_S
+                        .key = {
+                            .keycode = KEY_S + EVDEV_OFFSET,
+                            .direction = XKB_KEY_UP
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -1207,10 +1225,12 @@ test_redirect_key(struct xkb_context *ctx)
                 __func__, t, tests[t].keycode);
         assert(xkb_keymap_key_repeats(keymap, tests[t].keycode) ==
                tests[t].repeats);
+        fprintf(stderr, "+++ Key down +++\n");
         assert(xkb_machine_process_key(sm, tests[t].keycode,
                                        XKB_KEY_DOWN, events) == XKB_SUCCESS);
         assert(check_events(events, tests[t].down.events,
                             tests[t].down.events_count));
+        fprintf(stderr, "+++ Key repeat +++\n");
         assert(xkb_machine_process_key(sm, tests[t].keycode,
                                        XKB_KEY_REPEATED, events) == XKB_SUCCESS);
         if (tests[t].repeats) {
@@ -1218,10 +1238,13 @@ test_redirect_key(struct xkb_context *ctx)
             memcpy(ref, tests[t].down.events, sizeof(tests->down.events));
             ref[tests[t].down.events_count == 3].type =
                 XKB_EVENT_TYPE_KEY_REPEATED;
+            ref[tests[t].down.events_count == 3].key.direction =
+                XKB_KEY_REPEATED;
             assert(check_events(events, ref, tests[t].down.events_count));
         } else {
             assert(check_events(events, NULL, 0));
         }
+        fprintf(stderr, "+++ Key up +++\n");
         assert(xkb_machine_process_key(sm, tests[t].keycode,
                                        XKB_KEY_UP, events) == XKB_SUCCESS);
         assert(check_events(events, tests[t].up.events,
@@ -1277,7 +1300,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Latch LevelThree */
         {
-            .keycode = EVDEV_OFFSET + KEY_RIGHTALT,
+            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
             .repeats = false,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = {
@@ -1285,7 +1308,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_DOWN,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_DOWN
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -1308,7 +1334,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_REPEATED,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_REPEATED
+                        }
                     }
                 },
                 .events_count = 1
@@ -1318,7 +1347,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_UP,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_UP
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -1340,7 +1372,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Deactivated: move pointer (breaks latch) */
         {
-            .keycode = EVDEV_OFFSET + KEY_KP7,
+            .keycode = KEY_KP7 + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = {
@@ -1348,7 +1380,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_DOWN,
-                        .keycode = EVDEV_OFFSET + KEY_KP7
+                        .key = {
+                            .keycode = KEY_KP7 + EVDEV_OFFSET,
+                            .direction = XKB_KEY_DOWN
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -1370,7 +1405,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_REPEATED,
-                        .keycode = EVDEV_OFFSET + KEY_KP7
+                        .key = {
+                            .keycode = KEY_KP7 + EVDEV_OFFSET,
+                            .direction = XKB_KEY_REPEATED
+                        }
                     }
                 },
                 .events_count = 1
@@ -1380,7 +1418,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_UP,
-                        .keycode = EVDEV_OFFSET + KEY_KP7
+                        .key = {
+                            .keycode = KEY_KP7 + EVDEV_OFFSET,
+                            .direction = XKB_KEY_UP
+                        }
                     }
                 },
                 .events_count = 1
@@ -1389,7 +1430,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Latch LevelThree */
         {
-            .keycode = EVDEV_OFFSET + KEY_RIGHTALT,
+            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
             .repeats = false,
             .directions = XKB_KEY_TAP,
             .down = {
@@ -1397,7 +1438,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_DOWN,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_DOWN
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -1421,7 +1465,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_UP,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_UP
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -1443,7 +1490,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Deactivated: button (breaks latch) */
         {
-            .keycode = EVDEV_OFFSET + KEY_KP5,
+            .keycode = KEY_KP5 + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = {
@@ -1451,7 +1498,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_DOWN,
-                        .keycode = EVDEV_OFFSET + KEY_KP5
+                        .key = {
+                            .keycode = KEY_KP5 + EVDEV_OFFSET,
+                            .direction = XKB_KEY_DOWN
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -1473,7 +1523,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_REPEATED,
-                        .keycode = EVDEV_OFFSET + KEY_KP5
+                        .key = {
+                            .keycode = KEY_KP5 + EVDEV_OFFSET,
+                            .direction = XKB_KEY_REPEATED
+                        }
                     }
                 },
                 .events_count = 1
@@ -1483,7 +1536,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_UP,
-                        .keycode = EVDEV_OFFSET + KEY_KP5
+                        .key = {
+                            .keycode = KEY_KP5 + EVDEV_OFFSET,
+                            .direction = XKB_KEY_UP
+                        }
                     }
                 },
                 .events_count = 1
@@ -1492,7 +1548,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Latch LevelThree */
         {
-            .keycode = EVDEV_OFFSET + KEY_RIGHTALT,
+            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
             .repeats = false,
             .directions = XKB_KEY_TAP,
             .down = {
@@ -1500,7 +1556,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_DOWN,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_DOWN
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -1524,7 +1583,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_UP,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_UP
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -1546,7 +1608,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Deactivated: lock button (breaks latch) */
         {
-            .keycode = EVDEV_OFFSET + KEY_KP0,
+            .keycode = KEY_KP0 + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = {
@@ -1554,7 +1616,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_DOWN,
-                        .keycode = EVDEV_OFFSET + KEY_KP0
+                        .key = {
+                            .keycode = KEY_KP0 + EVDEV_OFFSET,
+                            .direction = XKB_KEY_DOWN
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -1576,7 +1641,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_REPEATED,
-                        .keycode = EVDEV_OFFSET + KEY_KP0
+                        .key = {
+                            .keycode = KEY_KP0 + EVDEV_OFFSET,
+                            .direction = XKB_KEY_REPEATED
+                        }
                     }
                 },
                 .events_count = 1
@@ -1586,7 +1654,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_UP,
-                        .keycode = EVDEV_OFFSET + KEY_KP0
+                        .key = {
+                            .keycode = KEY_KP0 + EVDEV_OFFSET,
+                            .direction = XKB_KEY_UP
+                        }
                     }
                 },
                 .events_count = 1
@@ -1595,7 +1666,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Latch LevelThree */
         {
-            .keycode = EVDEV_OFFSET + KEY_RIGHTALT,
+            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
             .repeats = false,
             .directions = XKB_KEY_TAP,
             .down = {
@@ -1603,7 +1674,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_DOWN,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_DOWN
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -1627,7 +1701,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_UP,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_UP
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -1649,7 +1726,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Deactivated: set default button (breaks latch) */
         {
-            .keycode = EVDEV_OFFSET + KEY_KPASTERISK,
+            .keycode = KEY_KPASTERISK + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = {
@@ -1657,7 +1734,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_DOWN,
-                        .keycode = EVDEV_OFFSET + KEY_KPASTERISK
+                        .key = {
+                            .keycode = KEY_KPASTERISK + EVDEV_OFFSET,
+                            .direction = XKB_KEY_DOWN
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -1679,7 +1759,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_REPEATED,
-                        .keycode = EVDEV_OFFSET + KEY_KPASTERISK
+                        .key = {
+                            .keycode = KEY_KPASTERISK + EVDEV_OFFSET,
+                            .direction = XKB_KEY_REPEATED
+                        }
                     }
                 },
                 .events_count = 1
@@ -1689,7 +1772,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_UP,
-                        .keycode = EVDEV_OFFSET + KEY_KPASTERISK
+                        .key = {
+                            .keycode = KEY_KPASTERISK + EVDEV_OFFSET,
+                            .direction = XKB_KEY_UP
+                        }
                     }
                 },
                 .events_count = 1
@@ -1700,7 +1786,7 @@ test_mouse_keys(struct xkb_context *ctx)
          * Enable mouse keys
          */
         {
-            .keycode = EVDEV_OFFSET + KEY_KPPLUSMINUS,
+            .keycode = KEY_KPPLUSMINUS + EVDEV_OFFSET,
             .repeats = false,
             .directions = XKB_KEY_TAP,
             .down = {
@@ -1708,7 +1794,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_DOWN,
-                        .keycode = EVDEV_OFFSET + KEY_KPPLUSMINUS
+                        .key = {
+                            .keycode = KEY_KPPLUSMINUS + EVDEV_OFFSET,
+                            .direction = XKB_KEY_DOWN
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -1730,7 +1819,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_UP,
-                        .keycode = EVDEV_OFFSET + KEY_KPPLUSMINUS
+                        .key = {
+                            .keycode = KEY_KPPLUSMINUS + EVDEV_OFFSET,
+                            .direction = XKB_KEY_UP
+                        }
                     },
                 },
                 .events_count = 1
@@ -1739,7 +1831,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Latch LevelThree */
         {
-            .keycode = EVDEV_OFFSET + KEY_RIGHTALT,
+            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
             .repeats = false,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = {
@@ -1747,7 +1839,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_DOWN,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_DOWN
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -1771,7 +1866,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_REPEATED,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_REPEATED
+                        }
                     }
                 },
                 .events_count = 1
@@ -1781,7 +1879,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_UP,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_UP
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -1809,7 +1910,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Motion */
         {
-            .keycode = EVDEV_OFFSET + KEY_KP7,
+            .keycode = KEY_KP7 + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = {
@@ -1847,7 +1948,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Button: separate press/release */
         {
-            .keycode = EVDEV_OFFSET + KEY_KP5,
+            .keycode = KEY_KP5 + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = {
@@ -1899,7 +2000,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Latch LevelThree */
         {
-            .keycode = EVDEV_OFFSET + KEY_RIGHTALT,
+            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
             .repeats = false,
             .directions = XKB_KEY_TAP,
             .down = {
@@ -1907,7 +2008,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_DOWN,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_DOWN
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -1932,7 +2036,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_UP,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_UP
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -1956,7 +2063,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Button: double click */
         {
-            .keycode = EVDEV_OFFSET + KEY_KPPLUS,
+            .keycode = KEY_KPPLUS + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = {
@@ -1994,7 +2101,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Latch LevelThree */
         {
-            .keycode = EVDEV_OFFSET + KEY_RIGHTALT,
+            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
             .repeats = false,
             .directions = XKB_KEY_TAP,
             .down = {
@@ -2002,7 +2109,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_DOWN,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_DOWN
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -2027,7 +2137,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_UP,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_UP
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -2051,7 +2164,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Button: lock 1 */
         {
-            .keycode = EVDEV_OFFSET + KEY_KP0,
+            .keycode = KEY_KP0 + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = {
@@ -2089,7 +2202,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Latch LevelThree */
         {
-            .keycode = EVDEV_OFFSET + KEY_RIGHTALT,
+            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
             .repeats = false,
             .directions = XKB_KEY_TAP,
             .down = {
@@ -2097,7 +2210,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_DOWN,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_DOWN
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -2122,7 +2238,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_UP,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_UP
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -2146,7 +2265,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Button: unlock 1 */
         {
-            .keycode = EVDEV_OFFSET + KEY_KPDOT,
+            .keycode = KEY_KPDOT + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = {
@@ -2188,7 +2307,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Button drag */
         {
-            .keycode = EVDEV_OFFSET + KEY_KPEQUAL,
+            .keycode = KEY_KPEQUAL + EVDEV_OFFSET,
             .repeats = false,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = {
@@ -2210,7 +2329,7 @@ test_mouse_keys(struct xkb_context *ctx)
             .up = { .events_count = 0 },
         },
         {
-            .keycode = EVDEV_OFFSET + KEY_KPEQUAL,
+            .keycode = KEY_KPEQUAL + EVDEV_OFFSET,
             .repeats = false,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = { .events_count = 0 },
@@ -2234,7 +2353,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Latch LevelThree */
         {
-            .keycode = EVDEV_OFFSET + KEY_RIGHTALT,
+            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
             .repeats = false,
             .directions = XKB_KEY_TAP,
             .down = {
@@ -2242,7 +2361,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_DOWN,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_DOWN
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -2267,7 +2389,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_UP,
-                        .keycode = EVDEV_OFFSET + KEY_RIGHTALT
+                        .key = {
+                            .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                            .direction = XKB_KEY_UP
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -2291,7 +2416,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Button: set default to 2 */
         {
-            .keycode = EVDEV_OFFSET + KEY_KPASTERISK,
+            .keycode = KEY_KPASTERISK + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = { .events_count = 0 },
@@ -2299,7 +2424,7 @@ test_mouse_keys(struct xkb_context *ctx)
             .up = { .events_count = 0 },
         },
         {
-            .keycode = EVDEV_OFFSET + KEY_KPPLUS,
+            .keycode = KEY_KPPLUS + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = {
@@ -2335,7 +2460,7 @@ test_mouse_keys(struct xkb_context *ctx)
             .up = { .events_count = 0 },
         },
         {
-            .keycode = EVDEV_OFFSET + KEY_KP0,
+            .keycode = KEY_KP0 + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = {
@@ -2359,7 +2484,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Button: set default to 3 */
         {
-            .keycode = EVDEV_OFFSET + KEY_KPMINUS,
+            .keycode = KEY_KPMINUS + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = { .events_count = 0 },
@@ -2367,7 +2492,7 @@ test_mouse_keys(struct xkb_context *ctx)
             .up = { .events_count = 0 },
         },
         {
-            .keycode = EVDEV_OFFSET + KEY_KPPLUS,
+            .keycode = KEY_KPPLUS + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = {
@@ -2389,7 +2514,7 @@ test_mouse_keys(struct xkb_context *ctx)
             .up = { .events_count = 0 },
         },
         {
-            .keycode = EVDEV_OFFSET + KEY_KPDOT,
+            .keycode = KEY_KPDOT + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = { .events_count = 0 },
@@ -2397,7 +2522,7 @@ test_mouse_keys(struct xkb_context *ctx)
             .up = { .events_count = 0 }, /* Cannot unlock button 3 */
         },
         {
-            .keycode = EVDEV_OFFSET + KEY_KP0,
+            .keycode = KEY_KP0 + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = {
@@ -2421,7 +2546,7 @@ test_mouse_keys(struct xkb_context *ctx)
 
         /* Button: set default to 2 */
         {
-            .keycode = EVDEV_OFFSET + KEY_KPASTERISK,
+            .keycode = KEY_KPASTERISK + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = { .events_count = 0 },
@@ -2429,7 +2554,7 @@ test_mouse_keys(struct xkb_context *ctx)
             .up = { .events_count = 0 },
         },
         {
-            .keycode = EVDEV_OFFSET + KEY_KPDOT,
+            .keycode = KEY_KPDOT + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = { .events_count = 0 },
@@ -2451,7 +2576,7 @@ test_mouse_keys(struct xkb_context *ctx)
             },
         },
         {
-            .keycode = EVDEV_OFFSET + KEY_KPPLUS,
+            .keycode = KEY_KPPLUS + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = {
@@ -2477,7 +2602,7 @@ test_mouse_keys(struct xkb_context *ctx)
          * Check disabling mouse keys control: press keys with pointer actions
          */
         {
-            .keycode = EVDEV_OFFSET + KEY_KP7,
+            .keycode = KEY_KP7 + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_PRESS,
             .down = {
@@ -2499,7 +2624,7 @@ test_mouse_keys(struct xkb_context *ctx)
             .up = { .events_count = 0 }
         },
         {
-            .keycode = EVDEV_OFFSET + KEY_KP5,
+            .keycode = KEY_KP5 + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_PRESS,
             .down = {
@@ -2521,7 +2646,7 @@ test_mouse_keys(struct xkb_context *ctx)
             .up = { .events_count = 0 }
         },
         {
-            .keycode = EVDEV_OFFSET + KEY_KPEQUAL,
+            .keycode = KEY_KPEQUAL + EVDEV_OFFSET,
             .repeats = false,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = {
@@ -2543,7 +2668,7 @@ test_mouse_keys(struct xkb_context *ctx)
             .up = { .events_count = 0 },
         },
         {
-            .keycode = EVDEV_OFFSET + KEY_KPEQUAL,
+            .keycode = KEY_KPEQUAL + EVDEV_OFFSET,
             .repeats = false,
             .directions = XKB_KEY_PRESS,
             .down = { .events_count = 0 },
@@ -2555,7 +2680,7 @@ test_mouse_keys(struct xkb_context *ctx)
              * This key is only tapped before deactivating mouse keys, in order
              * to check that locked buttons are reset at mouse key reactivation.
              */
-            .keycode = EVDEV_OFFSET + KEY_KPLEFTPAREN,
+            .keycode = KEY_KPLEFTPAREN + EVDEV_OFFSET,
             .repeats = false,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = {
@@ -2581,7 +2706,7 @@ test_mouse_keys(struct xkb_context *ctx)
          * Check disabling mouse keys control: switch mouse keys off
          */
         {
-            .keycode = EVDEV_OFFSET + KEY_KPPLUSMINUS,
+            .keycode = KEY_KPPLUSMINUS + EVDEV_OFFSET,
             .repeats = false,
             .directions = XKB_KEY_TAP,
             .down = {
@@ -2589,7 +2714,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_DOWN,
-                        .keycode = EVDEV_OFFSET + KEY_KPPLUSMINUS
+                        .key = {
+                            .keycode = KEY_KPPLUSMINUS + EVDEV_OFFSET,
+                            .direction = XKB_KEY_DOWN
+                        }
                     }
                 },
                 .events_count = 1
@@ -2599,7 +2727,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_UP,
-                        .keycode = EVDEV_OFFSET + KEY_KPPLUSMINUS
+                        .key = {
+                            .keycode = KEY_KPPLUSMINUS + EVDEV_OFFSET,
+                            .direction = XKB_KEY_UP
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -2622,7 +2753,7 @@ test_mouse_keys(struct xkb_context *ctx)
          * Check disabling mouse keys control: release keys with pointer actions
          */
         {
-            .keycode = EVDEV_OFFSET + KEY_KP7,
+            .keycode = KEY_KP7 + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_RELEASE,
             .down = { .events_count = 0 },
@@ -2630,7 +2761,7 @@ test_mouse_keys(struct xkb_context *ctx)
             .up = { .events_count = 0 }
         },
         {
-            .keycode = EVDEV_OFFSET + KEY_KP5,
+            .keycode = KEY_KP5 + EVDEV_OFFSET,
             .repeats = true,
             .directions = XKB_KEY_RELEASE,
             .down = { .events_count = 0 },
@@ -2652,7 +2783,7 @@ test_mouse_keys(struct xkb_context *ctx)
             }
         },
         {
-            .keycode = EVDEV_OFFSET + KEY_KPEQUAL,
+            .keycode = KEY_KPEQUAL + EVDEV_OFFSET,
             .repeats = false,
             .directions = XKB_KEY_RELEASE,
             .down = { .events_count = 0 },
@@ -2678,7 +2809,7 @@ test_mouse_keys(struct xkb_context *ctx)
          * Check disabling mouse keys control: switch mouse keys on
          */
         {
-            .keycode = EVDEV_OFFSET + KEY_KPPLUSMINUS,
+            .keycode = KEY_KPPLUSMINUS + EVDEV_OFFSET,
             .repeats = false,
             .directions = XKB_KEY_TAP,
             .down = {
@@ -2686,7 +2817,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_DOWN,
-                        .keycode = EVDEV_OFFSET + KEY_KPPLUSMINUS
+                        .key = {
+                            .keycode = KEY_KPPLUSMINUS + EVDEV_OFFSET,
+                            .direction = XKB_KEY_DOWN
+                        }
                     },
                     {
                         .ctx = ctx,
@@ -2708,7 +2842,10 @@ test_mouse_keys(struct xkb_context *ctx)
                     {
                         .ctx = ctx,
                         .type = XKB_EVENT_TYPE_KEY_UP,
-                        .keycode = EVDEV_OFFSET + KEY_KPPLUSMINUS
+                        .key = {
+                            .keycode = KEY_KPPLUSMINUS + EVDEV_OFFSET,
+                            .direction = XKB_KEY_UP
+                        }
                     },
                 },
                 .events_count = 1
@@ -2719,7 +2856,7 @@ test_mouse_keys(struct xkb_context *ctx)
          * Check disabling mouse keys control: locked controls value
          */
         {
-            .keycode = EVDEV_OFFSET + KEY_KPLEFTPAREN,
+            .keycode = KEY_KPLEFTPAREN + EVDEV_OFFSET,
             .repeats = false,
             .directions = XKB_KEY_TAP | XKB_KEY_REPEAT,
             .down = { .events_count = 0 },
@@ -2989,7 +3126,10 @@ test_shortcuts_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_Q + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_Q + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = context,
@@ -3034,7 +3174,10 @@ test_shortcuts_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_REPEATED,
-            .keycode = KEY_Q + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_Q + EVDEV_OFFSET,
+                .direction = XKB_KEY_REPEATED
+            }
         },
     );
 
@@ -3045,7 +3188,10 @@ test_shortcuts_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_UP,
-            .keycode = KEY_Q + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_Q + EVDEV_OFFSET,
+                .direction = XKB_KEY_UP
+            }
         }
     );
 
@@ -3056,7 +3202,10 @@ test_shortcuts_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_RIGHTCTRL + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_RIGHTCTRL + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = context,
@@ -3110,7 +3259,10 @@ test_shortcuts_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_UP,
-            .keycode = KEY_RIGHTCTRL + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_RIGHTCTRL + EVDEV_OFFSET,
+                .direction = XKB_KEY_UP
+            }
         },
         {
             .ctx = context,
@@ -3174,7 +3326,10 @@ test_shortcuts_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_102ND + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_102ND + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = context,
@@ -3239,7 +3394,10 @@ test_shortcuts_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_Q + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_Q + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = context,
@@ -3286,7 +3444,10 @@ test_shortcuts_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_UP,
-            .keycode = KEY_Q + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_Q + EVDEV_OFFSET,
+                .direction = XKB_KEY_UP
+            }
         }
     );
 
@@ -3297,7 +3458,10 @@ test_shortcuts_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_UP,
-            .keycode = KEY_102ND + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_102ND + EVDEV_OFFSET,
+                .direction = XKB_KEY_UP
+            }
         },
         {
             .ctx = context,
@@ -3398,7 +3562,10 @@ test_shortcuts_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_Q + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_Q + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = context,
@@ -3445,7 +3612,10 @@ test_shortcuts_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_REPEATED,
-            .keycode = KEY_Q + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_Q + EVDEV_OFFSET,
+                .direction = XKB_KEY_REPEATED
+            }
         },
         {
             .ctx = context,
@@ -3492,7 +3662,10 @@ test_shortcuts_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_UP,
-            .keycode = KEY_Q + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_Q + EVDEV_OFFSET,
+                .direction = XKB_KEY_UP
+            }
         },
         {
             .ctx = context,
@@ -3736,7 +3909,10 @@ test_shortcuts_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_COPY + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_COPY + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = context,
@@ -3821,7 +3997,10 @@ test_shortcuts_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_Q + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_Q + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = context,
@@ -3885,7 +4064,10 @@ test_shortcuts_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_COPY + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_COPY + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = context,
@@ -3975,7 +4157,10 @@ test_shortcuts_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_Q + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_Q + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = context,
@@ -4028,7 +4213,10 @@ test_shortcuts_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_Q + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_Q + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = context,
@@ -4075,7 +4263,10 @@ test_shortcuts_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_COPY + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_COPY + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = context,
@@ -4237,7 +4428,7 @@ test_overlays(struct xkb_context *context)
             continue;
 
         assert(xkb_machine_process_key(
-            sm, EVDEV_OFFSET + KEY_J, keycode_tests[t].direction, events
+            sm, KEY_J + EVDEV_OFFSET, keycode_tests[t].direction, events
         ) == XKB_SUCCESS);
         const struct xkb_event *event;
         while ((event = xkb_events_next(events))) {
@@ -4388,7 +4579,10 @@ test_modifiers_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_LEFTALT + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_LEFTALT + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = context,
@@ -4427,7 +4621,10 @@ test_modifiers_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_Y + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_Y + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = context,
@@ -4466,7 +4663,10 @@ test_modifiers_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_REPEATED,
-            .keycode = KEY_Y + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_Y + EVDEV_OFFSET,
+                .direction = XKB_KEY_REPEATED
+            }
         },
         {
             .ctx = context,
@@ -4505,7 +4705,10 @@ test_modifiers_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_UP,
-            .keycode = KEY_Y + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_Y + EVDEV_OFFSET,
+                .direction = XKB_KEY_UP
+            }
         },
         {
             .ctx = context,
@@ -4570,7 +4773,10 @@ test_modifiers_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_Y + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_Y + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = context,
@@ -4614,7 +4820,10 @@ test_modifiers_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_UP,
-            .keycode = KEY_Y + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_Y + EVDEV_OFFSET,
+                .direction = XKB_KEY_UP
+            }
         },
         {
             .ctx = context,
@@ -4642,7 +4851,10 @@ test_modifiers_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_BACKSPACE + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_BACKSPACE + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         }
     );
 
@@ -4669,7 +4881,10 @@ test_modifiers_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_UP,
-            .keycode = KEY_LEFTALT + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_LEFTALT + EVDEV_OFFSET,
+                .direction = XKB_KEY_UP
+            }
         },
         {
             .ctx = context,
@@ -4752,7 +4967,10 @@ test_modifiers_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_CAPSLOCK + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_CAPSLOCK + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = context,
@@ -4832,7 +5050,10 @@ test_modifiers_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_COPY + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_COPY + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = context,
@@ -4905,7 +5126,10 @@ test_modifiers_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_REPEATED,
-            .keycode = KEY_COPY + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_COPY + EVDEV_OFFSET,
+                .direction = XKB_KEY_REPEATED
+            }
         },
         {
             .ctx = context,
@@ -4979,7 +5203,10 @@ test_modifiers_tweak(struct xkb_context *context)
         {
             .ctx = context,
             .type = XKB_EVENT_TYPE_KEY_UP,
-            .keycode = KEY_COPY + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_COPY + EVDEV_OFFSET,
+                .direction = XKB_KEY_UP
+            }
         },
         {
             .ctx = context,

--- a/test/state.c
+++ b/test/state.c
@@ -812,7 +812,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_LEFTCTRL + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -846,7 +846,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -959,7 +959,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_UP,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_LEFTCTRL + EVDEV_OFFSET,
                 .direction = XKB_KEY_UP
@@ -1006,7 +1006,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_UP,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
                 .direction = XKB_KEY_UP
@@ -1101,7 +1101,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_CAPSLOCK + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -1129,7 +1129,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_UP,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_CAPSLOCK + EVDEV_OFFSET,
                 .direction = XKB_KEY_UP
@@ -1154,7 +1154,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_CAPSLOCK + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -1181,7 +1181,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_UP,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_CAPSLOCK + EVDEV_OFFSET,
                 .direction = XKB_KEY_UP
@@ -1214,7 +1214,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_NUMLOCK + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -1240,7 +1240,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_REPEATED,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_NUMLOCK + EVDEV_OFFSET,
                 .direction = XKB_KEY_REPEATED
@@ -1252,7 +1252,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_UP,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_NUMLOCK + EVDEV_OFFSET,
                 .direction = XKB_KEY_UP
@@ -1277,7 +1277,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_NUMLOCK + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -1302,7 +1302,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_REPEATED,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_NUMLOCK + EVDEV_OFFSET,
                 .direction = XKB_KEY_REPEATED
@@ -1314,7 +1314,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_UP,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_NUMLOCK + EVDEV_OFFSET,
                 .direction = XKB_KEY_UP
@@ -1346,7 +1346,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_5 + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -1359,7 +1359,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_REPEATED,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_5 + EVDEV_OFFSET,
                 .direction = XKB_KEY_REPEATED
@@ -1371,7 +1371,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_UP,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_5 + EVDEV_OFFSET,
                 .direction = XKB_KEY_UP
@@ -1392,7 +1392,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_DOWN,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_6 + EVDEV_OFFSET,
                 .direction = XKB_KEY_DOWN
@@ -1405,7 +1405,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_REPEATED,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_6 + EVDEV_OFFSET,
                 .direction = XKB_KEY_REPEATED
@@ -1417,7 +1417,7 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         events,
         {
             .ctx = ctx,
-            .type = XKB_EVENT_TYPE_KEY_UP,
+            .type = XKB_EVENT_TYPE_KEY,
             .key = {
                 .keycode = KEY_6 + EVDEV_OFFSET,
                 .direction = XKB_KEY_UP

--- a/test/state.c
+++ b/test/state.c
@@ -813,7 +813,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_LEFTCTRL + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_LEFTCTRL + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = ctx,
@@ -844,7 +847,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_RIGHTALT + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = ctx,
@@ -954,7 +960,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_UP,
-            .keycode = KEY_LEFTCTRL + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_LEFTCTRL + EVDEV_OFFSET,
+                .direction = XKB_KEY_UP
+            }
         },
         {
             .ctx = ctx,
@@ -998,7 +1007,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_UP,
-            .keycode = KEY_RIGHTALT + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_RIGHTALT + EVDEV_OFFSET,
+                .direction = XKB_KEY_UP
+            }
         },
         {
             .ctx = ctx,
@@ -1090,7 +1102,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_CAPSLOCK + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_CAPSLOCK + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = ctx,
@@ -1115,7 +1130,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_UP,
-            .keycode = KEY_CAPSLOCK + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_CAPSLOCK + EVDEV_OFFSET,
+                .direction = XKB_KEY_UP
+            }
         },
         {
             .ctx = ctx,
@@ -1137,7 +1155,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_CAPSLOCK + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_CAPSLOCK + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = ctx,
@@ -1161,7 +1182,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_UP,
-            .keycode = KEY_CAPSLOCK + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_CAPSLOCK + EVDEV_OFFSET,
+                .direction = XKB_KEY_UP
+            }
         },
         {
             .ctx = ctx,
@@ -1191,7 +1215,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_NUMLOCK + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_NUMLOCK + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = ctx,
@@ -1214,7 +1241,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_REPEATED,
-            .keycode = KEY_NUMLOCK + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_NUMLOCK + EVDEV_OFFSET,
+                .direction = XKB_KEY_REPEATED
+            }
         }
     );
     update_states(state, sm, KEY_NUMLOCK + EVDEV_OFFSET, XKB_KEY_UP);
@@ -1223,7 +1253,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_UP,
-            .keycode = KEY_NUMLOCK + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_NUMLOCK + EVDEV_OFFSET,
+                .direction = XKB_KEY_UP
+            }
         },
         {
             .ctx = ctx,
@@ -1245,7 +1278,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_NUMLOCK + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_NUMLOCK + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         },
         {
             .ctx = ctx,
@@ -1267,7 +1303,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_REPEATED,
-            .keycode = KEY_NUMLOCK + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_NUMLOCK + EVDEV_OFFSET,
+                .direction = XKB_KEY_REPEATED
+            }
         }
     );
     update_states(state, sm, KEY_NUMLOCK + EVDEV_OFFSET, XKB_KEY_UP);
@@ -1276,7 +1315,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_UP,
-            .keycode = KEY_NUMLOCK + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_NUMLOCK + EVDEV_OFFSET,
+                .direction = XKB_KEY_UP
+            }
         },
         {
             .ctx = ctx,
@@ -1305,7 +1347,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_5 + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_5 + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         }
     );
     /* Ensure it does repeat */
@@ -1315,7 +1360,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_REPEATED,
-            .keycode = KEY_5 + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_5 + EVDEV_OFFSET,
+                .direction = XKB_KEY_REPEATED
+            }
         }
     );
     update_states(state, sm, KEY_5 + EVDEV_OFFSET, XKB_KEY_UP);
@@ -1324,7 +1372,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_UP,
-            .keycode = KEY_5 + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_5 + EVDEV_OFFSET,
+                .direction = XKB_KEY_UP
+            }
         }
     );
 
@@ -1342,7 +1393,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_DOWN,
-            .keycode = KEY_6 + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_6 + EVDEV_OFFSET,
+                .direction = XKB_KEY_DOWN
+            }
         }
     );
     /* Ensure it does repeat */
@@ -1352,7 +1406,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_REPEATED,
-            .keycode = KEY_6 + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_6 + EVDEV_OFFSET,
+                .direction = XKB_KEY_REPEATED
+            }
         }
     );
     update_states(state, sm, KEY_6 + EVDEV_OFFSET, XKB_KEY_UP);
@@ -1361,7 +1418,10 @@ test_update_key(struct xkb_context *ctx, struct xkb_keymap *keymap,
         {
             .ctx = ctx,
             .type = XKB_EVENT_TYPE_KEY_UP,
-            .keycode = KEY_6 + EVDEV_OFFSET
+            .key = {
+                .keycode = KEY_6 + EVDEV_OFFSET,
+                .direction = XKB_KEY_UP
+            }
         }
     );
 

--- a/test/state.h
+++ b/test/state.h
@@ -148,9 +148,7 @@ xkb_event_eq(const struct xkb_event *event1, const struct xkb_event *event2)
     if (event1->type != event2->type)
         return false;
     switch (event1->type) {
-    case XKB_EVENT_TYPE_KEY_DOWN:
-    case XKB_EVENT_TYPE_KEY_REPEATED:
-    case XKB_EVENT_TYPE_KEY_UP:
+    case XKB_EVENT_TYPE_KEY:
         return event1->key.keycode == event2->key.keycode &&
                event1->key.direction == event2->key.direction;
     case XKB_EVENT_TYPE_COMPONENTS_CHANGE:
@@ -164,7 +162,7 @@ xkb_event_eq(const struct xkb_event *event1, const struct xkb_event *event2)
                       sizeof(event1->pointer_button)) == 0;
     default:
         {} /* Label followed by declaration requires C23 */
-        static_assert(XKB_EVENT_TYPE_POINTER_BUTTON == 6 &&
+        static_assert(XKB_EVENT_TYPE_POINTER_BUTTON == 4 &&
                       XKB_EVENT_TYPE_POINTER_BUTTON ==
                       (enum xkb_event_type) _LAST_XKB_EVENT_TYPE,
                       "Missing state event type");
@@ -177,9 +175,7 @@ print_event(const char *prefix, const struct xkb_event *event)
 {
     fprintf(stderr, "%s", prefix);
     switch (event->type) {
-    case XKB_EVENT_TYPE_KEY_DOWN:
-    case XKB_EVENT_TYPE_KEY_REPEATED:
-    case XKB_EVENT_TYPE_KEY_UP:
+    case XKB_EVENT_TYPE_KEY:
         fprintf(stderr, "type: key %s; keycode: %"PRIu32"\n",
                 (event->key.direction == XKB_KEY_UP)
                     ? "up"
@@ -222,7 +218,7 @@ print_event(const char *prefix, const struct xkb_event *event)
         break;
     default:
         {} /* Label followed by declaration requires C23 */
-        static_assert(XKB_EVENT_TYPE_POINTER_BUTTON == 6 &&
+        static_assert(XKB_EVENT_TYPE_POINTER_BUTTON == 4 &&
                       XKB_EVENT_TYPE_POINTER_BUTTON ==
                       (enum xkb_event_type) _LAST_XKB_EVENT_TYPE,
                       "Missing state event type");

--- a/test/state.h
+++ b/test/state.h
@@ -151,7 +151,8 @@ xkb_event_eq(const struct xkb_event *event1, const struct xkb_event *event2)
     case XKB_EVENT_TYPE_KEY_DOWN:
     case XKB_EVENT_TYPE_KEY_REPEATED:
     case XKB_EVENT_TYPE_KEY_UP:
-        return event1->keycode == event2->keycode;
+        return event1->key.keycode == event2->key.keycode &&
+               event1->key.direction == event2->key.direction;
     case XKB_EVENT_TYPE_COMPONENTS_CHANGE:
         return memcmp(&event1->components, &event2->components,
                       sizeof(event1->components)) == 0;
@@ -180,12 +181,12 @@ print_event(const char *prefix, const struct xkb_event *event)
     case XKB_EVENT_TYPE_KEY_REPEATED:
     case XKB_EVENT_TYPE_KEY_UP:
         fprintf(stderr, "type: key %s; keycode: %"PRIu32"\n",
-                (event->type == XKB_EVENT_TYPE_KEY_UP)
+                (event->key.direction == XKB_KEY_UP)
                     ? "up"
-                    : event->type == XKB_EVENT_TYPE_KEY_REPEATED
+                    : event->key.direction == XKB_KEY_REPEATED
                         ? "repeat"
                         : "down",
-                event->keycode);
+                event->key.keycode);
         break;
     case XKB_EVENT_TYPE_COMPONENTS_CHANGE:
         fprintf(stderr, "type: components; changed: 0x%x\n"

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -789,27 +789,23 @@ tools_print_events(const char *prefix, struct xkb_state *state,
 {
     const struct xkb_event *event;
     while ((event = xkb_events_next(events)) != NULL) {
-        const enum xkb_event_type event_type =
-            xkb_event_get_type(event);
+        const enum xkb_event_type event_type = xkb_event_get_type(event);
+        enum xkb_error_code error = XKB_SUCCESS;;
         switch (event_type) {
-            case XKB_EVENT_TYPE_KEY_DOWN:
-            case XKB_EVENT_TYPE_KEY_REPEATED:
-            case XKB_EVENT_TYPE_KEY_UP: {
-                const xkb_keycode_t kc = xkb_event_get_keycode(event);
-                const enum xkb_key_direction direction
-                    = (event_type == XKB_EVENT_TYPE_KEY_UP)
-                    ? XKB_KEY_UP
-                    : (event_type == XKB_EVENT_TYPE_KEY_REPEATED)
-                        ? XKB_KEY_REPEATED
-                        : XKB_KEY_DOWN;
+            case XKB_EVENT_TYPE_KEY: {
+                xkb_keycode_t kc;
+                enum xkb_key_direction direction;
+                error = xkb_event_get_keycode(event, &kc, &direction);
+                if (error != XKB_SUCCESS)
+                    goto event_error;
                 if (compose_state && direction == XKB_KEY_DOWN) {
                     const xkb_keysym_t keysym =
                         xkb_state_key_get_one_sym(state, kc);
                     xkb_compose_state_feed(compose_state, keysym);
                 }
                 tools_print_keycode_state(prefix, state, compose_state, kc,
-                                          direction, consumed_mode,
-                                          options);
+                                        direction, consumed_mode,
+                                        options);
                 if (compose_state) {
                     const enum xkb_compose_status status =
                         xkb_compose_state_get_status(compose_state);
@@ -830,37 +826,31 @@ tools_print_events(const char *prefix, struct xkb_state *state,
                 struct xkb_event_pointer_motion motion = {
                     .size = sizeof(motion)
                 };
-                const enum xkb_error_code error =
-                    xkb_event_get_pointer_motion(event, &motion);
-                if (error == XKB_SUCCESS) {
-                    tools_print_pointer_motion(prefix, &motion, options);
-                } else {
-                    fprintf(stderr,
-                            "ERROR: cannot process event type %d; error code: %d\n",
-                            event_type, error);
-                }
+                error = xkb_event_get_pointer_motion(event, &motion);
+                if (error != XKB_SUCCESS)
+                    goto event_error;
+                tools_print_pointer_motion(prefix, &motion, options);
                 break;
             }
             case XKB_EVENT_TYPE_POINTER_BUTTON: {
                 struct xkb_event_pointer_button button = {
                     .size = sizeof(button)
                 };
-                const enum xkb_error_code error =
-                    xkb_event_get_pointer_button(event, &button);
-                if (error == XKB_SUCCESS) {
-                    tools_print_pointer_button(prefix, &button, options);
-                } else {
-                    fprintf(stderr,
-                            "ERROR: cannot process event type %d; error code: %d\n",
-                            event_type, error);
-                }
+                error = xkb_event_get_pointer_button(event, &button);
+                if (error != XKB_SUCCESS)
+                    goto event_error;
+                tools_print_pointer_button(prefix, &button, options);
                 break;
             }
             default: {
-                static_assert(XKB_EVENT_TYPE_POINTER_BUTTON == 6 &&
+                static_assert(XKB_EVENT_TYPE_POINTER_BUTTON == 4 &&
                               XKB_EVENT_TYPE_POINTER_BUTTON ==
                               (enum xkb_event_type) _LAST_XKB_EVENT_TYPE,
                               "Missing event type");
+            event_error:
+                fprintf(stderr,
+                        "ERROR: cannot process event type %d; error code: %d\n",
+                        event_type, error);
             }
         }
     }


### PR DESCRIPTION
Make it consistent with the rest of the API