### PR TITLE
Release/v1.14.0 beta2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
-xkbcommon [1.14.0-beta1] – 2026-07-22
+xkbcommon [1.14.0-beta2] – 2026-09-10
 =====================================
 
-[1.14.0-beta1]: https://github.com/xkbcommon/libxkbcommon/tree/xkbcommon-1.14.0-beta1
+[1.14.0-beta2]: https://github.com/xkbcommon/libxkbcommon/tree/xkbcommon-1.14.0-beta2
 
 @note The highlights of this release are:
 - A new `xkb_machine` keyboard state API specifically designed for *server* applications.
@@ -474,6 +474,7 @@ xkbcommon [1.14.0-beta1] – 2026-07-22
 ## Full changelog
 
 [1.13.2 → 1.14.0-beta1](https://github.com/xkbcommon/libxkbcommon/compare/xkbcommon-1.13.2...xkbcommon-1.14.0-beta1)
+[1.14.0-beta1 → 1.14.0-beta2](https://github.com/xkbcommon/libxkbcommon/compare/xkbcommon-1.14.0-beta1...xkbcommon-1.14.0-beta2)
 
 
 xkbcommon [1.13.2] – 2026-05-30

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -66,8 +66,6 @@ git commit: <git commit sha>
   It may be necessary to use another version of Doxygen to get a clean build.
   Building from source using the main branch is also a good option.
 
-- [ ] Apply manual Doxygen fixes:
-
 - [ ] Update the `current` symlink: `ln -nsrf doc/<MAJOR.MINOR.PATCH> doc/current`.
 
 - [ ] Grab a link to the announcement mail from the [wayland-devel archives](https://lore.freedesktop.org/wayland-devel/).

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'xkbcommon',
     'c',
-    version: '1.14.0-beta1',
+    version: '1.14.0-beta2',
     default_options: [
         'c_std=c11',
         'build.c_std=c11',

--- a/test/tool-option-parsing.py
+++ b/test/tool-option-parsing.py
@@ -760,7 +760,6 @@ class TestXkbcli(unittest.TestCase):
         for args in (
             ["--verbose", "-h"],
             ["--format=v2", "-h"],
-            ["--strict", "-h"],
             ["--no-pretty", "-h"],
             ["--drop-unused", "-h"],
         ):


### PR DESCRIPTION
# How to make an xkbcommon release

### Prerequisites

- Have write access to xkbcommon Git repositories.
- Be subscribed to the [wayland-devel](https://lists.freedesktop.org/postorius/lists/wayland-devel.lists.freedesktop.org/) mailing list.
  <!-- Old link: https://lists.freedesktop.org/mailman/listinfo/wayland-devel -->

### Steps

#### Prepare the release

- [x] Ensure there is no issue in the tracker blocking the release. Make sure
  they have their milestone set to the relevant release and the relevant tag
  “critical”.

- [ ] Ensure all items in the current milestone are processed. Remaining items
  must be *explicitly* postponed by changing their milestone.

- [x] Ensure the keysyms header is up-to-date (see [xorgproto])

- [x] Create a release branch: `git checkout -b release/vMAJOR.MINOR.PATCH master`

- [x] Update the `NEWS.md` file for the release, following [the corresponding instructions](changes/README.md).

- [x] Bump the `version` in `meson.build`.

- [x] Run `meson dist -C build` to make sure the release is good to go.

- [x] Commit `git commit -m 'Bump version to MAJOR.MINOR.PATCH'`.

- [x] Create a pull request using this template and ensure *all* CI is green.

- [x] Merge the pull request.

- [x] Tag `git switch master && git pull && git tag --annotate -m xkbcommon-<MAJOR.MINOR.PATCH> xkbcommon-<MAJOR.MINOR.PATCH>`.

- [x] Push the tag `git push origin xkbcommon-<MAJOR.MINOR.PATCH>`.

[xorgproto]: https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/tree/master/include/X11

#### Send announcement email to wayland-devel

- [x] Send an email to the wayland-devel@lists.freedesktop.org mailing list, using this template:

```
Subject: [ANNOUNCE] xkbcommon MAJOR.MINOR.PATCH

<NEWS & comments for this release>

Git tag:
--------

git tag: xkbcommon-<MAJOR.MINOR.PATCH>
git commit: <git commit sha>

<YOUR NAME>
```

#### Update website

- [x] Pull the latest [website repository](https://github.com/xkbcommon/website).

- [x] Add the doc for the release: `cp -r <xkbommon>/build/doc/html doc/<MAJOR.MINOR.PATCH>`.
  Check carefully that there is no warning during generation with Doxygen.
  It may be necessary to use another version of Doxygen to get a clean build.
  Building from source using the main branch is also a good option.

- [ ] Update the `current` symlink: `ln -nsrf doc/<MAJOR.MINOR.PATCH> doc/current`.

- [ ] Grab a link to the announcement mail from the [wayland-devel archives](https://lore.freedesktop.org/wayland-devel/).
  <!-- Old archives: https://lists.freedesktop.org/archives/wayland-devel/ -->

- [ ] Update the `index.html`:
    - "Our latest API- and ABI-stable release ..."
    - Add entry to the `releases` HTML list.

- [x] Commit `git commit -m MAJOR.MINOR.PATCH`.

- [x] Push `git push`. This automatically publishes the website after a few seconds.
