### PR TITLE
state: Refactor xkb_state_serialize_enabled_controls()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -214,7 +214,7 @@ libxkbcommon [1.14.0-beta1] – 2026-07-22
 - Added `xkb_state::xkb_state_update_synthetic()` for out-of-band updates.
 - Added API to change controls of the keyboard state:
   - new enumeration `xkb_keyboard_control_flags`
-  - new function `xkb_state::xkb_state_serialize_enabled_controls()`
+  - new function `xkb_state::xkb_state_serialize_controls()`
   - new member `XKB_STATE_CONTROLS_EFFECTIVE` in the `xkb_state_component` enumeration.
 - Added support for the <strong>[sticky keys]</strong> accessibility feature.
   ([#596](https://github.com/xkbcommon/libxkbcommon/issues/596))

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -5503,8 +5503,8 @@ enum xkb_state_match {
  * [global keyboard controls]: @ref xkb_keyboard_control_flags
  */
 XKB_EXPORT enum xkb_keyboard_control_flags
-xkb_state_serialize_enabled_controls(const struct xkb_state *state,
-                                     enum xkb_state_component components);
+xkb_state_serialize_controls(const struct xkb_state *state,
+                             enum xkb_state_component components);
 
 /**
  * The counterpart to `xkb_state::xkb_state_update_mask()` for modifiers, to be

--- a/src/state.c
+++ b/src/state.c
@@ -2549,8 +2549,8 @@ serialize_controls(const struct state_components *components,
 }
 
 enum xkb_keyboard_control_flags
-xkb_state_serialize_enabled_controls(const struct xkb_state *state,
-                                     enum xkb_state_component type)
+xkb_state_serialize_controls(const struct xkb_state *state,
+                             enum xkb_state_component type)
 {
     return serialize_controls(&state->components, type);
 }

--- a/test/server-state.c
+++ b/test/server-state.c
@@ -642,7 +642,7 @@ test_state_update_basics(struct xkb_context *ctx)
             event.components.components.group);
         assert(xkb_state_serialize_leds(state, XKB_STATE_LEDS) ==
             event.components.components.leds);
-        assert(xkb_state_serialize_enabled_controls(state, XKB_STATE_CONTROLS_EFFECTIVE) ==
+        assert(xkb_state_serialize_controls(state, XKB_STATE_CONTROLS_EFFECTIVE) ==
                (enum xkb_keyboard_control_flags)event.components.components.controls);
     }
 
@@ -745,7 +745,7 @@ update_key(struct xkb_machine *sm,
                       xkb_state_serialize_leds(state, XKB_STATE_LEDS),
                       components.leds, "0x%"PRIx32);
             assert_eq("controls",
-                      xkb_state_serialize_enabled_controls(state, XKB_STATE_CONTROLS_EFFECTIVE),
+                      xkb_state_serialize_controls(state, XKB_STATE_CONTROLS_EFFECTIVE),
                       components.controls, "0x%x");
             break;
         }
@@ -940,7 +940,7 @@ test_sticky_keys(struct xkb_context *ctx)
     enum xkb_keyboard_control_flags controls;
     enum xkb_state_component changed;
 
-    controls = xkb_state_serialize_enabled_controls(state, XKB_STATE_CONTROLS_EFFECTIVE);
+    controls = xkb_state_serialize_controls(state, XKB_STATE_CONTROLS_EFFECTIVE);
     assert(controls == 0);
 
     enum sticky_key_activation {
@@ -975,7 +975,7 @@ test_sticky_keys(struct xkb_context *ctx)
             changed = update_key(sm, events, state, use_events,
                                  KEY_F2 + EVDEV_OFFSET, XKB_KEY_DOWN);
             assert(changed == XKB_STATE_CONTROLS_EFFECTIVE);
-            controls = xkb_state_serialize_enabled_controls(state, XKB_STATE_CONTROLS_EFFECTIVE);
+            controls = xkb_state_serialize_controls(state, XKB_STATE_CONTROLS_EFFECTIVE);
             assert(controls == XKB_KEYBOARD_CONTROL_A11Y_STICKY_KEYS);
             changed = update_key(sm, events, state, use_events,
                                  KEY_F2 + EVDEV_OFFSET, XKB_KEY_UP);
@@ -986,7 +986,7 @@ test_sticky_keys(struct xkb_context *ctx)
                                       XKB_KEYBOARD_CONTROL_A11Y_STICKY_KEYS,
                                       XKB_KEYBOARD_CONTROL_A11Y_STICKY_KEYS);
             assert(changed == XKB_STATE_CONTROLS_EFFECTIVE);
-            controls = xkb_state_serialize_enabled_controls(state, XKB_STATE_CONTROLS_EFFECTIVE);
+            controls = xkb_state_serialize_controls(state, XKB_STATE_CONTROLS_EFFECTIVE);
             assert(controls == XKB_KEYBOARD_CONTROL_A11Y_STICKY_KEYS);
             break;
         }
@@ -997,11 +997,11 @@ test_sticky_keys(struct xkb_context *ctx)
                 XKB_KEYBOARD_CONTROL_A11Y_STICKY_KEYS
             );
             assert(changed == XKB_STATE_CONTROLS_EFFECTIVE);
-            controls = xkb_state_serialize_enabled_controls(state, XKB_STATE_CONTROLS_EFFECTIVE);
+            controls = xkb_state_serialize_controls(state, XKB_STATE_CONTROLS_EFFECTIVE);
             assert(controls == XKB_KEYBOARD_CONTROL_A11Y_STICKY_KEYS);
             break;
         }
-        controls = xkb_state_serialize_enabled_controls(state, XKB_STATE_CONTROLS_EFFECTIVE);
+        controls = xkb_state_serialize_controls(state, XKB_STATE_CONTROLS_EFFECTIVE);
         assert(controls == XKB_KEYBOARD_CONTROL_A11Y_STICKY_KEYS);
 
         /* Latch shift (sticky) */
@@ -1148,7 +1148,7 @@ test_sticky_keys(struct xkb_context *ctx)
                                XKB_STATE_LEDS));
             break;
         }
-        controls = xkb_state_serialize_enabled_controls(state, XKB_STATE_CONTROLS_EFFECTIVE);
+        controls = xkb_state_serialize_controls(state, XKB_STATE_CONTROLS_EFFECTIVE);
         assert(controls == 0);
         mods = xkb_state_serialize_mods(state, XKB_STATE_MODS_EFFECTIVE);
         assert(mods == 0);
@@ -1164,7 +1164,7 @@ test_sticky_keys(struct xkb_context *ctx)
         mods = xkb_state_serialize_mods(state, XKB_STATE_MODS_EFFECTIVE);
         assert(mods == 0);
 
-        controls = xkb_state_serialize_enabled_controls(state, XKB_STATE_CONTROLS_EFFECTIVE);
+        controls = xkb_state_serialize_controls(state, XKB_STATE_CONTROLS_EFFECTIVE);
         assert(controls == 0);
     }
 

--- a/tools/tools-common.c
+++ b/tools/tools-common.c
@@ -367,7 +367,7 @@ print_controls(struct xkb_state *state, bool verbose) {
     );
 
     const enum xkb_keyboard_control_flags ctrls =
-        xkb_state_serialize_enabled_controls(state, XKB_STATE_CONTROLS_EFFECTIVE);
+        xkb_state_serialize_controls(state, XKB_STATE_CONTROLS_EFFECTIVE);
 
     if (verbose)
         printf("0x%08x ", ctrls);

--- a/xkbcommon.map
+++ b/xkbcommon.map
@@ -160,7 +160,7 @@ global:
     xkb_state_new_from_machine;
     xkb_state_update_event;
     xkb_state_update_synthetic;
-    xkb_state_serialize_enabled_controls;
+    xkb_state_serialize_controls;
     xkb_machine_builder_new;
     xkb_machine_builder_get_keymap;
     xkb_machine_builder_ref;


### PR DESCRIPTION
Rename `xkb_state_serialize_enabled_controls()` to `xkb_state_serialize_controls()`.