### PR TITLE
keymap: Make the key iterator skip unbound keys by default

### DIFF
--- a/data/enums/xkbcommon.yaml
+++ b/data/enums/xkbcommon.yaml
@@ -58,7 +58,7 @@ xkb_keymap_key_iterator_flags:
     value: 0
   - name: XKB_KEYMAP_KEY_ITERATOR_DESCENDING_ORDER
     value: 1
-  - name: XKB_KEYMAP_KEY_ITERATOR_SKIP_UNBOUND
+  - name: XKB_KEYMAP_KEY_ITERATOR_INCLUDE_UNBOUND
     value: 2
 xkb_event_type:
   - name: XKB_EVENT_TYPE_INVALID

--- a/include/xkbcommon/xkbcommon.h
+++ b/include/xkbcommon/xkbcommon.h
@@ -2170,7 +2170,7 @@ enum xkb_keymap_key_iterator_flags {
     /**
      * Do not apply any flags:
      * - iterate keys in *ascending* order;
-     * - iterate all keys, even if unbound (i.e. with no group).
+     * - iterate only *bound* keys, i.e. keys with some group.
      *
      * @since 1.14.0
      */
@@ -2183,12 +2183,12 @@ enum xkb_keymap_key_iterator_flags {
     XKB_KEYMAP_KEY_ITERATOR_DESCENDING_ORDER = (1 << 0),
     /**
      * @parblock
-     * Skip *unbound* keys, i.e. keys with no groups.
+     * Iterate all keys, including *unbound* keys, i.e. keys with no groups.
      * @endparblock
      *
      * @since 1.14.0
      */
-    XKB_KEYMAP_KEY_ITERATOR_SKIP_UNBOUND = (1 << 1),
+    XKB_KEYMAP_KEY_ITERATOR_INCLUDE_UNBOUND = (1 << 1),
 };
 
 /**

--- a/src/features/enums.h
+++ b/src/features/enums.h
@@ -125,7 +125,7 @@ enum xkb_enumerations_values {
     XKB_KEYMAP_KEY_ITERATOR_FLAGS_VALUES
         = XKB_KEYMAP_KEY_ITERATOR_NO_FLAGS
         | XKB_KEYMAP_KEY_ITERATOR_DESCENDING_ORDER
-        | XKB_KEYMAP_KEY_ITERATOR_SKIP_UNBOUND
+        | XKB_KEYMAP_KEY_ITERATOR_INCLUDE_UNBOUND
     ,
     XKB_EVENT_TYPE_VALUES
         = (1u << XKB_EVENT_TYPE_INVALID)
@@ -290,7 +290,7 @@ static const uint32_t xkb_keymap_serialize_flags_values[] = {
 static const uint32_t xkb_keymap_key_iterator_flags_values[] = {
     XKB_KEYMAP_KEY_ITERATOR_NO_FLAGS,
     XKB_KEYMAP_KEY_ITERATOR_DESCENDING_ORDER,
-    XKB_KEYMAP_KEY_ITERATOR_SKIP_UNBOUND,
+    XKB_KEYMAP_KEY_ITERATOR_INCLUDE_UNBOUND,
 };
 #endif
 

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -732,7 +732,7 @@ keymap_key_iterator_init(
         return;
     }
 
-    iter->skip_unbound = (config->flags & XKB_KEYMAP_KEY_ITERATOR_SKIP_UNBOUND);
+    iter->skip_unbound = !(config->flags & XKB_KEYMAP_KEY_ITERATOR_INCLUDE_UNBOUND);
     iter->increment = (config->flags & XKB_KEYMAP_KEY_ITERATOR_DESCENDING_ORDER)
         ? -1
         : 1;

--- a/test/keymap.c
+++ b/test/keymap.c
@@ -849,9 +849,9 @@ test_key_iterator(void)
         static const enum xkb_keymap_key_iterator_flags flags[] = {
             XKB_KEYMAP_KEY_ITERATOR_NO_FLAGS,
             XKB_KEYMAP_KEY_ITERATOR_DESCENDING_ORDER,
-            XKB_KEYMAP_KEY_ITERATOR_SKIP_UNBOUND,
+            XKB_KEYMAP_KEY_ITERATOR_INCLUDE_UNBOUND,
             XKB_KEYMAP_KEY_ITERATOR_DESCENDING_ORDER |
-            XKB_KEYMAP_KEY_ITERATOR_SKIP_UNBOUND,
+            XKB_KEYMAP_KEY_ITERATOR_INCLUDE_UNBOUND,
         };
         for (size_t f = 0; f < ARRAY_SIZE(flags); f++) {
             fprintf(stderr, "------\n*** %s: #%zu, flags: 0x%x ***\n",
@@ -866,7 +866,7 @@ test_key_iterator(void)
             const bool ascending =
                 !(flags[f] & XKB_KEYMAP_KEY_ITERATOR_DESCENDING_ORDER);
             const bool skip_unbound =
-                (flags[f] & XKB_KEYMAP_KEY_ITERATOR_SKIP_UNBOUND);
+                !(flags[f] & XKB_KEYMAP_KEY_ITERATOR_INCLUDE_UNBOUND);
             size_t expected_count = (skip_unbound)
                 ? tests[t].num_keys_bound
                 : tests[t].num_keys_all;


### PR DESCRIPTION
This is the configuration most users want.